### PR TITLE
docs: add wiki badge to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,6 +6,8 @@
 
 マルチプラットフォーム対応の AI コーディングエージェント定義集です。27 の専門エージェントがプロジェクトの全工程を自動化します。
 
+[![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.pages.dev-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.pages.dev/)
+
 **[English README](README.md)**
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A multi-platform collection of AI coding agent definitions that automates the entire project lifecycle with 27 specialized agents.
 
+[![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.pages.dev-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.pages.dev/)
+
 **[日本語版 README はこちら](README.ja.md)**
 
 ---


### PR DESCRIPTION
## Summary
- Add shields.io badge linking to the Cloudflare Pages deployment: https://aphelion-agents.pages.dev/
- Badge placed below the project description in both README.md and README.ja.md, above the language-switch link

Badge:
![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.pages.dev-F38020?logo=cloudflarepages&logoColor=white&style=flat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)