### PR TITLE
docs: document --service-ports requirement in docker-compose.yml (NI-004)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,13 @@
 #   docker compose run --rm --service-ports site-dev      # hot-reload dev at http://localhost:4321
 #   docker compose run --rm site-build                    # one-shot production build into ./site/dist
 #   docker compose run --rm --service-ports site-preview  # preview the built site at http://localhost:4321
+#
+# Note: `docker compose run` by default does NOT publish container ports.
+# For services exposing dev/preview servers (site-dev, site-preview),
+# add `--service-ports` so the container's port 4321 is mapped to the host:
+#   docker compose run --rm --service-ports site-dev
+# Without --service-ports, the server starts but is unreachable from the host
+# (including WSL-to-Windows scenarios).
 
 services:
   site-dev:


### PR DESCRIPTION
## Summary
Mirror the README note about `docker compose run --service-ports` into the compose file itself so users reading `docker-compose.yml` standalone (CI scripts etc.) see the requirement.

- **NI-004**: add a 5-line note to the header comment block explaining why `--service-ports` is required for `site-dev` / `site-preview`, including the WSL-to-Windows case.

## Scope boundary
Only `docker-compose.yml` is modified. No service definition changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)