### PR TITLE
refactor: improve sync-wiki.mjs quality (SH-003..SH-010, NI-001/002/005)

### DIFF
--- a/scripts/sync-wiki.mjs
+++ b/scripts/sync-wiki.mjs
@@ -20,7 +20,51 @@ const LOGO_SRC = path.join(REPO_ROOT, 'docs', 'images', 'aphelion-logo.png');
 const LOGO_DEST = path.join(REPO_ROOT, 'site', 'src', 'assets', 'logo.png');
 
 // リポジトリ外 (wiki 外) のファイルへのリンクを置き換える先。GitHub blob URL。
-const GITHUB_BLOB_BASE = 'https://github.com/kirin0198/aphelion-agents/blob/main/';
+// 優先順位: 1) 環境変数 APHELION_GITHUB_REPO_URL, 2) package.json の repository.url / homepage,
+// 3) ハードコードのフォールバック値
+const GITHUB_BLOB_BASE = resolveGithubBlobBase();
+
+/**
+ * GITHUB_BLOB_BASE を環境変数 / package.json / フォールバックの優先順で解決する。
+ * @returns {string} blob URL (末尾スラッシュ付き)
+ */
+function resolveGithubBlobBase() {
+  // 1) 環境変数
+  const envUrl = process.env.APHELION_GITHUB_REPO_URL;
+  if (envUrl) {
+    return envUrl.endsWith('/') ? envUrl : `${envUrl}/`;
+  }
+
+  // 2) package.json の repository.url または homepage
+  const fallback = 'https://github.com/kirin0198/aphelion-agents/blob/main/';
+  try {
+    const pkgPath = path.join(REPO_ROOT, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+      // repository.url: "git+https://github.com/X/Y.git" 形式を変換
+      const repoUrl = pkg?.repository?.url ?? pkg?.repository;
+      if (typeof repoUrl === 'string') {
+        const match = repoUrl.match(/github\.com[/:]([^/]+\/[^/.]+?)(?:\.git)?$/);
+        if (match) {
+          return `https://github.com/${match[1]}/blob/main/`;
+        }
+      }
+      // homepage: "https://github.com/X/Y" 形式
+      const homepage = pkg?.homepage;
+      if (typeof homepage === 'string' && homepage.includes('github.com')) {
+        const match = homepage.match(/github\.com\/([^/]+\/[^/]+)/);
+        if (match) {
+          return `https://github.com/${match[1]}/blob/main/`;
+        }
+      }
+    }
+  } catch (e) {
+    console.warn(`warn: failed to parse package.json for repository URL: ${e.message}`);
+  }
+
+  // 3) フォールバック
+  return fallback;
+}
 
 /**
  * ファイル先頭の frontmatter ブロック (---\n...\n---) を抽出する。
@@ -62,9 +106,32 @@ function extractTitle(body) {
 }
 
 /**
+ * Markdown の強調記号・コードスパン・リンクを除去してプレーンテキスト化する。
+ * SH-007: extractDescription の前処理として使用。
+ * @param {string} str
+ * @returns {string}
+ */
+function stripMarkdownInline(str) {
+  return (
+    str
+      // [text](url) → text
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // **text** / __text__ → text
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/__([^_]+)__/g, '$1')
+      // *text* / _text_ → text
+      .replace(/\*([^*]+)\*/g, '$1')
+      .replace(/_([^_]+)_/g, '$1')
+      // `text` → text
+      .replace(/`([^`]+)`/g, '$1')
+  );
+}
+
+/**
  * 本文から最初の説明段落を抽出する (140文字以内に切る)。
  * 引用行 (> ) やメタデータ行を飛ばし、通常の散文行を優先する。
  * 通常行が見つからない場合は引用行にフォールバック。
+ * Markdown 強調記号・コードスパン・リンクは除去してから切り詰める。
  * @param {string} body
  * @returns {string}
  */
@@ -88,13 +155,27 @@ function extractDescription(body) {
     // 引用行 (> で始まる) はフォールバック候補として保持
     if (trimmed.startsWith('>')) {
       if (!fallback) {
-        const cleaned = trimmed.replace(/^>\s*(\*\*[^*]+\*\*:\s*)?/, '').trim();
-        if (cleaned) fallback = cleaned.slice(0, 140);
+        const cleaned = stripMarkdownInline(
+          trimmed.replace(/^>\s*(\*\*[^*]+\*\*:\s*)?/, '').trim()
+        );
+        if (cleaned) {
+          // SH-006: 単語境界で切り詰め
+          const truncated = cleaned.slice(0, 140);
+          fallback =
+            cleaned.length > 140
+              ? truncated.replace(/\s+\S*$/, '') + '…'
+              : truncated;
+        }
       }
       continue;
     }
-    // 通常の散文行: そのまま採用
-    return trimmed.slice(0, 140);
+    // SH-007: 強調記号を剥がしてから切り詰め
+    const plain = stripMarkdownInline(trimmed);
+    // SH-006: 単語境界で切り詰め
+    const truncated = plain.slice(0, 140);
+    return plain.length > 140
+      ? truncated.replace(/\s+\S*$/, '') + '…'
+      : truncated;
   }
   return fallback ?? '';
 }
@@ -209,6 +290,7 @@ function removeH1(body) {
 /**
  * frontmatter オブジェクトを YAML 文字列にシリアライズする。
  * 値に : や ' が含まれる場合はダブルクォートで囲む。
+ * SH-005: \ / 改行 / タブ もエスケープする。
  * @param {Record<string, string>} fm
  * @returns {string}
  */
@@ -216,8 +298,12 @@ function serializeFrontmatter(fm) {
   const lines = [];
   for (const [key, value] of Object.entries(fm)) {
     // 特殊文字を含む場合はクォート
-    if (/[:"'#[\]{}|>*!&%@`]/.test(value) || value.includes('\n')) {
-      const escaped = value.replace(/"/g, '\\"');
+    if (/[:"'#[\]{}|>*!&%@`]/.test(value) || value.includes('\n') || value.includes('\\') || value.includes('\t')) {
+      const escaped = value
+        .replace(/\\/g, '\\\\') // \ → \\ (先にエスケープ)
+        .replace(/"/g, '\\"')   // " → \"
+        .replace(/\n/g, '\\n')  // 改行 → \n
+        .replace(/\t/g, '\\t'); // タブ → \t
       lines.push(`${key}: "${escaped}"`);
     } else {
       lines.push(`${key}: ${value}`);
@@ -228,46 +314,57 @@ function serializeFrontmatter(fm) {
 
 /**
  * 1ファイルを処理し、出力先に書き出す。
+ *
+ * 冪等性: 本関数は入力が docs/wiki/** (frontmatter なし) であることを前提とする。
+ * 同一入力を複数回処理しても出力は同一になる。
+ *
  * @param {string} srcPath 入力ファイルのフルパス
  * @param {string} destPath 出力ファイルのフルパス
  * @param {'en' | 'ja'} locale 現在処理中のロケール
  */
 function processFile(srcPath, destPath, locale) {
-  const raw = fs.readFileSync(srcPath, 'utf-8');
-  const { frontmatter, body } = extractFrontmatter(raw);
+  try {
+    const raw = fs.readFileSync(srcPath, 'utf-8');
+    const { frontmatter, body } = extractFrontmatter(raw);
 
-  // title と description を補完
-  if (!frontmatter.title) {
-    const title = extractTitle(body);
-    if (title) {
-      frontmatter.title = title;
-    } else {
-      // ファイル名からフォールバック
-      const baseName = path.basename(srcPath, '.md');
-      frontmatter.title = baseName.replace(/-/g, ' ');
+    // title と description を補完
+    if (!frontmatter.title) {
+      const title = extractTitle(body);
+      if (title) {
+        frontmatter.title = title;
+      } else {
+        // ファイル名からフォールバック
+        const baseName = path.basename(srcPath, '.md');
+        frontmatter.title = baseName.replace(/-/g, ' ');
+      }
     }
-  }
-  if (!frontmatter.description) {
-    const desc = extractDescription(body);
-    if (desc) {
-      frontmatter.description = desc;
+    // NI-005: template: splash の場合は description 自動生成をスキップ
+    // (splash レイアウトは description フィールドを使用しないため)
+    if (!frontmatter.description && frontmatter.template !== 'splash') {
+      const desc = extractDescription(body);
+      if (desc) {
+        frontmatter.description = desc;
+      }
     }
+
+    // H1 タイトル行を本文から削除 (frontmatter.title と重複するため)
+    // リンクを Starlight 形式 (絶対パス、kebab-case、.md 除去) に書き換え
+    const cleanedBody = rewriteLinks(removeH1(body), locale);
+
+    // frontmatter ブロックを先頭に付与して結合
+    const output = `---\n${serializeFrontmatter(frontmatter)}\n---\n\n${cleanedBody}`;
+
+    fs.writeFileSync(destPath, output, 'utf-8');
+    console.log(`  synced: ${path.relative(REPO_ROOT, srcPath)} → ${path.relative(REPO_ROOT, destPath)}`);
+  } catch (e) {
+    throw new Error(`failed to process ${srcPath}: ${e.message}`, { cause: e });
   }
-
-  // H1 タイトル行を本文から削除 (frontmatter.title と重複するため)
-  // リンクを Starlight 形式 (絶対パス、kebab-case、.md 除去) に書き換え
-  const cleanedBody = rewriteLinks(removeH1(body), locale);
-
-  // frontmatter ブロックを先頭に付与して結合
-  const output = `---\n${serializeFrontmatter(frontmatter)}\n---\n\n${cleanedBody}`;
-
-  fs.writeFileSync(destPath, output, 'utf-8');
-  console.log(`  synced: ${path.relative(REPO_ROOT, srcPath)} → ${path.relative(REPO_ROOT, destPath)}`);
 }
 
 /**
  * ロゴ画像を docs/images/aphelion-logo.png から site/src/assets/logo.png にコピーする。
- * Starlight 側のロゴと SSOT を一致させるため、毎ビルド時に上書きする。
+ * Starlight 側のロゴと SSOT を一致させるため、変更があった場合のみ上書きする。
+ * NI-001: src と dest の mtime/size を比較し、同一ならスキップする。
  */
 function syncLogo() {
   if (!fs.existsSync(LOGO_SRC)) {
@@ -275,12 +372,21 @@ function syncLogo() {
     return;
   }
   fs.mkdirSync(path.dirname(LOGO_DEST), { recursive: true });
+
+  const srcStat = fs.statSync(LOGO_SRC);
+  const destStat = fs.existsSync(LOGO_DEST) ? fs.statSync(LOGO_DEST) : null;
+  if (destStat && srcStat.size === destStat.size && srcStat.mtimeMs <= destStat.mtimeMs) {
+    console.log(`\n[logo] unchanged: ${path.relative(REPO_ROOT, LOGO_SRC)} (skipped)`);
+    return;
+  }
+
   fs.copyFileSync(LOGO_SRC, LOGO_DEST);
   console.log(`\n[logo] ${path.relative(REPO_ROOT, LOGO_SRC)} → ${path.relative(REPO_ROOT, LOGO_DEST)}`);
 }
 
 /**
  * メイン処理: docs/wiki/{locale}/*.md をすべて処理して site/src/content/docs/{locale}/ に出力する。
+ * SH-003: 同一ロケール内で slug の重複が検出された場合は即座にエラーとして終了する。
  */
 function main() {
   syncLogo();
@@ -302,9 +408,22 @@ function main() {
     const files = fs.readdirSync(srcDir).filter((f) => f.endsWith('.md'));
     console.log(`\n[${locale}] ${files.length} files found in ${path.relative(REPO_ROOT, srcDir)}`);
 
+    // SH-003: slug 衝突を検知するための Set
+    const slugsSeen = new Set();
+
     for (const file of files) {
-      const srcPath = path.join(srcDir, file);
       const destFile = slugify(file);
+
+      // SH-003: 同一ロケール内で slug が重複していれば即失敗
+      if (slugsSeen.has(destFile)) {
+        throw new Error(
+          `slug collision detected in locale "${locale}": "${file}" conflicts with an existing slug "${destFile}". ` +
+          `Check for case-insensitive duplicates (e.g. Home.md and home.md).`
+        );
+      }
+      slugsSeen.add(destFile);
+
+      const srcPath = path.join(srcDir, file);
       const destPath = path.join(destDir, destFile);
       processFile(srcPath, destPath, /** @type {'en' | 'ja'} */ (locale));
     }
@@ -313,4 +432,10 @@ function main() {
   console.log('\nsync-wiki: done.');
 }
 
-main();
+// SH-004: トップレベルのエラーハンドリング
+try {
+  main();
+} catch (e) {
+  console.error(`sync-wiki failed: ${e.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
Address outstanding SHOULD/NICE items from the PR #12 review (agentId af3790d84bb6424dd) for `scripts/sync-wiki.mjs`.

- **SH-003**: detect slug collisions per locale and throw on duplicates
- **SH-004**: wrap main() in top-level try/catch and enrich error messages with file paths
- **SH-005**: harden YAML escaping — backslash, newline, tab
- **SH-006**: truncate description at the last whitespace instead of mid-word, append `…`
- **SH-007**: strip Markdown inline markup (**, *, _, \`, [text](url)) before truncation
- **SH-010**: resolve GITHUB_BLOB_BASE from env var → package.json → hardcoded fallback
- **NI-001**: skip logo copy when source size+mtime match destination
- **NI-002**: document processFile idempotency expectations
- **NI-005**: skip description auto-generation for splash-template pages

## Scope boundary
Only `scripts/sync-wiki.mjs` is modified. No TypeScript migration, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)