### PR TITLE
refactor: DRY starlight sidebar + symmetric i18n labels (SH-009, NI-003)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,6 +3,28 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import remarkMermaid from './src/remark-mermaid.mjs';
 
+// ページ定義を一元管理する配列。
+// ページ追加・変更時はここだけ編集すれば sidebar に反映される (SH-009, NI-003)。
+/** @type {{ slug: string; labelEn: string; labelJa: string }[]} */
+const PAGES = [
+	{ slug: 'home',             labelEn: 'Overview',          labelJa: '概要'                   },
+	{ slug: 'getting-started',  labelEn: 'Getting Started',   labelJa: 'はじめる'               },
+	{ slug: 'architecture',     labelEn: 'Architecture',      labelJa: 'アーキテクチャ'         },
+	{ slug: 'triage-system',    labelEn: 'Triage System',     labelJa: 'トリアージシステム'     },
+	{ slug: 'agents-reference', labelEn: 'Agents Reference',  labelJa: 'エージェントリファレンス' },
+	{ slug: 'rules-reference',  labelEn: 'Rules Reference',   labelJa: 'ルールリファレンス'     },
+	{ slug: 'platform-guide',   labelEn: 'Platform Guide',    labelJa: 'プラットフォームガイド' },
+	{ slug: 'contributing',     labelEn: 'Contributing',      labelJa: 'コントリビューション'   },
+];
+
+// PAGES から Starlight sidebar エントリを生成する。
+// translations に en/ja 両言語を含めることで英日ラベルの対称性を保証する (NI-003)。
+const sidebar = PAGES.map(({ slug, labelEn, labelJa }) => ({
+	label: labelEn,
+	link: slug,
+	translations: { en: labelEn, ja: labelJa },
+}));
+
 // https://astro.build/config
 export default defineConfig({
 	markdown: {
@@ -40,48 +62,7 @@ export default defineConfig({
 			},
 			defaultLocale: 'en',
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/kirin0198/aphelion-agents' }],
-			sidebar: [
-				{
-					label: 'Overview',
-					link: 'home',
-					translations: { ja: '概要' },
-				},
-				{
-					label: 'Getting Started',
-					link: 'getting-started',
-					translations: { ja: 'はじめる' },
-				},
-				{
-					label: 'Architecture',
-					link: 'architecture',
-					translations: { ja: 'アーキテクチャ' },
-				},
-				{
-					label: 'Triage System',
-					link: 'triage-system',
-					translations: { ja: 'トリアージシステム' },
-				},
-				{
-					label: 'Agents Reference',
-					link: 'agents-reference',
-					translations: { ja: 'エージェントリファレンス' },
-				},
-				{
-					label: 'Rules Reference',
-					link: 'rules-reference',
-					translations: { ja: 'ルールリファレンス' },
-				},
-				{
-					label: 'Platform Guide',
-					link: 'platform-guide',
-					translations: { ja: 'プラットフォームガイド' },
-				},
-				{
-					label: 'Contributing',
-					link: 'contributing',
-					translations: { ja: 'コントリビューション' },
-				},
-			],
+			sidebar,
 		}),
 	],
 });


### PR DESCRIPTION
## Summary
Improve `site/astro.config.mjs` sidebar maintainability.

- **SH-009**: consolidate the 8 hand-listed sidebar entries into a `PAGES` array and generate `sidebar` by `PAGES.map(...)`. Adding a page now edits one array row.
- **NI-003**: use `translations: { en, ja }` symmetrically rather than `label: <en>` + `translations: { ja }`.

## Scope boundary
Only `site/astro.config.mjs` is modified. Sidebar content and page slugs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)