### PR TITLE
chore: reset TASK.md and add lifecycle rule

### DIFF
--- a/.claude/rules/document-versioning.md
+++ b/.claude/rules/document-versioning.md
@@ -42,3 +42,10 @@ Generated at implementation start and updated upon each task completion.
 ## 中断時のメモ
 （セッション中断時に状況をここに記録する）
 ```
+
+## TASK.md Lifecycle
+
+- Generated at the start of a new implementation phase (`developer` writes it based on ARCHITECTURE.md).
+- Updated at each task completion (tick the checkbox, refresh the recent-commits section, commit with `git add TASK.md`).
+- **On phase completion**, reset TASK.md to the empty template (one-line placeholder) so the next `developer` invocation starts from a clean state. Commit the reset as part of the phase's final commit or as a trailing `chore:` commit.
+  - Rationale: a completed TASK.md with every checkbox ticked is not a design artifact — the phase's analysis and outcome belong in the matching `docs/issues/<slug>.md` planning document. Leaving a completed TASK.md in the repo risks the next `developer` session misreading it as a resume target.

--- a/TASK.md
+++ b/TASK.md
@@ -1,30 +1,3 @@
 # TASK.md
 
-> 参照元: docs/issues/unify-scripts-to-node.md (2026-04-19)
-
-## フェーズ: scripts ランタイム統一 (Python → Node.js)
-最終更新: 2026-04-19
-ステータス: 完了
-
-## タスク一覧
-
-### Phase 1: scripts/generate.mjs 実装
-- [x] TASK-001: generate.py を generate.mjs に移植 | 対象ファイル: scripts/generate.mjs
-
-### Phase 2: 生成物 byte-for-byte 検証
-- [x] TASK-002: Python版 と Node版 の出力差分ゼロを確認 | 対象ファイル: (検証のみ、コミットなし)
-
-### Phase 3: package.json 新設
-- [x] TASK-003: ルート package.json 作成 | 対象ファイル: package.json
-
-### Phase 4: ドキュメント参照書換
-- [x] TASK-004: python3 scripts/generate.py を node scripts/generate.mjs に置換 | 対象ファイル: README.md, README.ja.md, docs/wiki/en/*.md, docs/wiki/ja/*.md, docs/wiki/DESIGN.md, ISSUE.md, docs/issues/*.md
-
-### Phase 5: generate.py 削除
-- [x] TASK-005: git rm scripts/generate.py | 対象ファイル: scripts/generate.py
-
-## 直近のコミット
-（タスク完了のたびに git log --oneline -3 を記録する）
-
-## 中断時のメモ
-（セッション中断時に状況をここに記録する）
+（フェーズ未割当。次回 `developer` 起動時に ARCHITECTURE.md を参照して再生成されます）


### PR DESCRIPTION
## Summary
- Reset TASK.md to the empty placeholder (the previous content was a fully-ticked completed phase from the script-unification refactor)
- Add a "TASK.md Lifecycle" section to `.claude/rules/document-versioning.md` stating that TASK.md must be reset on phase completion, so this cleanup becomes a standing rule rather than a one-off

## Rationale
The rule repo previously had no guidance on what to do with TASK.md after a phase finishes. A fully-ticked TASK.md lingering in the repo risks a future developer session misreading it as a resume target. Planning context belongs in `docs/issues/<slug>.md`, not in the ephemeral state file.

## Test plan
- [ ] Confirm TASK.md no longer contains completed-phase content
- [ ] Confirm document-versioning.md's new "TASK.md Lifecycle" section renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)