### PR TITLE
refactor: translate all agent definition body text to English (Issue #32 Phase 2)

### DIFF
--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -113,28 +113,28 @@ Do not proceed with document updates, GitHub issue creation, or handoff to archi
 **Procedure 1: Output analysis results as text**
 
 ```
-Issue 分析完了
+Issue analysis complete
 
-【Issue 種別】バグ修正 / 機能追加 / リファクタリング
-【Issue 概要】{1〜2行で要約}
+[Issue type] Bug fix / Feature addition / Refactoring
+[Issue summary] {1-2 line summary}
 
-【分析結果】
-{原因・要件・課題の整理（箇条書き）}
+[Analysis results]
+{organized causes, requirements, and issues (bullet points)}
 
-【対応方針】
-{具体的に何をするか（箇条書き）}
+[Approach]
+{specifically what will be done (bullet points)}
 
-【ドキュメント変更】
-  - SPEC.md: {変更なし / UC-XXX を更新 / UC-XXX を追加}
-  - UI_SPEC.md: {変更なし / SCR-XXX を追加}
-  - ARCHITECTURE.md: {変更なし / architect が更新}
+[Document changes]
+  - SPEC.md: {no change / update UC-XXX / add UC-XXX}
+  - UI_SPEC.md: {no change / add SCR-XXX}
+  - ARCHITECTURE.md: {no change / architect will update}
 
-【GitHub issue】
-  - タイトル: {issue概要}
-  - ラベル: {bug / enhancement / refactor}
+[GitHub issue]
+  - Title: {issue summary}
+  - Label: {bug / enhancement / refactor}
 
-【architect への引き継ぎ内容】
-  {設計変更・追加の概要}
+[Handoff to architect]
+  {overview of design changes / additions}
 ```
 
 **Procedure 2: Request approval via `AskUserQuestion`**
@@ -142,12 +142,12 @@ Issue 分析完了
 ```json
 {
   "questions": [{
-    "question": "上記の分析結果と対応方針で進めてよいですか？",
-    "header": "方針承認",
+    "question": "Proceed with the analysis results and approach above?",
+    "header": "Approach approval",
     "options": [
-      {"label": "承認して続行", "description": "この方針でドキュメント更新・GitHub issue 作成に進む"},
-      {"label": "方針を修正", "description": "修正内容を指示する"},
-      {"label": "中断", "description": "issue 対応を中止する"}
+      {"label": "Approve and continue", "description": "Proceed with document updates and GitHub issue creation using this approach"},
+      {"label": "Revise approach", "description": "Provide instructions for revision"},
+      {"label": "Abort", "description": "Stop issue handling"}
     ],
     "multiSelect": false
   }]
@@ -189,7 +189,7 @@ After branch creation, execute the following.
 ### SPEC.md Update Rules
 - **Modifying existing UCs**: Use `Edit` to incrementally update the relevant section (full rewrite is not allowed)
 - **Adding new UCs**: Append to the end and assign sequential UC numbers
-- Add `> 更新: {date} ({issue summary})` at the beginning of the changed section
+- Add `> Updated: {date} ({issue summary})` at the beginning of the changed section
 
 ### UI_SPEC.md Update Rules
 - Add new screens as `SCR-XXX`
@@ -226,22 +226,22 @@ If the label does not exist in the repository, omit `--label`.
 ### Issue Body Template
 
 ```markdown
-## 種別
-{バグ修正 / 機能追加 / リファクタリング}
+## Type
+{Bug fix / Feature addition / Refactoring}
 
-## 分析結果
-{原因・要件・課題の整理}
+## Analysis Results
+{organized causes, requirements, and issues}
 
-## 対応方針
-{具体的に何をするか}
+## Approach
+{specifically what will be done}
 
-## ドキュメント変更
-- SPEC.md: {変更なし / UC-XXX を更新 / UC-XXX を追加}
-- UI_SPEC.md: {変更なし / SCR-XXX を追加}
-- ARCHITECTURE.md: {変更なし / architect が更新}
+## Document Changes
+- SPEC.md: {no change / update UC-XXX / add UC-XXX}
+- UI_SPEC.md: {no change / add SCR-XXX}
+- ARCHITECTURE.md: {no change / architect will update}
 
-## architect への引き継ぎ
-{設計変更・追加の概要}
+## Handoff to architect
+{overview of design changes / additions}
 ```
 
 ### Execution Command
@@ -286,17 +286,17 @@ git push -u origin {branch-name}
 gh pr create \
   --title "{PR title}" \
   --body "$(cat <<'EOF'
-## 概要
-{変更内容の要約（箇条書き）}
+## Summary
+{summary of changes (bullet points)}
 
-## 関連 Issue
+## Related Issue
 - #{issue-number}
 
-## 変更ファイル
-- {変更したファイルのリスト}
+## Changed Files
+- {list of changed files}
 
-## architect への引き継ぎ
-{設計変更・追加の概要}
+## Handoff to architect
+{overview of design changes / additions}
 EOF
 )" \
   --base main
@@ -311,12 +311,12 @@ Present the PR URL to the user and wait for confirmation:
 ```json
 {
   "questions": [{
-    "question": "PR を作成しました。内容を確認してください。",
-    "header": "PR 確認",
+    "question": "PR has been created. Please review the content.",
+    "header": "PR review",
     "options": [
-      {"label": "承認して続行", "description": "この PR の内容で architect に引き継ぐ"},
-      {"label": "修正を依頼", "description": "PR の内容を修正する"},
-      {"label": "中断", "description": "issue 対応を中止する"}
+      {"label": "Approve and continue", "description": "Hand off to architect with this PR content"},
+      {"label": "Request revision", "description": "Revise the PR content"},
+      {"label": "Abort", "description": "Stop issue handling"}
     ],
     "multiSelect": false
   }]

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -76,107 +76,107 @@ If the user has specified a stack, always prioritize that; if no specification e
 ## Output File: `ARCHITECTURE.md`
 
 ```markdown
-# アーキテクチャ設計書: {プロジェクト名}
+# Architecture Design: {Project Name}
 
-> 参照元: SPEC.md ({バージョン or 最終更新日})
-> 作成日: {日付}
+> Source: SPEC.md ({version or last updated date})
+> Created: {date}
 
-## 1. アーキテクチャ概要
+## 1. Architecture Overview
 
-### システム構成図（テキスト）
-{ASCII または Mermaid 記法で描画}
+### System Diagram (text)
+{Draw using ASCII or Mermaid notation}
 
-### 採用アーキテクチャパターン
-- 理由と根拠を明記
+### Adopted Architecture Pattern
+- State reason and rationale explicitly
 
-### 技術スタック
-| 層 | 技術 | バージョン | 選定理由 |
+### Tech Stack
+| Layer | Technology | Version | Selection Rationale |
 |----|------|-----------|---------|
 
-## 2. ディレクトリ構造
+## 2. Directory Structure
 
 ```
-{プロジェクトルート}/
+{project root}/
 ├── src/
-│   ├── {各ディレクトリの役割をコメントで説明}
+│   ├── {explain the role of each directory in comments}
 ...
 ```
 
-## 3. モジュール設計
+## 3. Module Design
 
-### {モジュール名}
-- **責務:**
-- **依存関係:**
-- **公開インターフェース:**
+### {Module Name}
+- **Responsibilities:**
+- **Dependencies:**
+- **Public Interface:**
 
-## 4. データモデル（実装レベル）
+## 4. Data Model (Implementation Level)
 
-### {エンティティ名}
+### {Entity Name}
 ```
-{型定義 or スキーマ定義}
+{type definition or schema definition}
 ```
-- インデックス:
-- リレーション:
+- Indexes:
+- Relations:
 
-## 5. API設計（該当する場合）
+## 5. API Design (if applicable)
 
-### {エンドポイント}
-- **メソッド:**
-- **認証:**
-- **リクエスト:**
-- **レスポンス:**
-- **エラーコード:**
+### {Endpoint}
+- **Method:**
+- **Authentication:**
+- **Request:**
+- **Response:**
+- **Error codes:**
 
-## 6. 状態管理設計（フロントエンドの場合）
+## 6. State Management Design (for frontend)
 
-## 7. 認証・認可設計
+## 7. Authentication / Authorization Design
 
-## 8. エラーハンドリング方針
+## 8. Error Handling Policy
 
-## 9. テスト戦略
+## 9. Test Strategy
 
-| テスト種別 | ツール | カバレッジ目標 | 対象 |
+| Test Type | Tool | Coverage Target | Scope |
 |-----------|--------|-------------|------|
-| 単体テスト | {pytest / vitest / go test} | {目標値} | {対象} |
-| 統合テスト | {pytest + httpx / supertest} | {目標値} | {対象} |
-| E2E テスト | {Playwright / Selenium / なし} | {目標値} | {対象画面} |
-| GUI テスト | {pywinauto / pyautogui / なし} | {目標値} | {対象操作} |
+| Unit tests | {pytest / vitest / go test} | {target} | {scope} |
+| Integration tests | {pytest + httpx / supertest} | {target} | {scope} |
+| E2E tests | {Playwright / Selenium / none} | {target} | {target screens} |
+| GUI tests | {pywinauto / pyautogui / none} | {target} | {target operations} |
 
-### E2E テスト方針（HAS_UI: true の場合）
-- ツール選定理由: {選定根拠}
-- テスト対象ブラウザ: {Chromium / Firefox / WebKit}
-- 実行モード: {headless（CI）/ headed（開発時）}
-- Page Object Model: {使用する / 使用しない}
+### E2E Test Policy (when HAS_UI: true)
+- Tool selection rationale: {rationale}
+- Target browsers: {Chromium / Firefox / WebKit}
+- Execution mode: {headless (CI) / headed (development)}
+- Page Object Model: {used / not used}
 
-## 10. 実装順序・依存関係
+## 10. Implementation Order / Dependencies
 
 ```
-実装フェーズ 1: {基盤}
-  └─ Task 1-1: {具体的なタスク}（依存なし）
-  └─ Task 1-2: {具体的なタスク}（Task 1-1 完了後）
+Implementation Phase 1: {Foundation}
+  └─ Task 1-1: {specific task} (no dependencies)
+  └─ Task 1-2: {specific task} (after Task 1-1)
 
-実装フェーズ 2: {コア機能}
-  └─ Task 2-1: {具体的なタスク}（フェーズ1完了後）
+Implementation Phase 2: {Core Features}
+  └─ Task 2-1: {specific task} (after Phase 1)
   ...
 ```
 
-## 11. 環境・設定
+## 11. Environment / Configuration
 
-- 環境変数一覧（値は除く）
-- 設定ファイル一覧
+- Environment variable list (without values)
+- Configuration file list
 
-## 12. 既知のリスクと対策
+## 12. Known Risks and Mitigation
 
-| リスク | 影響度 | 対策 |
+| Risk | Impact | Mitigation |
 |--------|--------|------|
 
-## 13. 設計判断の記録（ADR）
+## 13. Architecture Decision Records (ADR)
 
-### ADR-001: {判断タイトル}
-- **状況:**
-- **決定:**
-- **理由:**
-- **却下した代替案:**
+### ADR-001: {decision title}
+- **Context:**
+- **Decision:**
+- **Rationale:**
+- **Rejected alternatives:**
 ```
 
 ---

--- a/.claude/agents/change-classifier.md
+++ b/.claude/agents/change-classifier.md
@@ -79,7 +79,7 @@ Assign a priority level:
 Use `Grep` and `Glob` to search for related code locations:
 
 ```bash
-# キーワードでファイルを検索
+# Search files by keyword
 grep -r "{keyword from trigger}" . --include="*.py" --include="*.ts" --include="*.go" -l
 ```
 
@@ -125,20 +125,20 @@ If `SPEC.md` or `ARCHITECTURE.md` is missing:
 
 1. Output a notification as text:
    ```
-   SPEC.md / ARCHITECTURE.md が見つかりません。
-   トリアージを正確に行うために、まず codebase-analyzer でドキュメントを生成することを推奨します。
+   SPEC.md / ARCHITECTURE.md not found.
+   To perform accurate triage, it is recommended to first generate documentation using codebase-analyzer.
    ```
 
 2. Ask the user via `AskUserQuestion`:
    ```json
    {
      "questions": [{
-       "question": "SPEC.md または ARCHITECTURE.md が存在しません。codebase-analyzer を先に実行しますか？",
-       "header": "前提ドキュメント確認",
+       "question": "SPEC.md or ARCHITECTURE.md does not exist. Run codebase-analyzer first?",
+       "header": "Prerequisite document check",
        "options": [
-         {"label": "codebase-analyzer を実行 (推奨)", "description": "コードベースを分析して SPEC.md / ARCHITECTURE.md を生成してから分類を行う"},
-         {"label": "ドキュメントなしで続行", "description": "不完全な情報でトリアージを試みる（精度が下がる）"},
-         {"label": "中断", "description": "作業を中止する"}
+         {"label": "Run codebase-analyzer (recommended)", "description": "Analyze the codebase to generate SPEC.md / ARCHITECTURE.md before classification"},
+         {"label": "Continue without documents", "description": "Attempt triage with incomplete information (lower accuracy)"},
+         {"label": "Abort", "description": "Stop work"}
        ],
        "multiSelect": false
      }]
@@ -156,19 +156,19 @@ After completing the analysis, present the triage result and request approval:
 **Step 1: Output analysis as text:**
 
 ```
-変更分類完了
+Change classification complete
 
-【トリガー種別】{bug | feature | tech_debt | performance | security}
-【優先度】{P1 | P2 | P3 | P4}
-【推定影響ファイル数】{N} ファイル
-【破壊的変更】{あり | なし}
-【SPEC.md への影響】{なし | 軽微 | 大きい}
-【判定プラン】{Patch | Minor | Major}
+[Trigger type] {bug | feature | tech_debt | performance | security}
+[Priority] {P1 | P2 | P3 | P4}
+[Estimated affected files] {N} files
+[Breaking change] {present | none}
+[SPEC.md impact] {none | minor | major}
+[Determined plan] {Patch | Minor | Major}
 
-【判定根拠】
-{上記 4 観点ごとの根拠を箇条書きで}
+[Classification rationale]
+{bullet points for each of the 4 dimensions above}
 
-【次のフェーズ】
+[Next phase]
 {Patch → analyst | Minor/Major → impact-analyzer}
 ```
 
@@ -177,14 +177,14 @@ After completing the analysis, present the triage result and request approval:
 ```json
 {
   "questions": [{
-    "question": "上記のトリアージ結果で maintenance-flow を進めてよいですか？プランを変更することも可能です。",
-    "header": "変更計画の承認",
+    "question": "Proceed with maintenance-flow using the triage result above? You can also change the plan.",
+    "header": "Change plan approval",
     "options": [
-      {"label": "承認して続行 (推奨)", "description": "判定されたプランで次フェーズへ進む"},
-      {"label": "Patch に変更", "description": "プランを Patch に格下げして続行する"},
-      {"label": "Minor に変更", "description": "プランを Minor に変更して続行する"},
-      {"label": "Major に変更", "description": "プランを Major に格上げして続行する"},
-      {"label": "中断", "description": "maintenance-flow を停止する"}
+      {"label": "Approve and continue (recommended)", "description": "Proceed to the next phase with the determined plan"},
+      {"label": "Change to Patch", "description": "Downgrade plan to Patch and continue"},
+      {"label": "Change to Minor", "description": "Change plan to Minor and continue"},
+      {"label": "Change to Major", "description": "Upgrade plan to Major and continue"},
+      {"label": "Abort", "description": "Stop maintenance-flow"}
     ],
     "multiSelect": false
   }]

--- a/.claude/agents/codebase-analyzer.md
+++ b/.claude/agents/codebase-analyzer.md
@@ -128,136 +128,137 @@ Observe from the code (do not speculate):
 
 ## Output File: `SPEC.md`
 
-Generate using the same format as `spec-designer` output, with `参照元: 既存コードベース分析` noted.
+Generate using the same format as `spec-designer` output, with `Source: existing codebase analysis` noted.
 
 ```markdown
-# 仕様書: {プロジェクト名}
+# Specification: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> 参照元: 既存コードベース分析（codebase-analyzer）
+> Created: {YYYY-MM-DD}
+> Source: Existing codebase analysis (codebase-analyzer)
 
-## 1. プロジェクト概要
-- 目的・背景（README.md や コードから推測）
-- スコープ（IN / OUT）
+## 1. Project Overview
+- Purpose / background (inferred from README.md and code)
+- Scope (IN / OUT)
 
-## 2. 技術スタック（確定）
-| 層 | 技術 | バージョン | 備考 |
+## 2. Tech Stack (confirmed)
+| Layer | Technology | Version | Notes |
 |----|------|-----------|------|
-> ※ 既存コードから検出した確定情報
+> * Confirmed information detected from existing code
 
-## 3. ユーザーストーリー
-- 対象ユーザー（推定）
-- ユースケース一覧（番号付き）
+## 3. User Stories
+- Target users (estimated)
+- Use case list (numbered)
 
-## 4. 機能要件
-### UC-001: {ユースケース名}
-- 概要:
-- 事前条件:
-- 正常フロー:
-- 例外フロー:
-- 受け入れ条件:
+## 4. Functional Requirements
+### UC-001: {Use case name}
+- Summary:
+- Preconditions:
+- Normal flow:
+- Exception flow:
+- Acceptance criteria:
 
-（コードから抽出した機能数分繰り返す）
+(Repeat for number of features extracted from code)
 
-## 5. 非機能要件
-- パフォーマンス（観測できる場合）
-- セキュリティ（実装されている機構）
-- 可用性
-- スケーラビリティ
+## 5. Non-Functional Requirements
+- Performance (if observable)
+- Security (implemented mechanisms)
+- Availability
+- Scalability
 
-## 6. データモデル（概念レベル）
-- エンティティ一覧
-- 主要な関係性
+## 6. Data Model (conceptual level)
+- Entity list
+- Key relationships
 
-## 7. API概要（該当する場合）
-- エンドポイント一覧
-- 主要なリクエスト/レスポンス形式
+## 7. API Overview (if applicable)
+- Endpoint list
+- Key request/response formats
 
-## 8. 制約・前提条件
+## 8. Constraints / Assumptions
 
-## 9. 用語集
+## 9. Glossary
 
-## 10. 未解決事項（TBD）
-{コードから読み取れなかった仕様や曖昧な箇所}
+## 10. Unresolved Items (TBD)
+{specs that could not be read from code or ambiguous areas}
 ```
 
 ---
 
 ## Output File: `ARCHITECTURE.md`
 
-Generate using the same format as `architect` output, with `参照元: 既存コードベース分析` noted.
+Generate using the same format as `architect` output, with `Source: existing codebase analysis` noted.
 
 ```markdown
-# アーキテクチャ設計書: {プロジェクト名}
+# Architecture Design: {Project Name}
 
-> 参照元: 既存コードベース分析（codebase-analyzer）
-> 作成日: {YYYY-MM-DD}
+> Source: Existing codebase analysis (codebase-analyzer)
+> Created: {YYYY-MM-DD}
 
-## 1. アーキテクチャ概要
+## 1. Architecture Overview
 
-### システム構成図（テキスト）
-{ASCII または Mermaid 記法で描画}
+### System Diagram (text)
+{drawn in ASCII or Mermaid notation}
 
-### 採用アーキテクチャパターン
-{コードから観測されたパターン（MVC, Clean Architecture, etc.）}
+### Adopted Architecture Pattern
+{pattern observed from code (MVC, Clean Architecture, etc.)}
 
-### 技術スタック
-| 層 | 技術 | バージョン | 選定理由（推定） |
+### Tech Stack
+| Layer | Technology | Version | Selection rationale (estimated) |
 |----|------|-----------|----------------|
 
-## 2. ディレクトリ構造
+## 2. Directory Structure
 
 ```
-{実際のディレクトリ構造を記録}
+{record the actual directory structure}
 ```
 
-## 3. モジュール設計
+## 3. Module Design
 
-### {モジュール名}
-- **責務:**
-- **依存関係:**
-- **公開インターフェース:**
+### {Module Name}
+- **Responsibilities:**
+- **Dependencies:**
+- **Public interfaces:**
 
-## 4. データモデル（実装レベル）
+## 4. Data Model (implementation level)
 
-### {エンティティ名}
-{実際のスキーマ定義}
-- インデックス:
-- リレーション:
+### {Entity Name}
+{actual schema definition}
+- Indexes:
+- Relations:
 
-## 5. API設計（該当する場合）
+## 5. API Design (if applicable)
 
-### {エンドポイント}
-- **メソッド:**
-- **認証:**
-- **リクエスト:**
-- **レスポンス:**
-- **エラーコード:**
+### {Endpoint}
+- **Method:**
+- **Authentication:**
+- **Request:**
+- **Response:**
+- **Error codes:**
 
-## 6. 状態管理設計（フロントエンドの場合）
+## 6. State Management Design (for frontend)
 
-## 7. 認証・認可設計
+## 7. Authentication / Authorization Design
 
-## 8. エラーハンドリング方針
+## 8. Error Handling Policy
 
-## 9. テスト戦略
+## 9. Test Strategy
 
-| テスト種別 | ツール | カバレッジ目標 | 対象 |
+| Test type | Tool | Coverage target | Scope |
 |-----------|--------|-------------|------|
 
-## 10. 実装順序・依存関係
-（既存プロジェクトのため該当なし。今後の拡張順序があれば記載）
+## 10. Implementation Order / Dependencies
+(Not applicable for existing projects. Document future extension order if needed)
 ```
 
 ---
 
 ## Quality Criteria
 
-- **Accuracy over speculation**: Only document what can be confirmed from the code. Mark uncertain items with `[推定]`
+- **Accuracy over speculation**: Only document what can be confirmed from the code. Mark uncertain items with `[Estimated]`
 - **Completeness**: All source files should be accounted for in the architecture
 - **Format compatibility**: SPEC.md and ARCHITECTURE.md must be in the exact format that `analyst`, `architect`, and `developer` expect
 - **No modification**: Do not modify any existing code. This agent is read-only (except for generating SPEC.md and ARCHITECTURE.md)
 - **TBD tracking**: Items that cannot be determined from code alone must be tagged with `[TBD]`
+
 
 ---
 
@@ -267,24 +268,24 @@ After generating both documents, present a summary and request user review.
 
 Output as text:
 ```
-コードベース分析完了
+Codebase analysis complete
 
-【検出した技術スタック】
-  {言語、フレームワーク、DB等}
+[Detected tech stack]
+  {language, framework, DB, etc.}
 
-【抽出したユースケース数】
-  {N} 件（UC-001 〜 UC-{N}）
+[Extracted use case count]
+  {N} items (UC-001 through UC-{N})
 
-【データモデル】
-  {エンティティ数} エンティティ
+[Data model]
+  {entity count} entities
 
-【生成した成果物】
-  - SPEC.md: {セクション数} セクション、{TBD数} 件の未解決事項
-  - ARCHITECTURE.md: {セクション数} セクション
+[Generated artifacts]
+  - SPEC.md: {section count} sections, {TBD count} unresolved items
+  - ARCHITECTURE.md: {section count} sections
 
-【注意事項】
-  - [推定] マークの項目はコードから確定できなかった推測です
-  - [TBD] マークの項目はユーザーの確認が必要です
+[Notes]
+  - Items marked [Estimated] are inferences that could not be confirmed from code
+  - Items marked [TBD] require user confirmation
 ```
 
 Then request approval via `AskUserQuestion`:
@@ -292,12 +293,12 @@ Then request approval via `AskUserQuestion`:
 ```json
 {
   "questions": [{
-    "question": "生成された SPEC.md と ARCHITECTURE.md を確認してください。どうしますか？",
-    "header": "分析結果",
+    "question": "Please review the generated SPEC.md and ARCHITECTURE.md. What would you like to do?",
+    "header": "Analysis results",
     "options": [
-      {"label": "承認", "description": "この内容で確定し、以降 analyst / delivery-flow で利用可能にする"},
-      {"label": "修正を指示", "description": "修正すべき箇所を指示する"},
-      {"label": "中断", "description": "分析を中止する"}
+      {"label": "Approve", "description": "Finalize this content and make it available for analyst / delivery-flow"},
+      {"label": "Request revision", "description": "Indicate areas that should be revised"},
+      {"label": "Abort", "description": "Stop the analysis"}
     ],
     "multiSelect": false
   }]
@@ -348,6 +349,6 @@ NEXT: done
 - [ ] Directory structure and module design are documented in ARCHITECTURE.md
 - [ ] PRODUCT_TYPE has been determined
 - [ ] HAS_UI has been determined
-- [ ] All uncertain items are marked with `[推定]` or `[TBD]`
+- [ ] All uncertain items are marked with `[Estimated]` or `[TBD]`
 - [ ] User has reviewed and approved the generated documents
 - [ ] Output block has been emitted

--- a/.claude/agents/concept-validator.md
+++ b/.claude/agents/concept-validator.md
@@ -92,57 +92,57 @@ Organize strengths, weaknesses, and improvement proposals, then summarize handof
 ## Output File: `CONCEPT_VALIDATION.md`
 
 ```markdown
-# Concept Validation: {プロジェクト名}
+# Concept Validation: {Project Name}
 
-> 参照元: INTERVIEW_RESULT.md, RESEARCH_RESULT.md, POC_RESULT.md
-> 検証日: {YYYY-MM-DD}
+> Source: INTERVIEW_RESULT.md, RESEARCH_RESULT.md, POC_RESULT.md
+> Validated: {YYYY-MM-DD}
 
-## 1. コンセプト概要
-{検証するコンセプトの説明}
+## 1. Concept Overview
+{Description of the concept being validated}
 
-## 2. ユーザーフロー
+## 2. User Flows
 
-### メインフロー
+### Main Flow
 ```
-{Mermaid または ASCII で描画}
+{Draw using Mermaid or ASCII}
 ```
 
-### サブフロー（必要に応じて）
+### Sub-flows (as needed)
 
-## 3. ワイヤーフレーム（主要画面）
+## 3. Wireframes (Primary Screens)
 
-### 画面1: {画面名}
+### Screen 1: {screen name}
 ```
-{ASCIIアートでワイヤーフレーム}
+{Wireframe as ASCII art}
 ```
-- **目的:** {この画面の目的}
-- **主要コンポーネント:** {配置するコンポーネント}
-- **検証ポイント:** {何を検証するか}
+- **Purpose:** {goal of this screen}
+- **Key components:** {components placed on this screen}
+- **Validation points:** {what is being validated}
 
-（主要画面数分繰り返す）
+(Repeat for each primary screen)
 
-## 4. UX検証結果
+## 4. UX Validation Results
 
-| # | 検証項目 | 仮説 | 評価 | 備考 |
+| # | Validation Item | Hypothesis | Evaluation | Notes |
 |---|---------|------|------|------|
-| 1 | {項目} | {仮説} | ✅/⚠️/❌ | {根拠} |
+| 1 | {item} | {hypothesis} | ✅/⚠️/❌ | {rationale} |
 
-## 5. コンセプト妥当性評価
+## 5. Concept Validity Evaluation
 
-### 強み
-- {強み}
+### Strengths
+- {strength}
 
-### 弱み・懸念
-- {懸念}
+### Weaknesses / Concerns
+- {concern}
 
-### 改善提案
-- {提案}
+### Improvement Proposals
+- {proposal}
 
-## 6. Delivery への引き継ぎ事項
-{ux-designer が参照すべきポイント}
-- デザイン方針の推奨事項
-- 特に注意すべきUX課題
-- ユーザーフロー上の重要判断
+## 6. Handoff Items to Delivery
+{Key points for ux-designer to reference}
+- Design approach recommendations
+- UX issues that require special attention
+- Key decisions in the user flow
 ```
 
 ---

--- a/.claude/agents/db-ops.md
+++ b/.claude/agents/db-ops.md
@@ -169,78 +169,78 @@ Generate `DB_OPS.md` from the above analysis results following the template belo
 ## Output File: `DB_OPS.md`
 
 ```markdown
-# DB運用ガイド: {プロジェクト名}
+# DB Operations Guide: {Project Name}
 
-> 参照元: ARCHITECTURE.md ({バージョン or 最終更新日})
-> 作成日: {YYYY-MM-DD}
+> Source: ARCHITECTURE.md ({version or last updated date})
+> Created: {YYYY-MM-DD}
 
-## 1. DB構成
+## 1. DB Configuration
 
-### 本番環境
-| 設定項目 | 値 | 備考 |
+### Production Environment
+| Setting | Value | Notes |
 |----------|---|------|
-| DB種別 | {PostgreSQL / MySQL / etc.} | |
-| バージョン | {バージョン} | |
-| 接続プール（最小/最大） | {N} / {N} | |
-| 接続タイムアウト | {N}秒 | |
-| ステートメントタイムアウト | {N}秒 | |
+| DB type | {PostgreSQL / MySQL / etc.} | |
+| Version | {version} | |
+| Connection pool (min/max) | {N} / {N} | |
+| Connection timeout | {N}s | |
+| Statement timeout | {N}s | |
 
-### 開発環境
-| 設定項目 | 値 | 備考 |
+### Development Environment
+| Setting | Value | Notes |
 |----------|---|------|
 
-### 接続文字列テンプレート
-{機密情報を含まない形式で記載}
+### Connection String Template
+{documented in a form that does not include sensitive information}
 
-## 2. マイグレーション手順
+## 2. Migration Procedures
 
-### マイグレーション一覧
-| # | ファイル名 | 内容 | 破壊的変更 |
+### Migration List
+| # | Filename | Contents | Destructive Change |
 |---|-----------|------|-----------|
 
-### 実行手順
-1. {手順}
+### Execution Procedure
+1. {step}
 
-### ロールバック手順
-1. {手順}
+### Rollback Procedure
+1. {step}
 
-### 破壊的変更の評価
-| 変更 | リスクレベル | 対策 |
+### Destructive Change Assessment
+| Change | Risk Level | Countermeasure |
 |------|------------|------|
 
-## 3. バックアップ/リストア
+## 3. Backup / Restore
 
-### バックアップ手順
-{技術スタックに応じた手順}
+### Backup Procedure
+{procedure appropriate for the tech stack}
 
-### リストア手順
-{技術スタックに応じた手順}
+### Restore Procedure
+{procedure appropriate for the tech stack}
 
-### バックアップスケジュール
-| 種別 | 頻度 | 保持期間 | 方法 |
+### Backup Schedule
+| Type | Frequency | Retention Period | Method |
 |------|------|---------|------|
 
-## 4. 監視項目
-| 項目 | 閾値 | アラート条件 |
+## 4. Monitoring Items
+| Item | Threshold | Alert Condition |
 |------|------|------------|
 
-## 5. トラブルシューティング
+## 5. Troubleshooting
 
-### 接続エラー
-- 原因:
-- 対処:
+### Connection Error
+- Cause:
+- Resolution:
 
-### スロークエリ
-- 原因:
-- 対処:
+### Slow Query
+- Cause:
+- Resolution:
 
-### デッドロック
-- 原因:
-- 対処:
+### Deadlock
+- Cause:
+- Resolution:
 
-### ディスク容量不足
-- 原因:
-- 対処:
+### Disk Space Full
+- Cause:
+- Resolution:
 ```
 
 ---

--- a/.claude/agents/delivery-flow.md
+++ b/.claude/agents/delivery-flow.md
@@ -28,7 +28,7 @@ You manage each phase of design, implementation, testing, review, documentation,
 You must never proceed to the next phase without user approval. This is an absolute rule.
 **Exception:** When auto-approve mode is active, approval gates are automatically passed (see orchestrator-rules.md "Auto-Approve Mode").
 
-> **共通ルール:** 起動時に `.claude/orchestrator-rules.md` を Read し、トリアージ・承認ゲート・エラーハンドリング・フェーズ実行ループ・差し戻しルールの共通ルールに従うこと。
+> **Common rules:** At startup, `Read` `.claude/orchestrator-rules.md` and follow its common rules for triage, approval gates, error handling, phase execution loop, and rollback.
 
 ---
 
@@ -43,8 +43,8 @@ If `DISCOVERY_RESULT.md` exists, validate the following required fields.
 If any are missing, report to the user and request corrections before proceeding to triage.
 
 - `PRODUCT_TYPE` (one of: service / tool / library / cli)
-- "プロジェクト概要" section (must not be empty)
-- "要件サマリー" section (must not be empty)
+- "Project Overview" section (must not be empty)
+- "Requirements Summary" section (must not be empty)
 
 If `DISCOVERY_RESULT.md` does not exist, skip validation and gather information by interviewing the user.
 
@@ -73,10 +73,10 @@ Output the triage result as text, then request approval via `AskUserQuestion`.
 
 First, output the result as text:
 ```
-Delivery トリアージ結果:
-  プラン: {Minimal | Light | Standard | Full}
-  判定理由: {1〜2行}
-  起動エージェント: {フェーズ番号と対応エージェントの一覧}
+Delivery triage results:
+  Plan: {Minimal | Light | Standard | Full}
+  Rationale: {1–2 lines}
+  Agents to launch: {phase numbers and corresponding agents}
 ```
 
 Then request approval via `AskUserQuestion`:
@@ -84,12 +84,12 @@ Then request approval via `AskUserQuestion`:
 ```json
 {
   "questions": [{
-    "question": "上記のトリアージ結果で Delivery を開始しますか？",
-    "header": "トリアージ",
+    "question": "Start Delivery with the triage results above?",
+    "header": "Triage",
     "options": [
-      {"label": "承認して開始", "description": "このプランで Delivery フローを開始する"},
-      {"label": "プランを変更", "description": "プランやエージェント構成を変更する"},
-      {"label": "中断", "description": "Delivery を開始しない"}
+      {"label": "Approve and start", "description": "Start the Delivery flow with this plan"},
+      {"label": "Change plan", "description": "Change the plan or agent configuration"},
+      {"label": "Abort", "description": "Do not start Delivery"}
     ],
     "multiSelect": false
   }]
@@ -102,17 +102,17 @@ Then request approval via `AskUserQuestion`:
 
 ### New Development (Standard Plan Example)
 ```
-Phase 1:  仕様策定         → spec-designer      → ⏸ ユーザー承認
-Phase 2:  UIデザイン       → ux-designer        → ⏸ ユーザー承認  ※ UIありの場合のみ
-Phase 3:  アーキテクチャ設計 → architect         → ⏸ ユーザー承認
-Phase 4:  プロジェクト初期化 → scaffolder        → ⏸ ユーザー承認
-Phase 5:  実装             → developer          → ⏸ ユーザー承認
-Phase 6:  テスト設計       → test-designer      → ⏸ ユーザー承認
-Phase 7:  E2Eテスト設計   → e2e-test-designer  → ⏸ ユーザー承認  ※ UIありの場合のみ
-Phase 8:  テスト実行       → tester             → ⏸ ユーザー承認
-Phase 9:  レビュー         → reviewer           → ⏸ ユーザー承認
-Phase 10: セキュリティ監査  → security-auditor   → ⏸ ユーザー承認
-Phase 11: ドキュメント      → doc-writer         → ⏸ ユーザー承認 → 完了
+Phase 1:  Spec definition        → spec-designer      → ⏸ User approval
+Phase 2:  UI design              → ux-designer        → ⏸ User approval  (UI projects only)
+Phase 3:  Architecture design    → architect          → ⏸ User approval
+Phase 4:  Project initialization → scaffolder         → ⏸ User approval
+Phase 5:  Implementation         → developer          → ⏸ User approval
+Phase 6:  Test design            → test-designer      → ⏸ User approval
+Phase 7:  E2E test design        → e2e-test-designer  → ⏸ User approval  (UI projects only)
+Phase 8:  Test execution         → tester             → ⏸ User approval
+Phase 9:  Review                 → reviewer           → ⏸ User approval
+Phase 10: Security audit         → security-auditor   → ⏸ User approval
+Phase 11: Documentation          → doc-writer         → ⏸ User approval → Done
 ```
 
 **Branching based on UI presence:**
@@ -125,13 +125,13 @@ Phase 11: ドキュメント      → doc-writer         → ⏸ ユーザー承
 The user launches it directly with `/analyst`, and after completion, the Delivery Flow joins from Phase 3.
 
 ```
-ユーザーが /analyst を起動
+User launches /analyst
          ↓
-analyst: issue 分析 → GitHub Issue + ARCHITECT_BRIEF 生成 → ⏸ ユーザー承認
+analyst: issue analysis → GitHub Issue + ARCHITECT_BRIEF generation → ⏸ User approval
          ↓
-Delivery Flow が Phase 3 から開始:
-Phase 3: アーキテクチャ設計 → architect      → ⏸ ユーザー承認
-（以降は通常フロー）
+Delivery Flow starts from Phase 3:
+Phase 3: Architecture design → architect      → ⏸ User approval
+(continues as normal flow)
 ```
 
 If you receive an `AGENT_RESULT` block from `analyst`, start from Phase 3.
@@ -146,27 +146,27 @@ If `developer` returns `STATUS: suspended`:
 
 1. Output the interruption status as text:
    ```
-   実装が中断されました
-   最後のコミット: {LAST_COMMIT}
-   次のタスク: TASK.md を確認してください
+   Implementation was interrupted
+   Last commit: {LAST_COMMIT}
+   Next task: Check TASK.md
    ```
 
 2. Let the user choose a response via `AskUserQuestion`:
    ```json
    {
      "questions": [{
-       "question": "実装が中断されました。どうしますか？",
-       "header": "中断対応",
+       "question": "Implementation was interrupted. How would you like to proceed?",
+       "header": "Session interrupted",
        "options": [
-         {"label": "再開する", "description": "developer を再起動して実装を続行する"},
-         {"label": "中断のまま終了", "description": "Delivery フローを停止する"}
+         {"label": "Resume", "description": "Restart developer and continue implementation"},
+         {"label": "Exit as interrupted", "description": "Stop the Delivery flow"}
        ],
        "multiSelect": false
      }]
    }
    ```
 
-If the user selects "再開する", restart `developer` (no approval gate required).
+If the user selects "Resume", restart `developer` (no approval gate required).
 
 ---
 
@@ -189,19 +189,19 @@ However, the results of re-execution after rollback still require user approval.
 ### Rollback Flow on Test Failure (Unit / Integration)
 
 ```
-tester（失敗検知）
-  → test-designer（原因分析・修正フィードバック作成）
-    → developer（修正実装）
-      → tester（再実行）
+tester (failure detected)
+  → test-designer (root cause analysis / correction feedback)
+    → developer (fix implementation)
+      → tester (re-run)
 ```
 
 ### Rollback Flow on E2E Test Failure
 
 ```
-tester（E2E 失敗検知）
-  → e2e-test-designer（原因分析・修正フィードバック作成）
-    → developer（修正実装）
-      → tester（再実行）
+tester (E2E failure detected)
+  → e2e-test-designer (root cause analysis / correction feedback)
+    → developer (fix implementation)
+      → tester (re-run)
 ```
 
 E2E test failures are routed to `e2e-test-designer` instead of `test-designer` for root cause analysis.
@@ -223,19 +223,19 @@ test-designer (or e2e-test-designer for E2E failures) determines the root cause 
 ### Rollback Flow on Review CRITICAL
 
 ```
-reviewer（CRITICAL 検知）
-  → developer（修正実装）
-    → tester（再実行）
-      → reviewer（再レビュー）
+reviewer (CRITICAL detected)
+  → developer (fix implementation)
+    → tester (re-run)
+      → reviewer (re-review)
 ```
 
 ### Rollback Flow on Security Audit CRITICAL
 
 ```
-security-auditor（CRITICAL 検知）
-  → developer（修正実装）
-    → tester（再実行）
-      → security-auditor（再監査）
+security-auditor (CRITICAL detected)
+  → developer (fix implementation)
+    → tester (re-run)
+      → security-auditor (re-audit)
 ```
 
 ### Rollback Limit
@@ -245,20 +245,20 @@ Rollbacks are limited to **3 times maximum**. If exceeded, report the situation 
 When rolling back, pass the following to `developer`:
 
 ```
-## 修正依頼
+## Fix Request
 
-### 差し戻し元
-{test-designer（テスト失敗分析）/ reviewer / security-auditor}
+### Rollback source
+{test-designer (test failure analysis) / reviewer / security-auditor}
 
-### 問題内容
-{テスト失敗の原因分析 / CRITICAL 指摘の詳細}
+### Issue description
+{Root cause analysis of test failures / details of CRITICAL findings}
 
-### 修正対象ファイル
-{ファイルパスと修正方針}
+### Files to fix
+{File paths and fix approach}
 
-### 制約
-- SPEC.md・ARCHITECTURE.md は変更しないこと
-- 修正後に実装完了レポートを出力すること
+### Constraints
+- Do not modify SPEC.md or ARCHITECTURE.md
+- Output an implementation completion report after fixing
 ```
 
 ---
@@ -275,11 +275,11 @@ When rolling back, pass the following to `developer`:
    ```json
    {
      "questions": [{
-       "question": "既存の SPEC.md / ARCHITECTURE.md が見つかりました。どうしますか？",
-       "header": "既存ファイル",
+       "question": "Existing SPEC.md / ARCHITECTURE.md were found. How would you like to proceed?",
+       "header": "Existing files",
        "options": [
-         {"label": "続きから始める", "description": "既存の成果物を活用して途中から再開する"},
-         {"label": "最初からやり直す", "description": "既存の成果物を無視して新規に開始する"}
+         {"label": "Continue from here", "description": "Reuse existing artifacts and resume from the current state"},
+         {"label": "Start over", "description": "Ignore existing artifacts and start fresh"}
        ],
        "multiSelect": false
      }]
@@ -294,32 +294,32 @@ When rolling back, pass the following to `developer`:
 
 At phase start:
 ```
-▶ Phase {N}/{総フェーズ数}: {エージェント名} を起動します...
+▶ Phase {N}/{total phases}: launching {agent name}...
 ```
 
 After all phases complete and final approval:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🎉 Delivery 完了
+Delivery complete
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Phase 1  仕様策定            ✅ 承認済み
-  Phase 2  UIデザイン          ✅ 承認済み / ⏭ スキップ（UIなし）
-  Phase 3  アーキテクチャ設計   ✅ 承認済み
-  Phase 4  プロジェクト初期化   ✅ 承認済み / ⏭ スキップ
-  Phase 5  実装               ✅ 承認済み
-  Phase 6  テスト設計          ✅ 承認済み
-  Phase 7  E2Eテスト設計      ✅ 承認済み / ⏭ スキップ（UIなし）
-  Phase 8  テスト実行          ✅ 承認済み ({N} テスト通過)
-  Phase 9  レビュー            ✅ 承認済み (CRITICAL なし)
-  Phase 10 セキュリティ監査    ✅ 承認済み (CRITICAL なし)
-  Phase 11 ドキュメント        ✅ 承認済み
+  Phase 1  Spec definition          ✅ Approved
+  Phase 2  UI design                ✅ Approved / ⏭ Skipped (no UI)
+  Phase 3  Architecture design      ✅ Approved
+  Phase 4  Project initialization   ✅ Approved / ⏭ Skipped
+  Phase 5  Implementation           ✅ Approved
+  Phase 6  Test design              ✅ Approved
+  Phase 7  E2E test design          ✅ Approved / ⏭ Skipped (no UI)
+  Phase 8  Test execution           ✅ Approved ({N} tests passed)
+  Phase 9  Review                   ✅ Approved (no CRITICALs)
+  Phase 10 Security audit           ✅ Approved (no CRITICALs)
+  Phase 11 Documentation            ✅ Approved
 
-成果物:
+Artifacts:
   SPEC.md          ✅
-  UI_SPEC.md       ✅ / （UIなし）
+  UI_SPEC.md       ✅ / (no UI)
   ARCHITECTURE.md  ✅
   TEST_PLAN.md     ✅
-  実装コード        ✅
+  Implementation   ✅
   README.md        ✅
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
@@ -329,31 +329,31 @@ After all phases complete and final approval:
 After all phases are complete, generate the handoff file that serves as input for Operations.
 
 ```markdown
-# Delivery Result: {プロジェクト名}
+# Delivery Result: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> Delivery プラン: {Minimal | Light | Standard | Full}
+> Created: {YYYY-MM-DD}
+> Delivery Plan: {Minimal | Light | Standard | Full}
 > PRODUCT_TYPE: {service | tool | library | cli}
 
-## 成果物
-- SPEC.md: {あり/なし}
-- ARCHITECTURE.md: {あり/なし}
-- UI_SPEC.md: {あり/なし/該当なし}
-- TEST_PLAN.md: {あり/なし}
-- 実装コード: {ファイル数}
-- README.md: {あり/なし}
+## Artifacts
+- SPEC.md: {present/absent}
+- ARCHITECTURE.md: {present/absent}
+- UI_SPEC.md: {present/absent/N/A}
+- TEST_PLAN.md: {present/absent}
+- Implementation code: {file count}
+- README.md: {present/absent}
 
-## 技術スタック
-{確定した技術スタックの要約}
+## Tech Stack
+{Summary of confirmed tech stack}
 
-## テスト結果
-- 合計: {N} / 成功: {N} / 失敗: {N}
+## Test Results
+- Total: {N} / Pass: {N} / Fail: {N}
 
-## セキュリティ監査結果
+## Security Audit Results
 - CRITICAL: {N} / WARNING: {N}
 
-## Operations への引き継ぎ（service の場合）
-{デプロイに必要な情報、環境変数一覧、DB要件等}
+## Handoff to Operations (for service type)
+{Information required for deployment, environment variable list, DB requirements, etc.}
 ```
 
 ---

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -92,24 +92,24 @@ Read the "Implementation Order" section of `ARCHITECTURE.md` and generate `TASK.
 ```markdown
 # TASK.md
 
-> 参照元: ARCHITECTURE.md ({バージョン or 最終更新日})
+> Source: ARCHITECTURE.md ({version or last updated date})
 
-## フェーズ: {フェーズ名}
-最終更新: {日時}
-ステータス: 進行中
+## Phase: {phase name}
+Last updated: {datetime}
+Status: In progress
 
-## タスク一覧
+## Task List
 
 ### Phase {N}
-- [ ] TASK-001: {タスク名} | 対象ファイル: src/...
-- [ ] TASK-002: {タスク名} | 対象ファイル: src/...
-- [ ] TASK-003: {タスク名} | 対象ファイル: src/...
+- [ ] TASK-001: {task name} | Target file: src/...
+- [ ] TASK-002: {task name} | Target file: src/...
+- [ ] TASK-003: {task name} | Target file: src/...
 
-## 直近のコミット
-（タスク完了のたびに git log --oneline -3 を記録する）
+## Recent Commits
+(Record git log --oneline -3 each time a task is completed)
 
-## 中断時のメモ
-（セッション中断時に状況をここに記録する）
+## Session Interruption Notes
+(Record the situation here when a session is interrupted)
 ```
 
 ### Resume Mode (when TASK.md exists)
@@ -120,14 +120,14 @@ Read the "Implementation Order" section of `ARCHITECTURE.md` and generate `TASK.
 4. Report the following to the user before resuming work
 
 ```
-## 再開レポート
+## Resume Report
 
-進捗状況:
-- 完了済み: TASK-001〜{N} （{N}件）
-- 次のタスク: TASK-{N+1}: {タスク名}
-- 最後のコミット: {git log の1行}
+Progress:
+- Completed: TASK-001 through TASK-{N} ({N} tasks)
+- Next task: TASK-{N+1}: {task name}
+- Last commit: {git log one-liner}
 
-TASK-{N+1} から再開します。
+Resuming from TASK-{N+1}.
 ```
 
 ### Task Completion Procedure (required, execute every time)
@@ -137,8 +137,8 @@ Each time a task is completed, always execute the following before moving to the
 ```bash
 # 1. Update TASK.md
 #    - Change completed task from [ ] to [x]
-#    - Update the "最終更新" timestamp
-#    - Update "直近のコミット"
+#    - Update the "Last updated" timestamp
+#    - Update "Recent Commits"
 
 # 2. Syntax check (see .claude/rules/build-verification-commands.md)
 #    Python: python -m py_compile {changed files}
@@ -160,10 +160,10 @@ Each time a task is completed, always execute the following before moving to the
 
 # 5. Git commit (always commit per task)
 git add {changed files}   # git add -A is prohibited (see .claude/rules/git-rules.md)
-git commit -m "{prefix}: {タスク名} (TASK-{N})
+git commit -m "{prefix}: {task name} (TASK-{N})
 
-- {実装内容の箇条書き}
-- 対応UC: UC-XXX（あれば）"
+- {bullet points of implementation details}
+- Related UC: UC-XXX (if applicable)"
 ```
 
 **Commit message prefix rules:** See .claude/rules/git-rules.md
@@ -173,7 +173,7 @@ git commit -m "{prefix}: {タスク名} (TASK-{N})
 When context remaining is running low, always execute the following before moving to the next task:
 
 ```bash
-# Update the "中断時のメモ" in TASK.md
+# Update the "Session Interruption Notes" in TASK.md
 # Contents to record:
 # - Completed tasks (TASK-001 through TASK-XXX)
 # - Next task to work on (TASK-XXX)
@@ -181,19 +181,19 @@ When context remaining is running low, always execute the following before movin
 # - Handoff notes
 
 git add TASK.md
-git commit -m "chore: セッション中断時点の進捗を記録 (TASK-{N}まで完了)"
+git commit -m "chore: record progress at session interruption (completed through TASK-{N})"
 ```
 
 Then communicate the following to the user and stop:
 
 ```
-セッションを中断します。
+Suspending session.
 
-完了済み: TASK-001〜TASK-{N}
-次のタスク: TASK-{N+1}: {タスク名}
+Completed: TASK-001 through TASK-{N}
+Next task: TASK-{N+1}: {task name}
 
-再開時は「developerを使って再開してください」と伝えてください。
-TASK.md と git log を確認して自動的に再開します。
+To resume, say "please resume using developer".
+TASK.md and git log will be checked to resume automatically.
 ```
 
 ---
@@ -234,7 +234,7 @@ FastAPI specific:
 
 ### Common Coding Conventions
 - Follow the naming rules in `ARCHITECTURE.md` for variable names, function names, and file names
-- Write comments in Japanese (code itself in English)
+- Write comments in the language specified by `Output Language` in project-rules.md (code itself in English)
 - Consider splitting if a file exceeds 300 lines
 
 ### File Operation Principles
@@ -263,7 +263,7 @@ Unlike `error`, this represents a state where the agent itself executed normally
 ```
 AGENT_RESULT: developer
 STATUS: blocked
-BLOCKED_REASON: ARCHITECTURE.md のモジュール X と Y の責務が重複しており、メソッド Z の配置先が不明
+BLOCKED_REASON: Module X and Y in ARCHITECTURE.md have overlapping responsibilities; placement of method Z is unclear
 BLOCKED_TARGET: architect
 CURRENT_TASK: TASK-005
 NEXT: suspended

--- a/.claude/agents/discovery-flow.md
+++ b/.claude/agents/discovery-flow.md
@@ -36,7 +36,7 @@ You must never proceed to the next phase without user approval. This is an absol
 Systematically conduct requirements exploration for the project and generate a **`DISCOVERY_RESULT.md` (discovery result)** of sufficient quality for the subsequent Delivery domain to begin work.
 Perform triage according to project characteristics and selectively launch only the necessary agents, balancing efficiency and quality.
 
-> **共通ルール:** 起動時に `.claude/orchestrator-rules.md` を Read し、トリアージ・承認ゲート・エラーハンドリング・フェーズ実行ループ・差し戻しルールの共通ルールに従うこと。
+> **Common rules:** At startup, `Read` `.claude/orchestrator-rules.md` and follow its common rules for triage, approval gates, error handling, phase execution loop, and rollback.
 
 ---
 
@@ -63,42 +63,42 @@ Since `AskUserQuestion` allows a maximum of 4 questions per call, split into 2 r
 {
   "questions": [
     {
-      "question": "プロジェクトの規模はどの程度ですか？",
-      "header": "規模",
+      "question": "What is the scale of the project?",
+      "header": "Scale",
       "options": [
-        {"label": "小規模スクリプト", "description": "個人利用の小さなツールやスクリプト"},
-        {"label": "個人PJ", "description": "個人のサイドプロジェクト。複数機能あり"},
-        {"label": "チームPJ", "description": "チームで開発する中規模プロジェクト"},
-        {"label": "大規模PJ", "description": "複数チーム・長期間の大規模プロジェクト"}
+        {"label": "Small script", "description": "A small personal tool or script"},
+        {"label": "Personal project", "description": "A personal side project with multiple features"},
+        {"label": "Team project", "description": "A medium-scale project developed by a team"},
+        {"label": "Large-scale project", "description": "A large project spanning multiple teams over a long period"}
       ],
       "multiSelect": false
     },
     {
-      "question": "UIの形態はどれですか？",
-      "header": "UI形態",
+      "question": "What type of UI does the project have?",
+      "header": "UI type",
       "options": [
-        {"label": "CLI", "description": "コマンドラインインターフェース"},
-        {"label": "API only", "description": "APIのみ（UIなし）"},
-        {"label": "Web UI", "description": "ブラウザで操作するWebアプリケーション"},
-        {"label": "モバイル", "description": "iOS / Android アプリ"}
+        {"label": "CLI", "description": "Command-line interface"},
+        {"label": "API only", "description": "API only (no UI)"},
+        {"label": "Web UI", "description": "A web application operated via browser"},
+        {"label": "Mobile", "description": "iOS / Android app"}
       ],
       "multiSelect": false
     },
     {
-      "question": "外部APIやサードパーティサービスを利用しますか？",
-      "header": "外部依存",
+      "question": "Will the project use external APIs or third-party services?",
+      "header": "External dependencies",
       "options": [
-        {"label": "なし", "description": "外部サービスへの依存なし"},
-        {"label": "あり", "description": "外部API・サードパーティサービスを利用する"}
+        {"label": "None", "description": "No dependency on external services"},
+        {"label": "Yes", "description": "Uses external APIs or third-party services"}
       ],
       "multiSelect": false
     },
     {
-      "question": "既存システムとの統合は必要ですか？",
-      "header": "既存統合",
+      "question": "Does the project need to integrate with an existing system?",
+      "header": "Existing integration",
       "options": [
-        {"label": "新規", "description": "ゼロから新規開発"},
-        {"label": "既存統合あり", "description": "既存システムやコードベースと統合する"}
+        {"label": "New development", "description": "Brand new development from scratch"},
+        {"label": "Integration required", "description": "Integrates with an existing system or codebase"}
       ],
       "multiSelect": false
     }
@@ -112,23 +112,23 @@ Since `AskUserQuestion` allows a maximum of 4 questions per call, split into 2 r
 {
   "questions": [
     {
-      "question": "ドメインの複雑度はどの程度ですか？",
-      "header": "複雑度",
+      "question": "How complex is the domain?",
+      "header": "Complexity",
       "options": [
-        {"label": "単純", "description": "一般的な技術領域。特殊なルールなし"},
-        {"label": "中程度", "description": "業界固有のルールがいくつかある"},
-        {"label": "複雑", "description": "規制あり・業界固有ルール・コンプライアンス対応が必要"}
+        {"label": "Simple", "description": "General technology area; no special rules"},
+        {"label": "Moderate", "description": "Has some industry-specific rules"},
+        {"label": "Complex", "description": "Requires regulatory compliance, industry-specific rules, or compliance handling"}
       ],
       "multiSelect": false
     },
     {
-      "question": "成果物の性質はどれに該当しますか？",
+      "question": "Which best describes the nature of the artifact?",
       "header": "PRODUCT_TYPE",
       "options": [
-        {"label": "service", "description": "ネットワーク越しにサービスを提供（Web API, Web アプリ等）"},
-        {"label": "tool", "description": "ローカルで動作するユーティリティ（GUI / TUI ツール等）"},
-        {"label": "library", "description": "他のコードから呼び出されるライブラリ / SDK"},
-        {"label": "cli", "description": "コマンドラインインターフェースツール"}
+        {"label": "service", "description": "Provides a service over the network (Web API, web app, etc.)"},
+        {"label": "tool", "description": "A locally running utility (GUI / TUI tool, etc.)"},
+        {"label": "library", "description": "A library / SDK called by other code"},
+        {"label": "cli", "description": "A command-line interface tool"}
       ],
       "multiSelect": false
     }
@@ -155,16 +155,16 @@ Output triage results as text, then request approval via `AskUserQuestion`.
 
 First, output results as text:
 ```
-トリアージ結果:
-  - 規模: {判定結果}
-  - UI有無: {判定結果}
-  - 外部依存: {判定結果}
-  - 既存システム: {判定結果}
-  - ドメイン複雑度: {判定結果}
+Triage results:
+  - Scale: {result}
+  - UI: {result}
+  - External dependencies: {result}
+  - Existing system: {result}
+  - Domain complexity: {result}
   - PRODUCT_TYPE: {service | tool | library | cli}
 
-選択プラン: {Minimal | Light | Standard | Full}
-起動エージェント: {エージェントの順序}
+Selected plan: {Minimal | Light | Standard | Full}
+Agents to launch: {agent order}
 ```
 
 Then request approval via `AskUserQuestion`:
@@ -172,12 +172,12 @@ Then request approval via `AskUserQuestion`:
 ```json
 {
   "questions": [{
-    "question": "上記のトリアージ結果で Discovery を開始しますか？",
-    "header": "トリアージ",
+    "question": "Start Discovery with the triage results above?",
+    "header": "Triage",
     "options": [
-      {"label": "承認して開始", "description": "このプランで Discovery フローを開始する"},
-      {"label": "プランを変更", "description": "プランやエージェント構成を変更する"},
-      {"label": "中断", "description": "Discovery を開始しない"}
+      {"label": "Approve and start", "description": "Start the Discovery flow with this plan"},
+      {"label": "Change plan", "description": "Change the plan or agent configuration"},
+      {"label": "Abort", "description": "Do not start Discovery"}
     ],
     "multiSelect": false
   }]
@@ -190,34 +190,34 @@ Then request approval via `AskUserQuestion`:
 
 ### Minimal Plan
 ```
-Phase 1: 要件ヒアリング    → interviewer       → ⏸ ユーザー承認
-→ DISCOVERY_RESULT.md 生成（Flow が interviewer の結果をもとに作成）
+Phase 1: Requirements interview  → interviewer       → ⏸ User approval
+→ Generate DISCOVERY_RESULT.md (flow creates it from interviewer's results)
 ```
 
 ### Light Plan
 ```
-Phase 1: 要件ヒアリング    → interviewer       → ⏸ ユーザー承認
-Phase 2: ルール策定        → rules-designer    → ⏸ ユーザー承認
-Phase 3: スコープ策定      → scope-planner     → ⏸ ユーザー承認 → 完了
+Phase 1: Requirements interview  → interviewer       → ⏸ User approval
+Phase 2: Rules definition        → rules-designer    → ⏸ User approval
+Phase 3: Scope definition        → scope-planner     → ⏸ User approval → Done
 ```
 
 ### Standard Plan
 ```
-Phase 1: 要件ヒアリング    → interviewer       → ⏸ ユーザー承認
-Phase 2: ドメイン調査      → researcher        → ⏸ ユーザー承認
-Phase 3: 技術PoC          → poc-engineer      → ⏸ ユーザー承認
-Phase 4: ルール策定        → rules-designer    → ⏸ ユーザー承認
-Phase 5: スコープ策定      → scope-planner     → ⏸ ユーザー承認 → 完了
+Phase 1: Requirements interview  → interviewer       → ⏸ User approval
+Phase 2: Domain research         → researcher        → ⏸ User approval
+Phase 3: Technical PoC           → poc-engineer      → ⏸ User approval
+Phase 4: Rules definition        → rules-designer    → ⏸ User approval
+Phase 5: Scope definition        → scope-planner     → ⏸ User approval → Done
 ```
 
 ### Full Plan
 ```
-Phase 1: 要件ヒアリング    → interviewer       → ⏸ ユーザー承認
-Phase 2: ドメイン調査      → researcher        → ⏸ ユーザー承認
-Phase 3: 技術PoC          → poc-engineer      → ⏸ ユーザー承認
-Phase 4: コンセプト検証    → concept-validator → ⏸ ユーザー承認  ※ UIありの場合のみ
-Phase 5: ルール策定        → rules-designer    → ⏸ ユーザー承認
-Phase 6: スコープ策定      → scope-planner     → ⏸ ユーザー承認 → 完了
+Phase 1: Requirements interview  → interviewer       → ⏸ User approval
+Phase 2: Domain research         → researcher        → ⏸ User approval
+Phase 3: Technical PoC           → poc-engineer      → ⏸ User approval
+Phase 4: Concept validation      → concept-validator → ⏸ User approval  (UI projects only)
+Phase 5: Rules definition        → rules-designer    → ⏸ User approval
+Phase 6: Scope definition        → scope-planner     → ⏸ User approval → Done
 ```
 
 ---
@@ -230,52 +230,52 @@ Rollbacks are limited to **3 times maximum**. If exceeded, report the situation 
 ### Pattern 1: poc-engineer → interviewer (technically infeasible requirements)
 
 ```
-poc-engineer（STATUS: blocked, BLOCKED_ITEMS > 0）
-  → interviewer（実現不可能な要件を除外・代替案をヒアリング）
-    → researcher（必要に応じて再調査）
-      → poc-engineer（再検証）
+poc-engineer (STATUS: blocked, BLOCKED_ITEMS > 0)
+  → interviewer (exclude infeasible requirements / interview for alternatives)
+    → researcher (re-investigate if needed)
+      → poc-engineer (re-verify)
 ```
 
 Pass the following to `interviewer` during rollback:
 
 ```
-## 差し戻し: 技術的に実現不可能な要件
+## Rollback: Technically infeasible requirements
 
-### 差し戻し元
+### Rollback source
 poc-engineer
 
-### 実現不可能な要件
-{POC_RESULT.md の「実現不可能な要件」セクションから抽出}
+### Infeasible requirements
+{Extracted from the "Infeasible Requirements" section of POC_RESULT.md}
 
-### 代替案の提案（poc-engineer からの提案があれば）
-{代替案}
+### Proposed alternatives (if any, from poc-engineer)
+{alternatives}
 
-### 依頼事項
-- 上記の要件について、ユーザーと代替案を協議してください
-- 要件の修正または削除を INTERVIEW_RESULT.md に反映してください
+### Request
+- Please discuss alternatives for the above requirements with the user
+- Reflect requirement changes or removals in INTERVIEW_RESULT.md
 ```
 
 ### Pattern 2: scope-planner → researcher (insufficient information)
 
 ```
-scope-planner（STATUS: blocked）
-  → researcher（不足情報を追加調査）
-    → scope-planner（再実行）
+scope-planner (STATUS: blocked)
+  → researcher (additional research on missing information)
+    → scope-planner (re-run)
 ```
 
 Pass the following to `researcher` during rollback:
 
 ```
-## 差し戻し: 情報不足
+## Rollback: Insufficient information
 
-### 差し戻し元
+### Rollback source
 scope-planner
 
-### 不足している情報
-{scope-planner の BLOCKED_REASON から抽出}
+### Missing information
+{Extracted from scope-planner's BLOCKED_REASON}
 
-### 依頼事項
-- 上記の情報を追加調査して RESEARCH_RESULT.md を更新してください
+### Request
+- Please conduct additional research on the above information and update RESEARCH_RESULT.md
 ```
 
 ---
@@ -303,30 +303,30 @@ scope-planner
 For the Minimal plan, the flow orchestrator generates this directly. For Light and above, scope-planner generates it.
 
 ```markdown
-# Discovery Result: {プロジェクト名}
+# Discovery Result: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> Discovery プラン: {Minimal | Light | Standard | Full}
+> Created: {YYYY-MM-DD}
+> Discovery Plan: {Minimal | Light | Standard | Full}
 
-## プロジェクト概要
-{1〜3行の要約}
+## Project Overview
+{1–3 line summary}
 
-## 成果物の性質
+## Artifact Type
 PRODUCT_TYPE: {service | tool | library | cli}
 
-## 要件サマリー
-{構造化された要件の要約}
+## Requirements Summary
+{Structured requirements summary}
 
-## スコープ（確定している場合）
-- MVP: {最小スコープ}
-- IN: {含むもの}
-- OUT: {含まないもの}
+## Scope (if confirmed)
+- MVP: {minimum scope}
+- IN: {included}
+- OUT: {excluded}
 
-## 技術リスク・制約（調査済みの場合）
-{PoCの結果、外部依存の制約等}
+## Technical Risks / Constraints (if investigated)
+{PoC results, external dependency constraints, etc.}
 
-## 未解決事項
-{Delivery で解決すべき残課題}
+## Unresolved Items
+{Remaining issues to be resolved in Delivery}
 ```
 
 ---
@@ -335,34 +335,34 @@ PRODUCT_TYPE: {service | tool | library | cli}
 
 At phase start:
 ```
-▶ Phase {N}/{総フェーズ数}: {エージェント名} を起動します...
+▶ Phase {N}/{total phases}: launching {agent name}...
 ```
 
 After all phases complete and final approval:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Discovery 完了
+Discovery complete
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  プラン: {選択プラン}
-  PRODUCT_TYPE: {判定結果}
+  Plan: {selected plan}
+  PRODUCT_TYPE: {result}
 
-  Phase 1 要件ヒアリング    ✅ 承認済み
-  Phase 2 ドメイン調査      ✅ 承認済み / ⏭ スキップ
-  Phase 3 技術PoC          ✅ 承認済み / ⏭ スキップ
-  Phase 4 コンセプト検証    ✅ 承認済み / ⏭ スキップ（UIなし）
-  Phase 5 ルール策定        ✅ 承認済み / ⏭ スキップ
-  Phase 6 スコープ策定      ✅ 承認済み / ⏭ スキップ
+  Phase 1 Requirements interview  ✅ Approved
+  Phase 2 Domain research         ✅ Approved / ⏭ Skipped
+  Phase 3 Technical PoC           ✅ Approved / ⏭ Skipped
+  Phase 4 Concept validation      ✅ Approved / ⏭ Skipped (no UI)
+  Phase 5 Rules definition        ✅ Approved / ⏭ Skipped
+  Phase 6 Scope definition        ✅ Approved / ⏭ Skipped
 
-成果物:
-  DISCOVERY_RESULT.md  ✅
-  INTERVIEW_RESULT.md  ✅
-  RESEARCH_RESULT.md   ✅ / （該当なし）
-  POC_RESULT.md        ✅ / （該当なし）
-  CONCEPT_VALIDATION.md ✅ / （該当なし）
-  SCOPE_PLAN.md        ✅ / （該当なし）
+Artifacts:
+  DISCOVERY_RESULT.md   ✅
+  INTERVIEW_RESULT.md   ✅
+  RESEARCH_RESULT.md    ✅ / (N/A)
+  POC_RESULT.md         ✅ / (N/A)
+  CONCEPT_VALIDATION.md ✅ / (N/A)
+  SCOPE_PLAN.md         ✅ / (N/A)
 
-次のステップ:
-  Delivery Flow を起動して DISCOVERY_RESULT.md を入力してください。
+Next step:
+  Launch Delivery Flow and provide DISCOVERY_RESULT.md as input.
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 

--- a/.claude/agents/doc-writer.md
+++ b/.claude/agents/doc-writer.md
@@ -53,65 +53,65 @@ Verify the following before starting work:
 The face of the project. Create with the following structure:
 
 ```markdown
-# {プロジェクト名}
+# {Project Name}
 
-{1〜3行のプロジェクト概要}
+{1-3 line project overview}
 
-## 機能
+## Features
 
-{主要機能の箇条書き}
+{bullet points of key features}
 
-## 技術スタック
+## Tech Stack
 
-| 技術 | 用途 |
+| Technology | Purpose |
 |------|------|
 
-## セットアップ
+## Setup
 
-### 前提条件
+### Prerequisites
 
-{必要なツール・ランタイムのバージョン}
+{required tools and runtime versions}
 
-### インストール
+### Installation
 
 ```bash
-{インストールコマンド}
+{installation command}
 ```
 
-### 環境変数
+### Environment Variables
 
-| 変数名 | 説明 | 必須 | デフォルト |
+| Variable | Description | Required | Default |
 |--------|------|------|----------|
 
-### 起動
+### Start
 
 ```bash
-{起動コマンド}
+{start command}
 ```
 
-## 使い方
+## Usage
 
-{基本的な使い方の例}
+{basic usage examples}
 
-## API（該当する場合）
+## API (if applicable)
 
-{主要エンドポイントの概要 or 自動ドキュメントへのリンク}
+{overview of main endpoints or link to auto-generated documentation}
 
-## テスト
+## Testing
 
 ```bash
-{テスト実行コマンド}
+{test execution command}
 ```
 
-## ディレクトリ構造
+## Directory Structure
 
 ```
-{ARCHITECTURE.md のディレクトリ構造を簡略化して転記}
+{simplified copy of the directory structure from ARCHITECTURE.md}
 ```
 
-## ライセンス
+## License
 
-{ライセンス種別}
+{license type}
 ```
 
 ### 2. `CHANGELOG.md` (generated from git log)
@@ -122,13 +122,13 @@ The face of the project. Create with the following structure:
 ## [Unreleased]
 
 ### Added
-{git log から feat: コミットを抽出}
+{extract feat: commits from git log}
 
 ### Fixed
-{git log から fix: コミットを抽出}
+{extract fix: commits from git log}
 
 ### Changed
-{git log から refactor: コミットを抽出}
+{extract refactor: commits from git log}
 ```
 
 ### 3. API Documentation (when APIs exist)
@@ -152,10 +152,10 @@ If not, document usage examples for the main endpoints.
 
 ```bash
 git add README.md CHANGELOG.md {other documents}
-git commit -m "docs: プロジェクトドキュメントを作成
+git commit -m "docs: create project documentation
 
-- README.md 作成
-- CHANGELOG.md 作成"
+- create README.md
+- create CHANGELOG.md"
 ```
 
 ---

--- a/.claude/agents/e2e-test-designer.md
+++ b/.claude/agents/e2e-test-designer.md
@@ -73,26 +73,26 @@ Step 1. Map screens to use cases
   - Identify the primary user flows that span multiple screens
 
 Step 2. Derive user interaction tests
-  - For each screen's "インタラクション" table, create test cases for:
+  - For each screen's "Interactions" table, create test cases for:
     - User action triggers (click, input, navigation)
     - Expected feedback (loading states, success/error messages, toasts)
     - Form submission and server response handling
 
 Step 3. Derive validation tests
-  - For each screen's "バリデーション" table, create test cases for:
+  - For each screen's "Validation" table, create test cases for:
     - Required field enforcement
     - Format validation (email, phone, URL, etc.)
     - Error message display at the correct location
 
 Step 4. Derive state rendering tests
-  - For each screen's "状態パターン" table, create test cases for:
+  - For each screen's "State Patterns" table, create test cases for:
     - Empty state rendering (no data)
     - Loading state rendering (spinner, skeleton)
     - Error state rendering (error message, retry button)
     - Normal state rendering (data displayed correctly)
 
 Step 5. Derive navigation tests
-  - From UI_SPEC.md "画面遷移フロー", create test cases for:
+  - From UI_SPEC.md "Screen Transition Flow", create test cases for:
     - Forward navigation (link clicks, form submissions)
     - Backward navigation (browser back, breadcrumbs)
     - Deep link / direct URL access
@@ -138,75 +138,75 @@ Step 3. Document test environment requirements
 Append the following section to the existing `TEST_PLAN.md`:
 
 ```markdown
-## 7. E2E / GUI テスト設計
+## 7. E2E / GUI Test Design
 
-### E2E テスト環境
-- ツール: {Playwright / pywinauto / pyautogui}
-- ブラウザ: {Chromium, Firefox, WebKit}（Web の場合）
-- 実行モード: {headless（CI）/ headed（開発時）}
-- ベースURL: {テスト対象URL}（Web の場合）
-- 解像度: {指定解像度}（GUI の場合）
+### E2E Test Environment
+- Tool: {Playwright / pywinauto / pyautogui}
+- Browsers: {Chromium, Firefox, WebKit} (for Web)
+- Execution mode: {headless (CI) / headed (development)}
+- Base URL: {target URL} (for Web)
+- Resolution: {specified resolution} (for GUI)
 
-### E2E テスト依存パッケージ
-| パッケージ | 用途 | 備考 |
+### E2E Test Dependency Packages
+| Package | Purpose | Notes |
 |-----------|------|------|
-| {パッケージ名} | {E2Eフレームワーク等} | {バージョン指定等} |
+| {package name} | {E2E framework, etc.} | {version specification, etc.} |
 
-### E2E テストファイル構成
+### E2E Test File Structure
 ```
 tests/
-├── e2e/                     # Web E2E テスト
-│   ├── conftest.py          # 共通フィクスチャ（Python）
-│   ├── playwright.config.ts # Playwright 設定（TypeScript）
-│   ├── fixtures/            # テストデータ・ログイン状態等
+├── e2e/                     # Web E2E tests
+│   ├── conftest.py          # shared fixtures (Python)
+│   ├── playwright.config.ts # Playwright configuration (TypeScript)
+│   ├── fixtures/            # test data, login state, etc.
 │   ├── pages/               # Page Object Model
-│   │   ├── login_page.py    # ログイン画面 POM
+│   │   ├── login_page.py    # Login screen POM
 │   │   └── ...
-│   └── test_{画面名}.py     # 画面ごとのテスト
-├── gui/                     # GUI テスト（デスクトップの場合）
-│   ├── conftest.py          # アプリ起動・終了フィクスチャ
-│   ├── images/              # 画像マッチング用参照画像
-│   └── test_{操作名}.py     # 操作ごとのテスト
+│   └── test_{screen_name}.py # tests per screen
+├── gui/                     # GUI tests (for desktop)
+│   ├── conftest.py          # app launch/close fixtures
+│   ├── images/              # reference images for image matching
+│   └── test_{operation}.py  # tests per operation
 ```
 
-### E2E テストケース一覧
+### E2E Test Case List
 
-#### Web E2E テストケース
-| TC番号 | テストケース名 | 対象画面 | 操作手順 | 期待結果 | 対応UC |
+#### Web E2E Test Cases
+| TC No. | Test Case Name | Target Screen | Operation Steps | Expected Result | UC |
 |--------|-------------|---------|---------|---------|--------|
-| TC-E2E-001 | {テストケース名} | SCR-XXX | {ステップ記述} | {期待結果} | UC-XXX |
+| TC-E2E-001 | {test case name} | SCR-XXX | {step description} | {expected result} | UC-XXX |
 
-#### GUI テストケース（該当する場合）
-| TC番号 | テストケース名 | 操作対象 | 操作手順 | 期待結果 | 対応UC | 識別方式 |
+#### GUI Test Cases (if applicable)
+| TC No. | Test Case Name | Target | Operation Steps | Expected Result | UC | ID Method |
 |--------|-------------|---------|---------|---------|--------|---------|
-| TC-GUI-001 | {テストケース名} | {ウィンドウ/コントロール} | {ステップ記述} | {期待結果} | UC-XXX | {accessibility/image/coordinate} |
+| TC-GUI-001 | {test case name} | {window/control} | {step description} | {expected result} | UC-XXX | {accessibility/image/coordinate} |
 
-### Page Object Model 設計（Web E2E の場合）
+### Page Object Model Design (Web E2E)
 
-| ページクラス | 対応画面 | 主要セレクタ | 主要アクション |
+| Page Class | Target Screen | Key Selectors | Key Actions |
 |------------|---------|------------|-------------|
 | LoginPage | SCR-001 | `[data-testid=email]`, `[data-testid=password]` | `login(email, password)` |
 
-### E2E テスト実行コマンド
+### E2E Test Execution Commands
 ```bash
-# 全 E2E テスト実行
-{E2E テスト実行コマンド}
+# Run all E2E tests
+{E2E test execution command}
 
-# 特定画面のみ実行
-{特定画面のテスト実行コマンド}
+# Run specific screen only
+{specific screen test command}
 
-# デバッグモード（headed）実行
-{headed モードのコマンド}
+# Debug mode (headed) execution
+{headed mode command}
 
-# トレース付き実行（失敗時の調査用）
-{トレース有効化コマンド}
+# Execution with trace (for failure investigation)
+{trace enable command}
 ```
 
-### E2E UC-テストケース トレーサビリティマトリクス
+### E2E UC-Test Case Traceability Matrix
 
-| UC番号 | 受け入れ条件 | E2E テストケース | 対象画面 |
+| UC No. | Acceptance Criterion | E2E Test Cases | Target Screen |
 |--------|------------|---------------|---------|
-| UC-001 | {条件1} | TC-E2E-001, TC-E2E-002 | SCR-001 |
+| UC-001 | {criterion 1} | TC-E2E-001, TC-E2E-002 | SCR-001 |
 ```
 
 ---
@@ -238,23 +238,23 @@ When `tester` reports E2E test failures, perform root cause analysis:
 ### E2E Failure Analysis Report Format
 
 ```
-## E2E テスト失敗分析レポート（developer 向け）
+## E2E Test Failure Analysis Report (for developer)
 
-### 原因分類
-{テストコードバグ / テスト環境 / UI実装バグ / 仕様不備}
+### Root Cause Classification
+{test code bug / test environment / UI implementation bug / spec deficiency}
 
-### 失敗テスト: {テストケース名} (TC-E2E-XXX / TC-GUI-XXX)
-- **対応UC:** UC-XXX
-- **対象画面:** SCR-XXX
-- **テストファイル:** {パス}
-- **対象コード:** {テスト対象のファイルパス}:{行番号}
-- **操作手順の再現:** {失敗に至る操作ステップ}
-- **期待値:** {expected}
-- **実際の値:** {actual}
-- **スクリーンショット:** {失敗時のスクリーンショットパス}
-- **トレース:** {Playwright トレースファイルパス}（Web E2E の場合）
-- **原因分析:** {なぜ失敗したかの詳細分析}
-- **修正方針:** {具体的にどう修正すべきか}
+### Failed Test: {test case name} (TC-E2E-XXX / TC-GUI-XXX)
+- **Corresponding UC:** UC-XXX
+- **Target screen:** SCR-XXX
+- **Test file:** {path}
+- **Target code:** {target file path}:{line number}
+- **Operation steps to reproduce:** {operation steps that led to failure}
+- **Expected:** {expected}
+- **Actual:** {actual}
+- **Screenshot:** {path to failure screenshot}
+- **Trace:** {Playwright trace file path} (for Web E2E)
+- **Root cause analysis:** {detailed analysis of why it failed}
+- **Fix approach:** {specifically how it should be fixed}
 ```
 
 ---

--- a/.claude/agents/impact-analyzer.md
+++ b/.claude/agents/impact-analyzer.md
@@ -56,10 +56,10 @@ Before starting analysis, verify you have:
 Locate the specific code positions related to the trigger using `Grep` and `Glob`:
 
 ```bash
-# エラーメッセージ・関数名・クラス名などで検索
+# Search by error message, function name, class name, etc.
 grep -r "{keyword}" . --include="*.py" --include="*.ts" --include="*.go" --include="*.rs" -n -l
 
-# 特定のモジュール・パスを対象に絞る場合
+# Narrow down to a specific module or path
 find . -path "*/module_name/*" -name "*.py"
 ```
 
@@ -78,7 +78,7 @@ For each target file, trace outgoing and incoming dependencies:
 **Incoming dependencies (what depends on this file — fan-in):**
 
 ```bash
-# 変更対象ファイルが export しているシンボルを他ファイルが import しているか検索
+# Search whether other files import symbols exported by the target file
 grep -r "{exported_symbol}" . --include="*.py" -l
 grep -r "from {module}" . --include="*.ts" -l
 ```
@@ -103,13 +103,13 @@ Evaluate the following factors:
 
 **Test coverage:**
 ```bash
-# 変更対象ファイルに対応するテストファイルが存在するか
+# Check whether test files corresponding to the target files exist
 find . -name "test_*.py" -o -name "*_test.go" -o -name "*.spec.ts" -o -name "*.test.ts" | head -50
 ```
 
 **Commit frequency (stability indicator):**
 ```bash
-# 過去 3 ヶ月の変更対象ファイルのコミット頻度
+# Commit frequency for target files over the past 3 months
 git log --since="3 months ago" --oneline -- {target_file}
 ```
 
@@ -140,25 +140,25 @@ After completing the analysis, present the impact report and request approval:
 **Step 1: Output impact report as text:**
 
 ```
-影響範囲調査完了
+Impact scope analysis complete
 
-【変更対象ファイル】
-  - {file path}: {変更予定の箇所}
+[Target files]
+  - {file path}: {expected change location}
   - ...
 
-【依存ファイル (影響を受ける可能性)】
-  - {file path}: {依存箇所}
+[Dependency files (potentially affected)]
+  - {file path}: {dependency location}
   - ...
 
-【破壊的変更】
-  - 公開 API: {変更あり / なし}
-  - DB スキーマ: {変更あり / なし}
-  - 環境変数: {変更あり / なし}
+[Breaking changes]
+  - Public API: {present / none}
+  - DB schema: {present / none}
+  - Environment variables: {present / none}
 
-【リグレッションリスク】{low | medium | high}
-  根拠: {テストカバレッジ・fan-in・コミット頻度の評価}
+[Regression risk] {low | medium | high}
+  Rationale: {assessment of test coverage, fan-in, commit frequency}
 
-【推奨テスト範囲】{unit | integration | e2e}
+[Recommended test scope] {unit | integration | e2e}
 ```
 
 **Step 2: Request approval via `AskUserQuestion`:**
@@ -166,12 +166,12 @@ After completing the analysis, present the impact report and request approval:
 ```json
 {
   "questions": [{
-    "question": "影響範囲調査結果を確認しました。analyst フェーズに進んでよいですか？",
-    "header": "影響評価の承認",
+    "question": "Impact scope analysis confirmed. Proceed to the analyst phase?",
+    "header": "Impact assessment approval",
     "options": [
-      {"label": "承認して続行 (推奨)", "description": "この影響範囲評価で analyst に引き継ぐ"},
-      {"label": "追加調査を依頼", "description": "調査範囲を広げるよう指示する"},
-      {"label": "中断", "description": "maintenance-flow を停止する"}
+      {"label": "Approve and continue (recommended)", "description": "Hand off to analyst with this impact scope assessment"},
+      {"label": "Request additional investigation", "description": "Expand the investigation scope"},
+      {"label": "Abort", "description": "Stop maintenance-flow"}
     ],
     "multiSelect": false
   }]

--- a/.claude/agents/infra-builder.md
+++ b/.claude/agents/infra-builder.md
@@ -194,29 +194,29 @@ Create based on the "Environment Variables" section of ARCHITECTURE.md.
 
 ```env
 # ===========================================
-# アプリケーション設定
+# Application settings
 # ===========================================
-# アプリケーション名
+# Application name
 APP_NAME=
-# 実行環境 (development | staging | production)
+# Runtime environment (development | staging | production)
 APP_ENV=
-# ログレベル (DEBUG | INFO | WARNING | ERROR)
+# Log level (DEBUG | INFO | WARNING | ERROR)
 LOG_LEVEL=
 
 # ===========================================
-# データベース設定
+# Database settings
 # ===========================================
-# データベース接続URL (例: postgresql://user:pass@host:5432/dbname)
+# Database connection URL (e.g., postgresql://user:pass@host:5432/dbname)
 DATABASE_URL=
-# 接続プール最大数
+# Max connection pool size
 DATABASE_POOL_SIZE=
 
 # ===========================================
-# セキュリティ設定
+# Security settings
 # ===========================================
-# JWT シークレットキー（本番環境では必ず変更すること）
+# JWT secret key (must be changed in production)
 SECRET_KEY=
-# CORS 許可オリジン（カンマ区切り）
+# CORS allowed origins (comma-separated)
 CORS_ORIGINS=
 ```
 

--- a/.claude/agents/interviewer.md
+++ b/.claude/agents/interviewer.md
@@ -93,13 +93,13 @@ At each step of the interview, use `AskUserQuestion` for questions that can be a
 ```json
 {
   "questions": [{
-    "question": "以下の非機能要件のうち、このプロジェクトで必要なものはどれですか？",
-    "header": "非機能要件",
+    "question": "Which of the following non-functional requirements are needed for this project?",
+    "header": "Non-functional requirements",
     "options": [
-      {"label": "認証・認可", "description": "ログイン機能やロールベースのアクセス制御"},
-      {"label": "データ永続化", "description": "データベースへの保存・バックアップ"},
-      {"label": "パフォーマンス要件", "description": "応答時間や同時接続数の目標値"},
-      {"label": "セキュリティ", "description": "個人情報の取り扱い・暗号化"}
+      {"label": "Authentication / Authorization", "description": "Login functionality or role-based access control"},
+      {"label": "Data persistence", "description": "Database storage and backup"},
+      {"label": "Performance requirements", "description": "Response time targets or concurrent user targets"},
+      {"label": "Security", "description": "Handling of personal data, encryption"}
     ],
     "multiSelect": true
   }]
@@ -111,13 +111,13 @@ At each step of the interview, use `AskUserQuestion` for questions that can be a
 ```json
 {
   "questions": [{
-    "question": "成果物はどの形態に最も近いですか？",
+    "question": "Which best describes the form of the artifact?",
     "header": "PRODUCT_TYPE",
     "options": [
-      {"label": "service", "description": "ネットワーク越しにサービスを提供（Web API, Web アプリ等）"},
-      {"label": "tool", "description": "ローカルで動作するユーティリティ（GUI / TUI ツール等）"},
-      {"label": "library", "description": "他のコードから呼び出されるライブラリ / SDK"},
-      {"label": "cli", "description": "コマンドラインインターフェースツール"}
+      {"label": "service", "description": "Provides a service over the network (Web API, web app, etc.)"},
+      {"label": "tool", "description": "A locally running utility (GUI / TUI tool, etc.)"},
+      {"label": "library", "description": "A library / SDK called by other code"},
+      {"label": "cli", "description": "A command-line interface tool"}
     ],
     "multiSelect": false
   }]
@@ -155,12 +155,12 @@ When a technically infeasible requirement is rolled back from `poc-engineer`:
 ```json
 {
   "questions": [{
-    "question": "「{要件名}」は技術的に実現不可能と判定されました。どう対応しますか？",
-    "header": "要件変更",
+    "question": "'{requirement name}' has been determined to be technically infeasible. How would you like to handle it?",
+    "header": "Requirement change",
     "options": [
-      {"label": "要件を削除", "description": "この要件をスコープから除外する"},
-      {"label": "代替案に変更", "description": "{代替案の概要}"},
-      {"label": "制約付きで維持", "description": "条件を明確化した上で要件を維持する"}
+      {"label": "Remove requirement", "description": "Exclude this requirement from the scope"},
+      {"label": "Switch to alternative", "description": "{summary of alternative}"},
+      {"label": "Retain with constraints", "description": "Retain the requirement with explicitly clarified conditions"}
     ],
     "multiSelect": false
   }]
@@ -175,53 +175,53 @@ When a technically infeasible requirement is rolled back from `poc-engineer`:
 ## Output File: `INTERVIEW_RESULT.md`
 
 ```markdown
-# Interview Result: {プロジェクト名}
+# Interview Result: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> 更新履歴:
->   - {YYYY-MM-DD}: 初回作成
+> Created: {YYYY-MM-DD}
+> Update history:
+>   - {YYYY-MM-DD}: Initial creation
 
-## プロジェクト概要
-{1〜3行の要約。何を作るのか、なぜ作るのか}
+## Project Overview
+{1–3 line summary: what is being built and why}
 
 ## PRODUCT_TYPE
 {service | tool | library | cli}
-判定理由: {なぜその種別と判定したか}
+Rationale: {why this type was determined}
 
-## ステークホルダー
-| ステークホルダー | 役割 | 関心事 |
+## Stakeholders
+| Stakeholder | Role | Concerns |
 |---|---|---|
-| {名前/種別} | {開発者/エンドユーザー/管理者等} | {主な関心事} |
+| {name/type} | {developer/end user/admin, etc.} | {primary concerns} |
 
-## 要件一覧
+## Requirements
 
-### 機能要件
-| # | 要件 | 優先度 | 備考 |
+### Functional Requirements
+| # | Requirement | Priority | Notes |
 |---|---|---|---|
-| FR-001 | {要件名} | 高/中/低 | {補足情報} |
+| FR-001 | {requirement name} | high/medium/low | {additional info} |
 
-### 非機能要件
-| カテゴリ | 要件 | 備考 |
+### Non-Functional Requirements
+| Category | Requirement | Notes |
 |---|---|---|
-| {パフォーマンス/セキュリティ/可用性等} | {具体的な要件} | {補足情報} |
+| {performance/security/availability, etc.} | {specific requirement} | {additional info} |
 
-### 暗黙要件（ヒアリングから発見）
-| # | 要件 | 根拠 |
+### Implicit Requirements (discovered via interview)
+| # | Requirement | Basis |
 |---|---|---|
-| IR-001 | {暗黙的に必要な要件} | {なぜこの要件が必要と判断したか} |
+| IR-001 | {implicitly required item} | {why this requirement was identified as necessary} |
 
-## 制約・前提条件
-- {技術的制約}
-- {ビジネス上の制約}
-- {環境の前提条件}
+## Constraints / Preconditions
+- {technical constraints}
+- {business constraints}
+- {environmental preconditions}
 
-## UI有無
+## UI Presence
 HAS_UI: {true | false}
-判定理由: {なぜそう判定したか}
+Rationale: {why this was determined}
 
-## 未解決事項
-- {ヒアリングでは確定できなかった事項}
-- {後続フェーズで検討が必要な事項}
+## Unresolved Items
+- {items that could not be confirmed during the interview}
+- {items that need consideration in subsequent phases}
 ```
 
 ---

--- a/.claude/agents/maintenance-flow.md
+++ b/.claude/agents/maintenance-flow.md
@@ -29,7 +29,7 @@ You manage the full maintenance lifecycle for changes to existing projects.
 You must never proceed to the next phase without user approval. This is an absolute rule.
 **Exception:** When auto-approve mode is active, approval gates are automatically passed (see orchestrator-rules.md "Auto-Approve Mode").
 
-> **共通ルール:** 起動時に `.claude/orchestrator-rules.md` を Read し、トリアージ・承認ゲート・エラーハンドリング・フェーズ実行ループ・差し戻しルールの共通ルールに従うこと。
+> **Common rules:** At startup, `Read` `.claude/orchestrator-rules.md` and follow its common rules for triage, approval gates, error handling, phase execution loop, and rollback.
 
 ---
 
@@ -69,45 +69,45 @@ The orchestrator reads the `AGENT_RESULT` from `change-classifier` to determine 
 ### Phase 0 (Conditional): codebase-analyzer
 Only when `change-classifier` reports `REQUIRES_CODEBASE_ANALYZER: true`:
 ```
-Phase 0: ドキュメント生成    → codebase-analyzer  → ⏸ ユーザー承認
+Phase 0: Document generation  → codebase-analyzer  → ⏸ User approval
 ```
 After Phase 0, re-run `change-classifier` to produce a valid AGENT_RESULT.
 
 ### Patch Plan
 ```
-Phase 1: 変更分類・緊急度判定  → change-classifier  → ⏸ ユーザー承認 (変更計画)  ← 必須 HITL ゲート①
-Phase 2: issue 化・方針決定   → analyst            → ⏸ ユーザー承認
-Phase 3: 実装                → developer          → ⏸ ユーザー承認
-Phase 4: テスト実行           → tester             → ⏸ ユーザー承認
-[フロー完了最終確認]                                 ⏸ ユーザー承認                ← 必須 HITL ゲート②
+Phase 1: Change classification / urgency  → change-classifier  → ⏸ User approval (change plan)  ← Mandatory HITL Gate #1
+Phase 2: Issue creation / approach        → analyst            → ⏸ User approval
+Phase 3: Implementation                  → developer          → ⏸ User approval
+Phase 4: Test execution                  → tester             → ⏸ User approval
+[Final flow completion confirmation]                           ⏸ User approval                   ← Mandatory HITL Gate #2
 ```
 
-CVE 対応 (`TRIGGER_TYPE: security`) の場合のみ security-auditor を Phase 4 と最終確認の間に任意挿入:
+For CVE responses (`TRIGGER_TYPE: security`) only, optionally insert security-auditor between Phase 4 and final confirmation:
 ```
-Phase 4: テスト実行           → tester             → ⏸ ユーザー承認
-Phase 5: セキュリティ監査 (任意) → security-auditor → ⏸ ユーザー承認
+Phase 4: Test execution       → tester             → ⏸ User approval
+Phase 5: Security audit (opt) → security-auditor   → ⏸ User approval
 ```
 
 ### Minor Plan
 ```
-Phase 1: 変更分類・緊急度判定       → change-classifier   → ⏸ ユーザー承認 (変更計画)  ← 必須 HITL ゲート①
-Phase 2: 影響範囲調査              → impact-analyzer     → ⏸ ユーザー承認
-Phase 3: issue 化・方針決定        → analyst             → ⏸ ユーザー承認
-Phase 4: 差分アーキテクチャ設計     → architect (差分モード) → ⏸ ユーザー承認
-Phase 5: 実装                     → developer           → ⏸ ユーザー承認
-Phase 6: テスト実行                → tester              → ⏸ ユーザー承認
-Phase 7: レビュー                  → reviewer            → ⏸ ユーザー承認
-[フロー完了最終確認]                                       ⏸ ユーザー承認              ← 必須 HITL ゲート②
+Phase 1: Change classification / urgency  → change-classifier         → ⏸ User approval (change plan)  ← Mandatory HITL Gate #1
+Phase 2: Impact analysis                  → impact-analyzer           → ⏸ User approval
+Phase 3: Issue creation / approach        → analyst                   → ⏸ User approval
+Phase 4: Differential architecture design → architect (differential)  → ⏸ User approval
+Phase 5: Implementation                   → developer                 → ⏸ User approval
+Phase 6: Test execution                   → tester                    → ⏸ User approval
+Phase 7: Review                           → reviewer                  → ⏸ User approval
+[Final flow completion confirmation]                                   ⏸ User approval              ← Mandatory HITL Gate #2
 ```
 
-### Major Plan (delivery-flow への引き渡し)
+### Major Plan (handoff to delivery-flow)
 ```
-Phase 1: 変更分類・緊急度判定  → change-classifier   → ⏸ ユーザー承認 (変更計画)  ← 必須 HITL ゲート①
-Phase 2: 影響範囲調査         → impact-analyzer     → ⏸ ユーザー承認
-Phase 3: issue 化・方針決定   → analyst             → ⏸ ユーザー承認
-Phase 4: セキュリティ事前監査  → security-auditor    → ⏸ ユーザー承認
-[MAINTENANCE_RESULT.md 生成]
-[delivery-flow 引き渡し最終確認]                        ⏸ ユーザー承認              ← 必須 HITL ゲート②
+Phase 1: Change classification / urgency  → change-classifier  → ⏸ User approval (change plan)  ← Mandatory HITL Gate #1
+Phase 2: Impact analysis                  → impact-analyzer    → ⏸ User approval
+Phase 3: Issue creation / approach        → analyst            → ⏸ User approval
+Phase 4: Pre-security audit               → security-auditor   → ⏸ User approval
+[Generate MAINTENANCE_RESULT.md]
+[delivery-flow handoff confirmation]                           ⏸ User approval                   ← Mandatory HITL Gate #2
 ```
 
 ---
@@ -127,12 +127,12 @@ When launching `architect` in Minor plan, always include the following in the pr
 
 ```
 mode: differential
-base_version: ARCHITECTURE.md (最終更新日を Read して取得)
+base_version: ARCHITECTURE.md (read Last Updated date via Read)
 analyst_brief: {ARCHITECT_BRIEF from analyst AGENT_RESULT}
 impact_summary: {IMPACT_SUMMARY from impact-analyzer AGENT_RESULT}
-scope: 以下の差分のみを ARCHITECTURE.md に反映すること。全体書き換えは禁止。
-       変更対象: {TARGET_FILES from impact-analyzer}
-       影響範囲: {DEPENDENCY_FILES from impact-analyzer}
+scope: Apply only the following diff to ARCHITECTURE.md. Full rewrites are prohibited.
+       Target files: {TARGET_FILES from impact-analyzer}
+       Impact scope: {DEPENDENCY_FILES from impact-analyzer}
 ```
 
 ### Information Passing Between Phases
@@ -168,42 +168,42 @@ Inherits `.claude/orchestrator-rules.md` Rollback Rules with the following maint
 After Phase 4 (security-auditor) completes for the Major plan, generate `MAINTENANCE_RESULT.md`:
 
 ```markdown
-# Maintenance Result: {変更サマリ}
+# Maintenance Result: {Change summary}
 
-> 作成日: {YYYY-MM-DD}
-> Maintenance プラン: Major
-> トリガー種別: {bug | feature | tech_debt | performance | security}
-> 緊急度: {P1 | P2 | P3 | P4}
+> Created: {YYYY-MM-DD}
+> Maintenance Plan: Major
+> Trigger type: {bug | feature | tech_debt | performance | security}
+> Priority: {P1 | P2 | P3 | P4}
 
-## 変更概要
-{1–3 行の要約}
+## Change Overview
+{1–3 line summary}
 
-## change-classifier 判定
+## change-classifier Verdict
 - PLAN: Major
 - BREAKING_CHANGE: {true | false}
 - SPEC_IMPACT: major
 - RATIONALE: {RATIONALE from change-classifier}
 
-## impact-analyzer 調査結果
+## impact-analyzer Findings
 - TARGET_FILES: {TARGET_FILES list}
 - BREAKING_API_CHANGES: {list or "none"}
 - DB_SCHEMA_CHANGES: {true | false}
 - REGRESSION_RISK: {low | medium | high}
 - RECOMMENDED_TEST_SCOPE: {unit | integration | e2e}
 
-## analyst による差分設計方針
-- SPEC.md への差分: {from analyst AGENT_RESULT}
-- ARCHITECTURE.md への影響: {architect が差分設計する箇所}
+## analyst Differential Design Approach
+- SPEC.md diff: {from analyst AGENT_RESULT}
+- ARCHITECTURE.md impact: {areas where architect will apply differential design}
 - GitHub Issue URL: {GITHUB_ISSUE from analyst}
 
-## security-auditor 事前監査結果
+## security-auditor Pre-audit Results
 - CRITICAL: {N}
 - WARNING: {N}
-- 事前対策必須項目: {list}
+- Required pre-remediation items: {list}
 
-## delivery-flow への引き継ぎ
-- 推奨プラン: Standard | Full
-- 追加指示: {considerations for delivery-flow execution}
+## Handoff to delivery-flow
+- Recommended plan: Standard | Full
+- Additional notes: {considerations for delivery-flow execution}
 
 ## PRODUCT_TYPE
 {inherit from existing SPEC.md PRODUCT_TYPE}
@@ -215,35 +215,35 @@ After Phase 4 (security-auditor) completes for the Major plan, generate `MAINTEN
 
 At phase start:
 ```
-▶ Phase {N}/{総フェーズ数}: {エージェント名} を起動します... [Maintenance プラン: {Patch | Minor | Major}]
+▶ Phase {N}/{total phases}: launching {agent name}... [Maintenance Plan: {Patch | Minor | Major}]
 ```
 
 After all phases complete and final approval (Patch / Minor):
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Maintenance フロー完了 ({Patch | Minor} プラン)
+Maintenance flow complete ({Patch | Minor} plan)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  プラン: {Patch | Minor}
-  トリガー種別: {trigger_type}
-  優先度: {P1 | P2 | P3 | P4}
+  Plan: {Patch | Minor}
+  Trigger type: {trigger_type}
+  Priority: {P1 | P2 | P3 | P4}
 
-  Phase 1  変更分類            ✅ 承認済み
-  Phase 2  影響範囲調査        ✅ 承認済み / ⏭ スキップ（Patch）
-  Phase 3  issue 化・方針決定  ✅ 承認済み
-  Phase 4  差分設計            ✅ 承認済み / ⏭ スキップ（Patch）
-  Phase 5  実装               ✅ 承認済み
-  Phase 6  テスト実行          ✅ 承認済み ({N} テスト通過)
-  Phase 7  レビュー            ✅ 承認済み / ⏭ スキップ（Patch）
+  Phase 1  Change classification      ✅ Approved
+  Phase 2  Impact analysis            ✅ Approved / ⏭ Skipped (Patch)
+  Phase 3  Issue creation / approach  ✅ Approved
+  Phase 4  Differential design        ✅ Approved / ⏭ Skipped (Patch)
+  Phase 5  Implementation             ✅ Approved
+  Phase 6  Test execution             ✅ Approved ({N} tests passed)
+  Phase 7  Review                     ✅ Approved / ⏭ Skipped (Patch)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 After Major plan completion:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Maintenance フロー完了 (Major プラン → delivery-flow 引き渡し)
+Maintenance flow complete (Major plan → handoff to delivery-flow)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  MAINTENANCE_RESULT.md を生成しました。
-  delivery-flow を起動して続行してください: /delivery-flow
+  MAINTENANCE_RESULT.md has been generated.
+  Launch delivery-flow to continue: /delivery-flow
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -260,12 +260,12 @@ Output the completion summary as text, then:
 ```json
 {
   "questions": [{
-    "question": "maintenance-flow が完了しました。変更内容を最終確認してください。",
-    "header": "フロー完了最終確認",
+    "question": "maintenance-flow has completed. Please review the changes for final confirmation.",
+    "header": "Final flow confirmation",
     "options": [
-      {"label": "完了として確定", "description": "変更を受け入れてフローを終了する"},
-      {"label": "追加修正を依頼", "description": "追加の修正を developer に依頼する"},
-      {"label": "ロールバック", "description": "変更を破棄してフローを終了する"}
+      {"label": "Confirm as complete", "description": "Accept the changes and end the flow"},
+      {"label": "Request additional fixes", "description": "Request additional fixes from developer"},
+      {"label": "Rollback", "description": "Discard the changes and end the flow"}
     ],
     "multiSelect": false
   }]
@@ -277,12 +277,12 @@ Output the completion summary as text, then:
 ```json
 {
   "questions": [{
-    "question": "Major プランの前処理が完了しました。MAINTENANCE_RESULT.md を生成しました。delivery-flow に引き渡してよいですか？",
-    "header": "delivery-flow 引き渡し確認",
+    "question": "Major plan pre-processing is complete. MAINTENANCE_RESULT.md has been generated. Proceed to hand off to delivery-flow?",
+    "header": "delivery-flow handoff confirmation",
     "options": [
-      {"label": "delivery-flow に引き渡す", "description": "/delivery-flow を起動して続行する"},
-      {"label": "内容を確認してから判断", "description": "MAINTENANCE_RESULT.md を確認してから決定する"},
-      {"label": "中断", "description": "maintenance-flow を停止する"}
+      {"label": "Hand off to delivery-flow", "description": "Launch /delivery-flow to continue"},
+      {"label": "Review before deciding", "description": "Review MAINTENANCE_RESULT.md before deciding"},
+      {"label": "Abort", "description": "Stop maintenance-flow"}
     ],
     "multiSelect": false
   }]

--- a/.claude/agents/observability.md
+++ b/.claude/agents/observability.md
@@ -137,11 +137,11 @@ Implement the health check endpoint according to the tech stack.
 # Verify operation
 # Commit
 git add {files}
-git commit -m "ops: ヘルスチェックエンドポイントを追加
+git commit -m "ops: add health check endpoint
 
-- /health エンドポイント実装
-- DB接続チェック
-- 外部サービスチェック"
+- implement /health endpoint
+- add DB connection check
+- add external service check"
 ```
 
 ---
@@ -149,37 +149,37 @@ git commit -m "ops: ヘルスチェックエンドポイントを追加
 ## Output File: `OBSERVABILITY.md`
 
 ```markdown
-# 可観測性設計: {プロジェクト名}
+# Observability Design: {Project Name}
 
-> 参照元: ARCHITECTURE.md
-> 作成日: {YYYY-MM-DD}
+> Source: ARCHITECTURE.md
+> Created: {YYYY-MM-DD}
 
-## 1. ヘルスチェック
-### エンドポイント
-### チェック項目
-### レスポンス形式
+## 1. Health Checks
+### Endpoint
+### Check Items
+### Response Format
 
-## 2. ログ設計
-### ログレベル定義
-### ログフォーマット
-### ログ出力先
-### 機密情報マスクルール
+## 2. Log Design
+### Log Level Definitions
+### Log Format
+### Log Output Destination
+### Sensitive Information Masking Rules
 
-## 3. メトリクス（REDメソッド）
+## 3. Metrics (RED Method)
 ### Rate
 ### Errors
 ### Duration
 
-## 4. アラートルール
-| ルール名 | 条件 | 重篤度 | 通知先 | 対応手順 |
+## 4. Alert Rules
+| Rule Name | Condition | Severity | Notification Target | Response Procedure |
 |---------|------|--------|--------|---------|
 
-## 5. パフォーマンスベースライン
-| エンドポイント | P50 | P95 | P99 | 目標 |
+## 5. Performance Baseline
+| Endpoint | P50 | P95 | P99 | Target |
 |--------------|-----|-----|-----|------|
 
-## 6. ダッシュボード設計（推奨パネル）
-| パネル名 | 表示内容 | 更新間隔 |
+## 6. Dashboard Design (Recommended Panels)
+| Panel Name | Display Content | Refresh Interval |
 |---------|---------|---------|
 ```
 

--- a/.claude/agents/operations-flow.md
+++ b/.claude/agents/operations-flow.md
@@ -29,7 +29,7 @@ You manage the entire deploy and operations flow, and **you must always obtain u
 You must never proceed to the next phase without user approval. This is an absolute rule.
 **Exception:** When auto-approve mode is active, approval gates are automatically passed (see orchestrator-rules.md "Auto-Approve Mode").
 
-> **共通ルール:** 起動時に `.claude/orchestrator-rules.md` を Read し、トリアージ・承認ゲート・エラーハンドリング・フェーズ実行ループ・差し戻しルールの共通ルールに従うこと。
+> **Common rules:** At startup, `Read` `.claude/orchestrator-rules.md` and follow its common rules for triage, approval gates, error handling, phase execution loop, and rollback.
 
 ## Mission
 
@@ -83,13 +83,13 @@ Once the plan is determined, report it via text output and obtain approval via `
 
 First, output the results as text:
 ```
-Operations トリアージ結果:
-  選定プラン: {Light | Standard | Full}
-  判定根拠:
-    - DB: {あり/なし} — {根拠}
-    - ユーザー向け: {はい/いいえ} — {根拠}
-    - 可用性要件: {あり/なし} — {根拠}
-  起動エージェント: {フェーズと対応エージェントの一覧}
+Operations triage results:
+  Selected plan: {Light | Standard | Full}
+  Rationale:
+    - DB: {present/absent} — {basis}
+    - User-facing: {yes/no} — {basis}
+    - Availability requirements: {present/absent} — {basis}
+  Agents to launch: {phase and corresponding agent list}
 ```
 
 Then request approval via `AskUserQuestion`:
@@ -97,12 +97,12 @@ Then request approval via `AskUserQuestion`:
 ```json
 {
   "questions": [{
-    "question": "上記のトリアージ結果で Operations を開始しますか？",
-    "header": "トリアージ",
+    "question": "Start Operations with the triage results above?",
+    "header": "Triage",
     "options": [
-      {"label": "承認して開始", "description": "このプランで Operations フローを開始する"},
-      {"label": "プランを変更", "description": "プランやエージェント構成を変更する"},
-      {"label": "中断", "description": "Operations を開始しない"}
+      {"label": "Approve and start", "description": "Start the Operations flow with this plan"},
+      {"label": "Change plan", "description": "Change the plan or agent configuration"},
+      {"label": "Abort", "description": "Do not start Operations"}
     ],
     "multiSelect": false
   }]
@@ -115,23 +115,23 @@ Then request approval via `AskUserQuestion`:
 
 ### Light Plan
 ```
-Phase 1: インフラ構築       → infra-builder  → ⏸ ユーザー承認
-Phase 2: 運用計画           → ops-planner    → ⏸ ユーザー承認 → 完了
+Phase 1: Infrastructure build  → infra-builder  → ⏸ User approval
+Phase 2: Operations planning   → ops-planner    → ⏸ User approval → Done
 ```
 
 ### Standard Plan
 ```
-Phase 1: インフラ構築       → infra-builder  → ⏸ ユーザー承認
-Phase 2: DB運用設計         → db-ops         → ⏸ ユーザー承認
-Phase 3: 運用計画           → ops-planner    → ⏸ ユーザー承認 → 完了
+Phase 1: Infrastructure build  → infra-builder  → ⏸ User approval
+Phase 2: DB operations design  → db-ops         → ⏸ User approval
+Phase 3: Operations planning   → ops-planner    → ⏸ User approval → Done
 ```
 
 ### Full Plan
 ```
-Phase 1: インフラ構築       → infra-builder  → ⏸ ユーザー承認
-Phase 2: DB運用設計         → db-ops         → ⏸ ユーザー承認
-Phase 3: 可観測性設計       → observability  → ⏸ ユーザー承認
-Phase 4: 運用計画           → ops-planner    → ⏸ ユーザー承認 → 完了
+Phase 1: Infrastructure build  → infra-builder  → ⏸ User approval
+Phase 2: DB operations design  → db-ops         → ⏸ User approval
+Phase 3: Observability design  → observability  → ⏸ User approval
+Phase 4: Operations planning   → ops-planner    → ⏸ User approval → Done
 ```
 
 ---
@@ -176,28 +176,28 @@ Operations Flow verifies its content and displays the following completion summa
 
 At phase start:
 ```
-▶ Phase {N}/{総フェーズ数}: {エージェント名} を起動します...
+▶ Phase {N}/{total phases}: launching {agent name}...
 ```
 
 After all phases complete and final approval:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Operations フロー完了
+Operations flow complete
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Operations プラン: {Light | Standard | Full}
+  Operations Plan: {Light | Standard | Full}
 
-  Phase 1 インフラ構築       ✅ 承認済み
-  Phase 2 DB運用設計         ✅ 承認済み / ⏭ スキップ
-  Phase 3 可観測性設計       ✅ 承認済み / ⏭ スキップ
-  Phase 4 運用計画           ✅ 承認済み
+  Phase 1 Infrastructure build  ✅ Approved
+  Phase 2 DB operations design  ✅ Approved / ⏭ Skipped
+  Phase 3 Observability design  ✅ Approved / ⏭ Skipped
+  Phase 4 Operations planning   ✅ Approved
 
-成果物:
+Artifacts:
   Dockerfile           ✅
   docker-compose.yml   ✅
-  CI/CD パイプライン    ✅
+  CI/CD pipeline       ✅
   .env.example         ✅
-  DB_OPS.md            ✅ / （該当なし）
-  OBSERVABILITY.md     ✅ / （該当なし）
+  DB_OPS.md            ✅ / (N/A)
+  OBSERVABILITY.md     ✅ / (N/A)
   OPS_PLAN.md          ✅
   OPS_RESULT.md        ✅
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/.claude/agents/ops-planner.md
+++ b/.claude/agents/ops-planner.md
@@ -89,133 +89,133 @@ Record a summary of all artifacts and readiness status as the final artifact of 
 ### `OPS_PLAN.md`
 
 ```markdown
-# 運用計画書: {プロジェクト名}
+# Operations Plan: {Project Name}
 
-> 参照元: ARCHITECTURE.md, {前段成果物}
-> 作成日: {YYYY-MM-DD}
+> Source: ARCHITECTURE.md, {preceding artifacts}
+> Created: {YYYY-MM-DD}
 
-## 1. デプロイ手順
+## 1. Deploy Procedure
 
-### 前提条件
-- {必要なアクセス権限}
-- {必要なツール・CLI}
-- {環境変数の設定}
+### Prerequisites
+- {required access permissions}
+- {required tools / CLI}
+- {environment variable configuration}
 
-### 初回デプロイ手順
-1. {手順} ← ロールバックポイント①
-2. {手順}
-3. {手順} ← ロールバックポイント②
-4. {手順}
+### Initial Deploy Procedure
+1. {step} ← Rollback point 1
+2. {step}
+3. {step} ← Rollback point 2
+4. {step}
 
-### 通常デプロイ手順（2回目以降）
-1. {手順}
-2. {手順}
+### Routine Deploy Procedure (2nd time onwards)
+1. {step}
+2. {step}
 
-### デプロイ確認チェックリスト
-- [ ] アプリケーションが起動している
-- [ ] ヘルスチェックが通過している
-- [ ] ログにエラーが出ていない
-- [ ] 主要機能が動作している
+### Deploy Verification Checklist
+- [ ] Application is running
+- [ ] Health check is passing
+- [ ] No errors in logs
+- [ ] Key features are working
 
-## 2. ロールバック手順
+## 2. Rollback Procedure
 
-### トリガー条件
-以下のいずれかに該当する場合、ロールバックを実行する：
-- ヘルスチェックが3回連続失敗
-- エラー率が {閾値}% を超過
-- 主要機能が動作しない
+### Trigger Conditions
+Execute rollback if any of the following apply:
+- Health check fails 3 consecutive times
+- Error rate exceeds {threshold}%
+- Key features not functioning
 
-### ロールバック手順
-1. {手順}
-2. {手順}
+### Rollback Steps
+1. {step}
+2. {step}
 
-### ロールバック確認
-- [ ] 前バージョンが起動している
-- [ ] ヘルスチェックが通過している
+### Rollback Verification
+- [ ] Previous version is running
+- [ ] Health check is passing
 
-## 3. インシデント対応プレイブック
+## 3. Incident Response Playbook
 
-### 重篤度定義
-| レベル | 定義 | 対応時間目標 | エスカレーション |
+### Severity Definitions
+| Level | Definition | Response Time Target | Escalation |
 |--------|------|------------|----------------|
-| P1 | サービス全面停止 | 15分以内 | 即時 |
-| P2 | 主要機能の障害 | 30分以内 | 30分後 |
-| P3 | 一部機能の障害 | 2時間以内 | 翌営業日 |
-| P4 | 軽微な問題 | 翌営業日 | 不要 |
+| P1 | Full service outage | Within 15 minutes | Immediate |
+| P2 | Major feature failure | Within 30 minutes | After 30 minutes |
+| P3 | Partial feature failure | Within 2 hours | Next business day |
+| P4 | Minor issue | Next business day | Not required |
 
-### シナリオ別対応
+### Response by Scenario
 
-#### シナリオ1: アプリケーション停止
-- **検知:** ヘルスチェック失敗アラート
-- **初動:** ログ確認 → プロセス再起動
-- **エスカレーション:** 再起動で復旧しない場合
-- **復旧:** ロールバック実行
+#### Scenario 1: Application Down
+- **Detection:** Health check failure alert
+- **Initial action:** Check logs → restart process
+- **Escalation:** If service does not recover after restart
+- **Recovery:** Execute rollback
 
-#### シナリオ2: DB接続障害
-- **検知:** ヘルスチェック（DB）失敗
-- **初動:** DB サーバー状態確認 → 接続プール確認
-- **エスカレーション:** DB サーバー自体の障害の場合
-- **復旧:** DB 復旧後にアプリケーション再起動
+#### Scenario 2: DB Connection Failure
+- **Detection:** Health check (DB) failure
+- **Initial action:** Check DB server status → check connection pool
+- **Escalation:** If the DB server itself has failed
+- **Recovery:** Restart application after DB recovery
 
-#### シナリオ3: 外部API障害
-- **検知:** エラーログ増加 / タイムアウト増加
-- **初動:** 外部APIステータスページ確認
-- **エスカレーション:** 長時間の障害の場合
-- **復旧:** 外部API復旧後に自動回復 / フォールバック
+#### Scenario 3: External API Failure
+- **Detection:** Increasing error logs / increasing timeouts
+- **Initial action:** Check external API status page
+- **Escalation:** If the outage is prolonged
+- **Recovery:** Auto-recovery after external API recovers / fallback
 
-## 4. メンテナンスチェックリスト
+## 4. Maintenance Checklist
 
-### 日次
-- [ ] ログの異常確認
-- [ ] ディスク使用量確認
-- [ ] バックアップ完了確認
+### Daily
+- [ ] Check logs for anomalies
+- [ ] Check disk usage
+- [ ] Confirm backup completed
 
-### 週次
-- [ ] 依存パッケージの脆弱性チェック
-- [ ] パフォーマンスメトリクスの傾向確認
-- [ ] ログのローテーション確認
+### Weekly
+- [ ] Dependency vulnerability check
+- [ ] Check performance metrics trends
+- [ ] Confirm log rotation
 
-### 月次
-- [ ] DB のバキューム / 最適化
-- [ ] SSL 証明書の有効期限確認
-- [ ] アクセス権限の棚卸し
+### Monthly
+- [ ] DB vacuum / optimization
+- [ ] Check SSL certificate expiry
+- [ ] Review access permissions
 
-## 5. 連絡先・エスカレーション
-| 役割 | 連絡先 | 備考 |
+## 5. Contacts / Escalation
+| Role | Contact | Notes |
 |------|--------|------|
 ```
 
 ### `OPS_RESULT.md`
 
 ```markdown
-# Operations Result: {プロジェクト名}
+# Operations Result: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> Operations プラン: {Light | Standard | Full}
+> Created: {YYYY-MM-DD}
+> Operations plan: {Light | Standard | Full}
 
-## 成果物一覧
-| ファイル | 内容 | 状態 |
+## Artifact List
+| File | Contents | Status |
 |---------|------|------|
-| Dockerfile | コンテナ定義 | あり/なし |
-| docker-compose.yml | コンテナ構成 | あり/なし |
-| .github/workflows/ci.yml | CI/CD | あり/なし |
-| .env.example | 環境変数テンプレート | あり/なし |
-| DB_OPS.md | DB運用ガイド | あり/なし |
-| OBSERVABILITY.md | 可観測性設計 | あり/なし |
-| OPS_PLAN.md | 運用計画書 | あり |
+| Dockerfile | Container definition | present/absent |
+| docker-compose.yml | Container configuration | present/absent |
+| .github/workflows/ci.yml | CI/CD | present/absent |
+| .env.example | Environment variable template | present/absent |
+| DB_OPS.md | DB operations guide | present/absent |
+| OBSERVABILITY.md | Observability design | present/absent |
+| OPS_PLAN.md | Operations plan | present |
 
-## デプロイ準備状態
-- [ ] Dockerfile / docker-compose 作成済み
-- [ ] CI/CD パイプライン構築済み
-- [ ] 環境変数テンプレート作成済み
-- [ ] DB運用ガイド作成済み（該当する場合）
-- [ ] 可観測性設計完了（該当する場合）
-- [ ] デプロイ手順書作成済み
-- [ ] ロールバック手順策定済み
-- [ ] インシデント対応プレイブック作成済み
+## Deploy Readiness
+- [ ] Dockerfile / docker-compose created
+- [ ] CI/CD pipeline built
+- [ ] Environment variable template created
+- [ ] DB operations guide created (if applicable)
+- [ ] Observability design complete (if applicable)
+- [ ] Deploy procedure document created
+- [ ] Rollback procedure defined
+- [ ] Incident response playbook created
 
-## 未対応事項
-{残タスクがあれば記載}
+## Outstanding Items
+{list any remaining tasks}
 ```
 
 ---

--- a/.claude/agents/poc-engineer.md
+++ b/.claude/agents/poc-engineer.md
@@ -124,78 +124,78 @@ When a requirement is determined infeasible, provide alternatives whenever possi
 ## Output File: `POC_RESULT.md`
 
 ```markdown
-# PoC Result: {プロジェクト名}
+# PoC Result: {Project Name}
 
-> 参照元: INTERVIEW_RESULT.md, RESEARCH_RESULT.md
-> 実施日: {YYYY-MM-DD}
-> 更新履歴:
->   - {YYYY-MM-DD}: 初回作成
+> Source: INTERVIEW_RESULT.md, RESEARCH_RESULT.md
+> Conducted: {YYYY-MM-DD}
+> Update history:
+>   - {YYYY-MM-DD}: Initial creation
 
-## PoC概要
-{何を検証したか、1〜3行の要約}
+## PoC Overview
+{1–3 line summary of what was verified}
 
-## 検証項目と結果
+## Verification Items and Results
 
-| # | 検証項目 | 結果 | 備考 |
+| # | Verification Item | Result | Notes |
 |---|---|---|---|
-| 1 | {検証項目} | ✅ 成功 / ❌ 失敗 / ⚠️ 条件付き | {詳細・制約} |
+| 1 | {verification item} | ✅ Pass / ❌ Fail / ⚠️ Conditional | {details / constraints} |
 
-### 検証詳細
+### Verification Details
 
-#### 検証 1: {検証項目名}
-- **目的:** {何を確認するか}
-- **手法:** {どのように検証したか}
-- **結果:** {✅ 成功 / ❌ 失敗 / ⚠️ 条件付き}
-- **詳細:** {具体的な結果・数値・ログ等}
-- **所見:** {この結果から言えること}
+#### Verification 1: {verification item name}
+- **Purpose:** {what is being confirmed}
+- **Method:** {how it was verified}
+- **Result:** {✅ Pass / ❌ Fail / ⚠️ Conditional}
+- **Details:** {specific results, numbers, logs, etc.}
+- **Findings:** {what can be concluded from this result}
 
-## 既存システム分析（該当する場合）
+## Existing System Analysis (if applicable)
 
-### コードベース概要
-- 言語・フレームワーク: {特定結果}
-- ファイル数: {概算}
-- ディレクトリ構造: {主要な構造}
+### Codebase Overview
+- Language / framework: {identified result}
+- File count: {estimate}
+- Directory structure: {key structure}
 
-### 技術的負債
-| 項目 | 深刻度 | 影響 |
+### Technical Debt
+| Item | Severity | Impact |
 |---|---|---|
-| {負債の内容} | 高/中/低 | {プロジェクトへの影響} |
+| {debt description} | high/medium/low | {impact on the project} |
 
-### 統合ポイント
-| 統合箇所 | 既存コード | 新規機能 | 難易度 |
+### Integration Points
+| Integration point | Existing code | New feature | Difficulty |
 |---|---|---|---|
-| {統合ポイント} | {既存側のファイル/モジュール} | {新規側の機能} | 高/中/低 |
+| {integration point} | {existing file/module} | {new feature} | high/medium/low |
 
-## データ戦略評価（該当する場合）
+## Data Strategy Evaluation (if applicable)
 
-### データ量の推定
-{初期データ量・成長率の概算}
+### Data Volume Estimation
+{Estimate of initial data volume and growth rate}
 
-### 移行要件
-{既存データの移行が必要な場合の計画}
+### Migration Requirements
+{Plan if existing data migration is needed}
 
-### 統合要件
-{外部データソースとの連携が必要な場合の方針}
+### Integration Requirements
+{Approach if integration with external data sources is needed}
 
-## PoCコード
-| ファイル | 概要 | 検証項目 |
+## PoC Code
+| File | Description | Verification item |
 |---|---|---|
-| poc/{ファイル名} | {概要} | 検証 {N} |
+| poc/{filename} | {description} | Verification {N} |
 
-## 技術的な制約・発見事項
-- {PoC を通じて発見した制約や注意点}
+## Technical Constraints / Findings
+- {constraints and caveats discovered through PoC}
 
-## 実現不可能な要件（該当する場合）
-| 要件 | 理由 | 代替案 |
+## Infeasible Requirements (if any)
+| Requirement | Reason | Alternative |
 |---|---|---|
-| {要件名} | {なぜ実現不可能か} | {代替案の提案} |
+| {requirement name} | {why it is infeasible} | {proposed alternative} |
 
-{interviewer への差し戻し理由を明記}
+{Clearly state the reason for rollback to interviewer}
 
-## 推奨技術スタック（初期提案）
-| 層 | 技術 | 選定理由 |
+## Recommended Tech Stack (Initial Proposal)
+| Layer | Technology | Selection Rationale |
 |---|---|---|
-| {バックエンド/フロントエンド/DB等} | {技術名} | {PoC結果に基づく理由} |
+| {backend/frontend/DB, etc.} | {technology name} | {rationale based on PoC results} |
 ```
 
 ---

--- a/.claude/agents/releaser.md
+++ b/.claude/agents/releaser.md
@@ -132,11 +132,11 @@ go build -o dist/ ./...
 ```bash
 # Commit version updates
 git add {updated files}
-git commit -m "chore: リリース v{バージョン}
+git commit -m "chore: release v{version}
 
-- バージョンを {バージョン} に更新
-- CHANGELOG.md を更新
-- リリースノートを作成"
+- update version to {version}
+- update CHANGELOG.md
+- create release notes"
 
 # Create tag
 git tag -a v{version} -m "Release v{version}"
@@ -157,30 +157,30 @@ If gh CLI is not available, skip and provide manual creation instructions.
 ## Output File: `RELEASE_NOTES.md`
 
 ```markdown
-# Release v{バージョン}
+# Release v{version}
 
-> リリース日: {YYYY-MM-DD}
+> Release date: {YYYY-MM-DD}
 
-## ハイライト
-{このリリースの主要な変更を1〜3行で要約}
+## Highlights
+{1-3 line summary of the major changes in this release}
 
-## 新機能
-- {feat: コミットから抽出}
+## New Features
+- {extract from feat: commits}
 
-## バグ修正
-- {fix: コミットから抽出}
+## Bug Fixes
+- {extract from fix: commits}
 
-## その他の変更
-- {refactor:, docs:, chore: コミットから抽出}
+## Other Changes
+- {extract from refactor:, docs:, chore: commits}
 
-## 破壊的変更（該当する場合）
-- {互換性のない変更の詳細}
+## Breaking Changes (if applicable)
+- {details of incompatible changes}
 
-## アップグレード手順（該当する場合）
-{前バージョンからのアップグレード方法}
+## Upgrade Instructions (if applicable)
+{how to upgrade from the previous version}
 
-## コントリビューター
-{コミットログから抽出}
+## Contributors
+{extracted from commit log}
 ```
 
 ---

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -112,61 +112,61 @@ When rolled back from `scope-planner` due to insufficient information:
 ## Output File: `RESEARCH_RESULT.md`
 
 ```markdown
-# Research Result: {プロジェクト名}
+# Research Result: {Project Name}
 
-> 参照元: INTERVIEW_RESULT.md
-> 調査日: {YYYY-MM-DD}
-> 更新履歴:
->   - {YYYY-MM-DD}: 初回作成
+> Source: INTERVIEW_RESULT.md
+> Research date: {YYYY-MM-DD}
+> Update history:
+>   - {YYYY-MM-DD}: Initial creation
 
-## ドメイン調査
+## Domain Research
 
-### 業界標準・ベストプラクティス
-{このドメインで一般的に採用されている標準・手法}
+### Industry Standards / Best Practices
+{Standards and methods commonly adopted in this domain}
 
-### 規制・コンプライアンス要件（該当する場合）
-{法規制・業界規制・認証要件等}
+### Regulatory / Compliance Requirements (if applicable)
+{Laws, industry regulations, certification requirements, etc.}
 
-## 競合・類似サービス分析
+## Competitive / Similar Service Analysis
 
-| サービス | 特徴 | 強み | 弱み | 参考URL |
+| Service | Description | Strengths | Weaknesses | Reference URL |
 |---|---|---|---|---|
-| {サービス名} | {概要} | {強み} | {弱み} | {URL} |
+| {service name} | {overview} | {strengths} | {weaknesses} | {URL} |
 
-### 差別化ポイント
-{本プロジェクトが競合に対して差別化できる点}
+### Differentiation Points
+{Areas where this project can differentiate from competitors}
 
-## 外部依存の調査
+## External Dependency Investigation
 
-### API・サービス
-| API/サービス | 用途 | 料金体系 | 制約 | 代替案 |
+### APIs / Services
+| API/Service | Purpose | Pricing | Constraints | Alternatives |
 |---|---|---|---|---|
-| {API名} | {何に使うか} | {無料枠/従量課金等} | {レート制限等} | {代替候補} |
+| {API name} | {what it is used for} | {free tier/pay-as-you-go, etc.} | {rate limits, etc.} | {alternative candidates} |
 
-### ライブラリ・フレームワーク
-| ライブラリ | 用途 | ライセンス | メンテナンス状況 | 備考 |
+### Libraries / Frameworks
+| Library | Purpose | License | Maintenance Status | Notes |
 |---|---|---|---|---|
-| {ライブラリ名} | {何に使うか} | {MIT/Apache等} | {アクティブ/メンテナンスモード等} | {注意点} |
+| {library name} | {what it is used for} | {MIT/Apache, etc.} | {active/maintenance mode, etc.} | {caveats} |
 
-## ユビキタス言語（ドメイン用語集）
-| 用語 | 定義 | 備考 |
+## Ubiquitous Language (Domain Glossary)
+| Term | Definition | Notes |
 |---|---|---|
-| {ドメイン用語} | {プロジェクト内での定義} | {注意点・別名等} |
+| {domain term} | {definition within the project} | {caveats, aliases, etc.} |
 
-## 技術的リスク
-| リスク | 影響度 | 発生確率 | 対策案 |
+## Technical Risks
+| Risk | Impact | Probability | Mitigation |
 |---|---|---|---|
-| {リスク名} | 高/中/低 | 高/中/低 | {具体的な対策} |
+| {risk name} | high/medium/low | high/medium/low | {specific countermeasure} |
 
-## 推奨事項
-{調査結果に基づく推奨事項を箇条書きで記載}
-- {推奨事項1}
-- {推奨事項2}
+## Recommendations
+{Recommendations based on research findings}
+- {recommendation 1}
+- {recommendation 2}
 
-## 出典・参考資料
-| # | タイトル | URL | 取得日 |
+## Sources / References
+| # | Title | URL | Retrieved |
 |---|---|---|---|
-| 1 | {資料タイトル} | {URL} | {YYYY-MM-DD} |
+| 1 | {document title} | {URL} | {YYYY-MM-DD} |
 ```
 
 ---

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -96,67 +96,67 @@ and generate a quality report. **You do not modify code; you focus solely on pre
 ## Review Report Format
 
 ```
-## コードレビューレポート
+## Code Review Report
 
-### 対象コミット / ブランチ
-{git log --oneline -5 の出力}
+### Target Commit / Branch
+{output of git log --oneline -5}
 
-### 総合評価
-{✅ 承認 / ⚠️ 条件付き承認 / ❌ 要修正}
-
----
-
-### 🔴 CRITICAL（必須修正）
-データ損失リスク・仕様の重大な欠落・API契約違反
-
-#### [CR-001] {指摘タイトル}
-- **ファイル:** `{パス}:{行番号}`
-- **観点:** {仕様適合/設計整合/コード品質/テスト品質/API契約}
-- **問題:** {何が問題か}
-- **根拠:** SPEC.md UC-XXX / ARCHITECTURE.md セクション X
-- **修正方針:** {どう直すべきか}
+### Overall Assessment
+{✅ Approved / ⚠️ Conditionally approved / ❌ Fix required}
 
 ---
 
-### 🟡 WARNING（推奨修正）
-コード品質・保守性・テスト不足
+### 🔴 CRITICAL (must fix)
+Data loss risk / critical spec gaps / API contract violations
 
-#### [WR-001] {指摘タイトル}
-- **ファイル:** `{パス}:{行番号}`
-- **観点:** {観点}
-- **問題:** {何が問題か}
-- **修正方針:** {どう改善できるか}
-
----
-
-### 🟢 SUGGESTION（任意改善）
-より良くできる点・リファクタリング提案
-
-#### [SG-001] {指摘タイトル}
-- **ファイル:** `{パス}:{行番号}`
-- **提案:** {どう改善できるか}
+#### [CR-001] {Finding title}
+- **File:** `{path}:{line number}`
+- **Perspective:** {spec compliance / design consistency / code quality / test quality / API contract}
+- **Issue:** {what the problem is}
+- **Basis:** SPEC.md UC-XXX / ARCHITECTURE.md Section X
+- **Remediation:** {how it should be fixed}
 
 ---
 
-### 仕様適合チェック
-| UC番号 | 機能 | 実装 | 備考 |
+### 🟡 WARNING (recommended fix)
+Code quality / maintainability / insufficient test coverage
+
+#### [WR-001] {Finding title}
+- **File:** `{path}:{line number}`
+- **Perspective:** {perspective}
+- **Issue:** {what the problem is}
+- **Remediation:** {how it can be improved}
+
+---
+
+### 🟢 SUGGESTION (optional improvement)
+Areas that could be improved / refactoring proposals
+
+#### [SG-001] {Finding title}
+- **File:** `{path}:{line number}`
+- **Proposal:** {how it can be improved}
+
+---
+
+### Spec Compliance Check
+| UC No. | Feature | Implemented | Notes |
 |--------|------|------|------|
-| UC-001 | {機能名} | ✅/❌ | |
+| UC-001 | {feature name} | ✅/❌ | |
 
-### 設計整合チェック
-| 項目 | 状態 | 備考 |
+### Design Consistency Check
+| Item | Status | Notes |
 |------|------|------|
-| ディレクトリ構造 | ✅/⚠️/❌ | |
-| 命名規則 | ✅/⚠️/❌ | |
-| データモデル | ✅/⚠️/❌ | |
-| API契約 | ✅/⚠️/❌ | |
+| Directory structure | ✅/⚠️/❌ | |
+| Naming conventions | ✅/⚠️/❌ | |
+| Data model | ✅/⚠️/❌ | |
+| API contract | ✅/⚠️/❌ | |
 
 ---
 
-### 次のステップ
-→ CRITICAL がある場合: `developer` で修正 → `tester` → `reviewer` の順に再実行
-→ WARNING のみの場合: 修正推奨。対応後に `reviewer` を再実行
-→ SUGGESTION のみ / 指摘なし: ✅ 承認
+### Next Steps
+→ If CRITICAL exists: fix with `developer` → re-run in order: `tester` → `reviewer`
+→ If WARNING only: fix recommended; re-run `reviewer` after addressing
+→ SUGGESTION only / no findings: ✅ Approved
 ```
 
 ---

--- a/.claude/agents/rules-designer.md
+++ b/.claude/agents/rules-designer.md
@@ -71,24 +71,24 @@ Ask only what cannot be inferred from artifacts. Skip questions where the answer
 {
   "questions": [
     {
-      "question": "メインの開発言語はどれですか？",
-      "header": "言語",
+      "question": "What is the main development language?",
+      "header": "Language",
       "options": [
-        {"label": "Python", "description": "FastAPI / Django / Flask 等"},
-        {"label": "TypeScript", "description": "Next.js / Express / Hono 等"},
-        {"label": "Go", "description": "標準ライブラリ / Echo / Gin 等"},
-        {"label": "Rust", "description": "Actix / Axum 等"}
+        {"label": "Python", "description": "FastAPI / Django / Flask, etc."},
+        {"label": "TypeScript", "description": "Next.js / Express / Hono, etc."},
+        {"label": "Go", "description": "Standard library / Echo / Gin, etc."},
+        {"label": "Rust", "description": "Actix / Axum, etc."}
       ],
       "multiSelect": false
     },
     {
-      "question": "パッケージマネージャーはどれを使用しますか？",
-      "header": "パッケージ管理",
+      "question": "Which package manager will you use?",
+      "header": "Package management",
       "options": [
-        {"label": "uv (推奨)", "description": "Python: 高速なパッケージマネージャー"},
-        {"label": "pip", "description": "Python: 標準パッケージマネージャー"},
-        {"label": "npm", "description": "Node.js: 標準パッケージマネージャー"},
-        {"label": "pnpm", "description": "Node.js: 高速・省ディスクなパッケージマネージャー"}
+        {"label": "uv (recommended)", "description": "Python: fast package manager"},
+        {"label": "pip", "description": "Python: standard package manager"},
+        {"label": "npm", "description": "Node.js: standard package manager"},
+        {"label": "pnpm", "description": "Node.js: fast, disk-efficient package manager"}
       ],
       "multiSelect": false
     }
@@ -105,31 +105,31 @@ Adjust package manager options based on the selected language.
 {
   "questions": [
     {
-      "question": "コードコメントの言語はどちらにしますか？",
-      "header": "コメント言語",
+      "question": "What language should code comments be written in?",
+      "header": "Comment language",
       "options": [
-        {"label": "日本語 (推奨)", "description": "コメント・ドキュメントを日本語で記述"},
-        {"label": "英語", "description": "コメント・ドキュメントを英語で記述"}
+        {"label": "Japanese (recommended)", "description": "Write comments and documentation in Japanese"},
+        {"label": "English", "description": "Write comments and documentation in English"}
       ],
       "multiSelect": false
     },
     {
-      "question": "型アノテーション（型注釈）のポリシーはどうしますか？",
-      "header": "型注釈",
+      "question": "What is the type annotation policy?",
+      "header": "Type annotations",
       "options": [
-        {"label": "厳密 (推奨)", "description": "全ての関数引数・戻り値に型を付与"},
-        {"label": "緩め", "description": "公開APIのみ型を付与"},
-        {"label": "なし", "description": "型注釈は使用しない"}
+        {"label": "Strict (recommended)", "description": "Add types to all function arguments and return values"},
+        {"label": "Relaxed", "description": "Add types to public APIs only"},
+        {"label": "None", "description": "Do not use type annotations"}
       ],
       "multiSelect": false
     },
     {
-      "question": "1ファイルあたりの推奨最大行数は？",
-      "header": "ファイルサイズ",
+      "question": "What is the recommended maximum line count per file?",
+      "header": "File size",
       "options": [
-        {"label": "300行 (推奨)", "description": "超えたら分割を検討"},
-        {"label": "500行", "description": "大きめのファイルも許容"},
-        {"label": "制限なし", "description": "行数制限を設けない"}
+        {"label": "300 lines (recommended)", "description": "Consider splitting if exceeded"},
+        {"label": "500 lines", "description": "Larger files are acceptable"},
+        {"label": "No limit", "description": "Do not impose a line count limit"}
       ],
       "multiSelect": false
     }
@@ -143,22 +143,22 @@ Adjust package manager options based on the selected language.
 {
   "questions": [
     {
-      "question": "コミットメッセージの形式はどうしますか？",
-      "header": "コミット形式",
+      "question": "What format should commit messages follow?",
+      "header": "Commit format",
       "options": [
-        {"label": "Conventional Commits (推奨)", "description": "feat: / fix: / refactor: 等のプレフィックス付き"},
-        {"label": "自由形式", "description": "特にルールを設けない"},
-        {"label": "カスタム", "description": "独自のルールを指定する"}
+        {"label": "Conventional Commits (recommended)", "description": "Prefixes like feat: / fix: / refactor:, etc."},
+        {"label": "Free-form", "description": "No specific rules"},
+        {"label": "Custom", "description": "Specify a custom rule"}
       ],
       "multiSelect": false
     },
     {
-      "question": "ブランチ戦略はどうしますか？",
-      "header": "ブランチ戦略",
+      "question": "What branching strategy will you use?",
+      "header": "Branch strategy",
       "options": [
-        {"label": "GitHub Flow (推奨)", "description": "main + feature ブランチのシンプルな構成"},
+        {"label": "GitHub Flow (recommended)", "description": "Simple setup: main + feature branches"},
         {"label": "Git Flow", "description": "main / develop / feature / release / hotfix"},
-        {"label": "Trunk-based", "description": "main に直接コミット（短命ブランチあり）"}
+        {"label": "Trunk-based", "description": "Commit directly to main (with short-lived branches)"}
       ],
       "multiSelect": false
     }
@@ -172,11 +172,11 @@ Adjust package manager options based on the selected language.
 {
   "questions": [
     {
-      "question": "このプロジェクト固有のルールや制約はありますか？",
-      "header": "追加ルール",
+      "question": "Are there any project-specific rules or constraints?",
+      "header": "Additional rules",
       "options": [
-        {"label": "特になし", "description": "上記の設定で十分"},
-        {"label": "あり", "description": "追加のルールを指定する"}
+        {"label": "None in particular", "description": "The settings above are sufficient"},
+        {"label": "Yes", "description": "Specify additional rules"}
       ],
       "multiSelect": false
     }
@@ -184,7 +184,7 @@ Adjust package manager options based on the selected language.
 }
 ```
 
-If the user selects "あり", ask for details via text output and incorporate them.
+If the user selects "Yes", ask for details via text output and incorporate them.
 
 **Round 5: Agent Behavior Policies (2 questions, presented in parallel)**
 
@@ -192,20 +192,20 @@ If the user selects "あり", ask for details via text output and incorporate th
 {
   "questions": [
     {
-      "question": "エージェント出力の既定言語はどれにしますか？",
-      "header": "出力言語",
+      "question": "What should be the default output language for agents?",
+      "header": "Output language",
       "options": [
         {"label": "English (recommended)", "description": "Default. AskUserQuestion / approval gates / progress / reports are in English"},
-        {"label": "Japanese", "description": "日本語で出力する。既存 Aphelion 本体もこちら"}
+        {"label": "Japanese", "description": "Output in Japanese. The Aphelion core itself uses this setting"}
       ],
       "multiSelect": false
     },
     {
-      "question": "コミットに Co-Authored-By: Claude を付与しますか？",
+      "question": "Should commits include Co-Authored-By: Claude?",
       "header": "Co-Author",
       "options": [
-        {"label": "付与する (recommended)", "description": "Claude の関与を co-author として明示。OSS 標準慣行に準拠"},
-        {"label": "付与しない", "description": "プロジェクトポリシーで co-author が禁止されている場合など"}
+        {"label": "Yes (recommended)", "description": "Explicitly attribute Claude's involvement as co-author. Follows OSS standard practice"},
+        {"label": "No", "description": "For projects where co-author attribution is prohibited by policy"}
       ],
       "multiSelect": false
     }
@@ -226,19 +226,19 @@ Output a summary of the generated rules as text, then request approval:
 ```json
 {
   "questions": [{
-    "question": "上記のプロジェクトルール（project-rules.md）で問題ありませんか？",
-    "header": "ルール確認",
+    "question": "Are the project rules (project-rules.md) above acceptable?",
+    "header": "Rule confirmation",
     "options": [
-      {"label": "承認", "description": "このルールで確定する"},
-      {"label": "修正を指示", "description": "一部のルールを変更する"},
-      {"label": "最初からやり直し", "description": "ルール決定をやり直す"}
+      {"label": "Approve", "description": "Confirm with these rules"},
+      {"label": "Request modification", "description": "Change some of the rules"},
+      {"label": "Start over", "description": "Redo the rule determination"}
     ],
     "multiSelect": false
   }]
 }
 ```
 
-If "修正を指示" is selected, apply the changes and re-present.
+If "Request modification" is selected, apply the changes and re-present.
 
 ---
 
@@ -247,89 +247,89 @@ If "修正を指示" is selected, apply the changes and re-present.
 Adapt the template below based on the determined language/framework. Omit sections that are not applicable.
 
 ```markdown
-# Project Rules — {プロジェクト名}
+# Project Rules — {Project Name}
 
-> 作成日: {YYYY-MM-DD}
+> Created: {YYYY-MM-DD}
 
-## プロジェクト概要
+## Project Overview
 
-{INTERVIEW_RESULT.md から1〜3行の要約}
+{1–3 line summary from INTERVIEW_RESULT.md}
 
-## 技術スタック
+## Tech Stack
 
-- 言語: {language} {version}
-- フレームワーク: {framework}
-- パッケージマネージャー: {manager}
-- リンター: {linter}
-- フォーマッター: {formatter}
-- テストフレームワーク: {test framework}
+- Language: {language} {version}
+- Framework: {framework}
+- Package manager: {manager}
+- Linter: {linter}
+- Formatter: {formatter}
+- Test framework: {test framework}
 
-## コーディング規約
+## Coding Conventions
 
-### 命名規則
+### Naming Rules
 
-| 対象 | 規則 | 例 |
+| Target | Rule | Example |
 |------|------|-----|
-| 変数・関数 | {snake_case / camelCase} | {example} |
-| クラス・型 | PascalCase | {example} |
-| 定数 | UPPER_SNAKE_CASE | {example} |
-| ファイル名 | {kebab-case / snake_case} | {example} |
+| Variables / functions | {snake_case / camelCase} | {example} |
+| Classes / types | PascalCase | {example} |
+| Constants | UPPER_SNAKE_CASE | {example} |
+| File names | {kebab-case / snake_case} | {example} |
 
-### コードスタイル
+### Code Style
 
-- インデント: {スペース / タブ}, サイズ: {2 / 4}
-- 最大行長: {80 / 120}
-- コメント言語: {日本語 / 英語}
-- 型注釈: {厳密 / 緩め / なし}
-- 1ファイル推奨最大行数: {300 / 500 / 制限なし}
+- Indent: {spaces / tabs}, size: {2 / 4}
+- Max line length: {80 / 120}
+- Comment language: {Japanese / English}
+- Type annotations: {strict / relaxed / none}
+- Recommended max lines per file: {300 / 500 / no limit}
 
-### {言語}固有のルール
+### {Language}-specific Rules
 
-{言語・フレームワーク固有の規約をここに記載}
+{Language and framework specific conventions go here}
 
-## Git ルール
+## Git Rules
 
-### コミットメッセージ
+### Commit Messages
 
-{Conventional Commits の場合:}
+{For Conventional Commits:}
 ```
-{prefix}: {概要}
+{prefix}: {summary}
 
-- {詳細（箇条書き）}
+- {details (bullet points)}
 ```
 
-| prefix | 用途 |
+| prefix | Usage |
 |--------|------|
-| `feat:` | 新機能 |
-| `fix:` | バグ修正 |
-| `refactor:` | リファクタリング |
-| `test:` | テスト |
-| `docs:` | ドキュメント |
-| `chore:` | 設定・環境 |
+| `feat:` | New feature |
+| `fix:` | Bug fix |
+| `refactor:` | Refactoring |
+| `test:` | Tests |
+| `docs:` | Documentation |
+| `chore:` | Configuration / environment |
 
-### ブランチ戦略
+### Branch Strategy
 
-{選択されたブランチ戦略の説明}
+{Description of the selected branch strategy}
 
-### ステージング
+### Staging
 
-- `git add -A` は禁止（機密ファイルの混入防止）
-- `git add {対象ファイル}` で明示的にステージング
-- `.env`, `credentials.*`, `*.secret` 等はコミットしない
+- `git add -A` is prohibited (prevents accidental inclusion of sensitive files)
+- Stage explicitly with `git add {target files}`
+- Never commit `.env`, `credentials.*`, `*.secret`, etc.
 
-## ビルド・テストコマンド
+## Build / Test Commands
 
-| 操作 | コマンド |
+| Operation | Command |
 |------|---------|
-| ビルド / 型チェック | {command} |
-| リント | {command} |
-| フォーマット | {command} |
-| テスト | {command} |
+| Build / type check | {command} |
+| Lint | {command} |
+| Format | {command} |
+| Test | {command} |
 
-## ディレクトリ構成
+## Directory Structure
 
 ```
-{想定されるディレクトリ構成}
+{expected directory structure}
 ```
 
 ## Authoring
@@ -341,9 +341,9 @@ Adapt the template below based on the determined language/framework. Omit sectio
 - Output Language: {en | ja}
 - Fallback Language: en
 
-## プロジェクト固有のルール
+## Project-Specific Rules
 
-{ユーザーが指定した追加ルール。なければ「特になし」}
+{Additional rules specified by the user. If none, write "None in particular"}
 ```
 
 ### Language-Specific Defaults

--- a/.claude/agents/scaffolder.md
+++ b/.claude/agents/scaffolder.md
@@ -142,12 +142,12 @@ Run a build verification appropriate for the tech stack:
 
 ```bash
 git add {created files}
-git commit -m "chore: プロジェクト初期化 (scaffolder)
+git commit -m "chore: initialize project (scaffolder)
 
-- ディレクトリ構造の作成
-- 依存パッケージの定義・インストール
-- 設定ファイルの配置
-- エントリーポイントの作成"
+- create directory structure
+- define and install dependency packages
+- place configuration files
+- create entry point"
 ```
 
 ---

--- a/.claude/agents/scope-planner.md
+++ b/.claude/agents/scope-planner.md
@@ -102,12 +102,12 @@ If any item is unmet, explain the reason via text output and use `AskUserQuestio
 ```json
 {
   "questions": [{
-    "question": "ハンドオフ判定が NOT READY です。どう対応しますか？",
-    "header": "ハンドオフ",
+    "question": "The handoff assessment is NOT READY. How would you like to proceed?",
+    "header": "Handoff",
     "options": [
-      {"label": "Delivery へ進む", "description": "未達項目があるが、Delivery で対処する"},
-      {"label": "researcher に差し戻し", "description": "情報不足の項目を追加調査する"},
-      {"label": "中断", "description": "Discovery フローを停止する"}
+      {"label": "Proceed to Delivery", "description": "There are unmet items, but address them in Delivery"},
+      {"label": "Roll back to researcher", "description": "Conduct additional research on missing information"},
+      {"label": "Abort", "description": "Stop the Discovery flow"}
     ],
     "multiSelect": false
   }]
@@ -121,106 +121,106 @@ If any item is unmet, explain the reason via text output and use `AskUserQuestio
 ### `SCOPE_PLAN.md`
 
 ```markdown
-# Scope Plan: {プロジェクト名}
+# Scope Plan: {Project Name}
 
-> 参照元: {存在する前段成果物を列挙}
-> 作成日: {YYYY-MM-DD}
+> Source: {list preceding artifacts that exist}
+> Created: {YYYY-MM-DD}
 
-## 1. MVP定義
+## 1. MVP Definition
 
-### 最小スコープ
-{MVP に含める最小限の機能を箇条書き}
+### Minimum Scope
+{Minimum set of features included in the MVP}
 
-### MVP の提供価値
-{この MVP でユーザーが得られる価値}
+### Value Delivered by MVP
+{Value users gain from this MVP}
 
-## 2. 要件優先順位（MoSCoW）
+## 2. Requirements Prioritization (MoSCoW)
 
-| # | 要件 | 分類 | 理由 |
+| # | Requirement | Category | Rationale |
 |---|------|------|------|
-| 1 | {要件} | Must | {理由} |
-| 2 | {要件} | Should | {理由} |
-| 3 | {要件} | Could | {理由} |
-| 4 | {要件} | Won't | {理由} |
+| 1 | {requirement} | Must | {rationale} |
+| 2 | {requirement} | Should | {rationale} |
+| 3 | {requirement} | Could | {rationale} |
+| 4 | {requirement} | Won't | {rationale} |
 
-## 3. KPI・成功指標
+## 3. KPIs / Success Metrics
 
-| 指標 | 目標値 | 測定方法 | 備考 |
+| Metric | Target | Measurement Method | Notes |
 |------|--------|---------|------|
 
-## 4. リスク評価
+## 4. Risk Assessment
 
-| # | リスク | 影響度 | 発生確率 | 対策 | 出典 |
+| # | Risk | Impact | Probability | Mitigation | Source |
 |---|--------|--------|---------|------|------|
-| 1 | {リスク} | 高/中/低 | 高/中/低 | {対策} | {RESEARCH/POC等} |
+| 1 | {risk} | high/medium/low | high/medium/low | {mitigation} | {RESEARCH/POC, etc.} |
 
-## 5. コスト概算（工数ベース）
+## 5. Cost Estimate (Effort-Based)
 
-| フェーズ | 推定工数 | 備考 |
+| Phase | Estimated Effort | Notes |
 |---------|---------|------|
-| 仕様策定 | {時間} | |
-| 設計 | {時間} | |
-| 実装 | {時間} | |
-| テスト | {時間} | |
-| 合計 | {時間} | |
+| Spec definition | {hours} | |
+| Design | {hours} | |
+| Implementation | {hours} | |
+| Testing | {hours} | |
+| Total | {hours} | |
 
-※ 概算であり正確な見積もりではない
+* This is an estimate, not an exact quote
 
-## 6. ハンドオフ判定
+## 6. Handoff Assessment
 
-- [ ] 要件が十分に明確化されている
-- [ ] 技術リスクが許容範囲内である
-- [ ] スコープが合意されている
-- [ ] 未解決事項が Delivery で対処可能である
+- [ ] Requirements are sufficiently clarified
+- [ ] Technical risks are within acceptable range
+- [ ] Scope has been agreed upon
+- [ ] Unresolved items can be addressed in Delivery
 
-**判定: READY / NOT READY**
-{NOT READY の場合は理由と対策}
+**Assessment: READY / NOT READY**
+{If NOT READY, state the reason and countermeasures}
 
-## 7. 未解決事項
+## 7. Unresolved Items
 
-{Delivery で解決すべき残課題}
+{Remaining issues to be resolved in Delivery}
 ```
 
 ### `DISCOVERY_RESULT.md` (Final Handoff File)
 
 ```markdown
-# Discovery Result: {プロジェクト名}
+# Discovery Result: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> Discovery プラン: {Minimal | Light | Standard | Full}
+> Created: {YYYY-MM-DD}
+> Discovery Plan: {Minimal | Light | Standard | Full}
 
-## プロジェクト概要
-{1〜3行の要約}
+## Project Overview
+{1–3 line summary}
 
-## 成果物の性質
+## Artifact Type
 PRODUCT_TYPE: {service | tool | library | cli}
 
-## 要件サマリー
-### 機能要件（Must）
-{Must 要件の一覧}
+## Requirements Summary
+### Functional Requirements (Must)
+{List of Must requirements}
 
-### 非機能要件
-{主要な非機能要件}
+### Non-Functional Requirements
+{Key non-functional requirements}
 
-## スコープ
-- **MVP:** {最小スコープの概要}
-- **IN:** {含むもの}
-- **OUT:** {含まないもの}
+## Scope
+- **MVP:** {minimum scope summary}
+- **IN:** {included}
+- **OUT:** {excluded}
 
-## 技術リスク・制約
-{PoCの結果、外部依存の制約等。調査していない場合は「未調査」}
+## Technical Risks / Constraints
+{PoC results, external dependency constraints, etc. Write "Not investigated" if not researched}
 
-## Discovery 成果物一覧
-| ファイル | 内容 | 状態 |
+## Discovery Artifacts
+| File | Description | Status |
 |---------|------|------|
-| INTERVIEW_RESULT.md | 要件ヒアリング結果 | あり |
-| RESEARCH_RESULT.md | ドメイン調査結果 | あり/なし |
-| POC_RESULT.md | 技術PoC結果 | あり/なし |
-| CONCEPT_VALIDATION.md | コンセプト検証結果 | あり/なし |
-| SCOPE_PLAN.md | スコープ計画 | あり |
+| INTERVIEW_RESULT.md | Requirements interview results | present |
+| RESEARCH_RESULT.md | Domain research results | present/absent |
+| POC_RESULT.md | Technical PoC results | present/absent |
+| CONCEPT_VALIDATION.md | Concept validation results | present/absent |
+| SCOPE_PLAN.md | Scope plan | present |
 
-## 未解決事項
-{Delivery で解決すべき残課題}
+## Unresolved Items
+{Remaining issues to be resolved in Delivery}
 ```
 
 ---

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -153,74 +153,74 @@ Select and inspect CWE (Common Weakness Enumeration) items appropriate for the t
 ## Output File: `SECURITY_AUDIT.md`
 
 ```markdown
-# セキュリティ監査レポート: {プロジェクト名}
+# Security Audit Report: {Project Name}
 
-> 参照元: SPEC.md, ARCHITECTURE.md
-> 監査日: {YYYY-MM-DD}
-> 監査範囲: {ファイル数} ファイル
+> Source: SPEC.md, ARCHITECTURE.md
+> Audit date: {YYYY-MM-DD}
+> Audit scope: {file count} files
 
-## 総合評価
-{✅ 問題なし / ⚠️ 要対応あり / ❌ 重大な脆弱性あり}
-
----
-
-## 🔴 CRITICAL（即時修正必須）
-
-### [SEC-001] {脆弱性タイトル}
-- **カテゴリ:** OWASP {A0X} / CWE-{XXX}
-- **ファイル:** `{パス}:{行番号}`
-- **問題:** {脆弱性の説明}
-- **攻撃シナリオ:** {どのように悪用されるか}
-- **修正方針:** {具体的な修正方法}
-- **参考:** {OWASP/CWE のリンク等}
+## Overall Assessment
+{✅ No issues / ⚠️ Action required / ❌ Critical vulnerabilities found}
 
 ---
 
-## 🟡 WARNING（推奨修正）
+## 🔴 CRITICAL (immediate fix required)
 
-### [SEC-XXX] {指摘タイトル}
-- **カテゴリ:** {カテゴリ}
-- **ファイル:** `{パス}:{行番号}`
-- **問題:** {問題の説明}
-- **修正方針:** {修正方法}
-
----
-
-## 🟢 INFO（情報・推奨事項）
-
-### [SEC-XXX] {推奨事項}
-- **内容:** {説明}
+### [SEC-001] {Vulnerability title}
+- **Category:** OWASP {A0X} / CWE-{XXX}
+- **File:** `{path}:{line number}`
+- **Issue:** {description of the vulnerability}
+- **Attack scenario:** {how it can be exploited}
+- **Remediation:** {specific fix approach}
+- **Reference:** {OWASP/CWE link, etc.}
 
 ---
 
-## 監査チェックリスト
+## 🟡 WARNING (recommended fix)
+
+### [SEC-XXX] {Finding title}
+- **Category:** {category}
+- **File:** `{path}:{line number}`
+- **Issue:** {description of the issue}
+- **Remediation:** {fix approach}
+
+---
+
+## 🟢 INFO (informational / recommendations)
+
+### [SEC-XXX] {Recommendation}
+- **Detail:** {description}
+
+---
+
+## Audit Checklist
 
 ### OWASP Top 10
-| # | カテゴリ | 結果 | 備考 |
+| # | Category | Result | Notes |
 |---|---------|------|------|
 | A01 | Broken Access Control | ✅/⚠️/❌ | |
 | A02 | Cryptographic Failures | ✅/⚠️/❌ | |
 | ... | ... | ... | |
 
-### 依存パッケージ脆弱性
-- スキャンツール: {使用したツール}
-- 脆弱性件数: {件数}
-- 詳細: {ツール出力の要約}
+### Dependency Vulnerability Scanning
+- Scan tool: {tool used}
+- Vulnerability count: {count}
+- Details: {summary of tool output}
 
-### 認証・認可
-| エンドポイント | 認証 | 認可 | 備考 |
+### Authentication / Authorization
+| Endpoint | Authentication | Authorization | Notes |
 |---|---|---|---|
 
-### 機密情報ハードコード
-- 検出件数: {件数}
-- 検索対象外: .env, .env.example, テストフィクスチャ
+### Hardcoded Secrets
+- Detected count: {count}
+- Excluded from search: .env, .env.example, test fixtures
 
-### 入力値バリデーション
-| 入力箇所 | バリデーション | 備考 |
+### Input Validation
+| Input point | Validation | Notes |
 |---|---|---|
 
-### CWE チェック
-| CWE | 結果 | 備考 |
+### CWE Check
+| CWE | Result | Notes |
 |-----|------|------|
 ```
 

--- a/.claude/agents/spec-designer.md
+++ b/.claude/agents/spec-designer.md
@@ -94,53 +94,53 @@ Verify the following before starting work:
 ## Output File: `SPEC.md`
 
 ```markdown
-# 仕様書: {プロジェクト名}
+# Specification: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> 参照元: {DISCOVERY_RESULT.md の有無}
+> Created: {YYYY-MM-DD}
+> Source: {whether DISCOVERY_RESULT.md exists}
 
-## 1. プロジェクト概要
-- 目的・背景
-- スコープ（IN / OUT）
+## 1. Project Overview
+- Purpose / Background
+- Scope (IN / OUT)
 
-## 2. 推奨技術スタック
-| 層 | 技術 | 選定理由 |
+## 2. Recommended Tech Stack
+| Layer | Technology | Selection Rationale |
 |----|------|---------|
-> ※ architect にて確定・詳細化する
+> * To be finalized and detailed by architect
 
-## 3. ユーザーストーリー
-- ペルソナ定義
-- ユースケース一覧（番号付き）
+## 3. User Stories
+- Persona definitions
+- Use case list (numbered)
 
-## 4. 機能要件
-### UC-001: {ユースケース名}
-- 概要:
-- 事前条件:
-- 正常フロー:
-- 例外フロー:
-- 受け入れ条件:
+## 4. Functional Requirements
+### UC-001: {use case name}
+- Overview:
+- Preconditions:
+- Normal flow:
+- Exception flow:
+- Acceptance criteria:
 
-（ユースケース数分繰り返す）
+(Repeat for each use case)
 
-## 5. 非機能要件
-- パフォーマンス
-- セキュリティ
-- 可用性
-- スケーラビリティ
+## 5. Non-Functional Requirements
+- Performance
+- Security
+- Availability
+- Scalability
 
-## 6. データモデル（概念レベル）
-- エンティティ一覧
-- 主要な関係性
+## 6. Data Model (Conceptual Level)
+- Entity list
+- Key relationships
 
-## 7. API概要（該当する場合）
-- エンドポイント一覧
-- 主要なリクエスト/レスポンス形式
+## 7. API Overview (if applicable)
+- Endpoint list
+- Key request/response formats
 
-## 8. 制約・前提条件
+## 8. Constraints / Preconditions
 
-## 9. 用語集
+## 9. Glossary
 
-## 10. 未解決事項（TBD）
+## 10. Unresolved Items (TBD)
 ```
 
 ---

--- a/.claude/agents/test-designer.md
+++ b/.claude/agents/test-designer.md
@@ -92,84 +92,84 @@ Step 4. Design test cases
 ## Output File: `TEST_PLAN.md`
 
 ```markdown
-# テスト計画書: {プロジェクト名}
+# Test Plan: {Project Name}
 
-> 参照元: SPEC.md ({バージョン or 最終更新日})
-> 参照元: ARCHITECTURE.md ({バージョン or 最終更新日})
-> 作成日: {日付}
+> Source: SPEC.md ({version or last updated date})
+> Source: ARCHITECTURE.md ({version or last updated date})
+> Created: {date}
 
-## 1. テスト方針
+## 1. Test Policy
 
-### テスト戦略
-- テストフレームワーク: {ARCHITECTURE.md のテスト戦略から引用}
-- カバレッジ目標: {目標値}
-- テスト環境: {開発DB / モック / テストサーバー等}
+### Test Strategy
+- Test framework: {quoted from ARCHITECTURE.md test strategy}
+- Coverage target: {target value}
+- Test environment: {development DB / mocks / test server, etc.}
 
-### テスト依存パッケージ
-| パッケージ | 用途 | 備考 |
+### Test Dependency Packages
+| Package | Purpose | Notes |
 |-----------|------|------|
-| {パッケージ名} | {テストフレームワーク等} | {バージョン指定等} |
+| {package name} | {test framework, etc.} | {version specification, etc.} |
 
-## 2. テストケース一覧
+## 2. Test Case List
 
-### UC-001: {ユースケース名}
+### UC-001: {use case name}
 
-#### 正常系
+#### Normal Cases
 
-| TC番号 | テストケース名 | 種別 | 入力 | 期待値 | 対象ファイル |
+| TC No. | Test Case Name | Type | Input | Expected | Target File |
 |--------|-------------|------|------|--------|------------|
-| TC-001 | {テストケース名} | 単体/統合/E2E | {入力データ} | {期待する出力・状態} | {src/xxx.py} |
+| TC-001 | {test case name} | unit/integration/E2E | {input data} | {expected output/state} | {src/xxx.py} |
 
-#### 異常系・境界値
+#### Error Cases / Boundary Values
 
-| TC番号 | テストケース名 | 種別 | 入力 | 期待値 | 対象ファイル |
+| TC No. | Test Case Name | Type | Input | Expected | Target File |
 |--------|-------------|------|------|--------|------------|
-| TC-002 | {テストケース名} | 単体/統合/E2E | {異常入力} | {期待するエラー・挙動} | {src/xxx.py} |
+| TC-002 | {test case name} | unit/integration/E2E | {invalid input} | {expected error/behavior} | {src/xxx.py} |
 
-（ユースケース数分繰り返す）
+(Repeat for each use case)
 
-### 非機能要件テスト（該当する場合）
+### Non-Functional Requirement Tests (if applicable)
 
-| TC番号 | テストケース名 | 種別 | 条件 | 基準値 | 対象 |
+| TC No. | Test Case Name | Type | Condition | Threshold | Scope |
 |--------|-------------|------|------|--------|------|
-| TC-NF-001 | {テストケース名} | パフォーマンス/セキュリティ | {条件} | {基準} | {対象} |
+| TC-NF-001 | {test case name} | performance/security | {condition} | {threshold} | {scope} |
 
-## 3. テストファイル構成
+## 3. Test File Structure
 
 ```
-{ARCHITECTURE.md のテスト戦略に基づく配置}
+{Layout based on test strategy in ARCHITECTURE.md}
 tests/
-├── conftest.py          # 共通フィクスチャ
-├── test_xxx/            # テスト対象ごとのディレクトリ
-│   ├── test_yyy.py      # テストファイル
+├── conftest.py          # shared fixtures
+├── test_xxx/            # directory per test target
+│   ├── test_yyy.py      # test file
 ...
 ```
 
-## 4. テストデータ
+## 4. Test Data
 
-### フィクスチャ・テストデータ
-| データ名 | 内容 | 使用テスト |
+### Fixtures / Test Data
+| Name | Description | Used In |
 |---------|------|----------|
-| {フィクスチャ名} | {データの概要} | TC-XXX, TC-YYY |
+| {fixture name} | {data summary} | TC-XXX, TC-YYY |
 
-## 5. 実行手順
+## 5. Execution Procedure
 
-### テスト実行コマンド
+### Test Execution Commands
 ```bash
-{全テスト実行コマンド}
-{カバレッジ付き実行コマンド}
-{特定テスト実行コマンド}
+{command to run all tests}
+{command to run with coverage}
+{command to run specific tests}
 ```
 
-### 実行順序の制約
-{テスト間の依存関係がある場合に記述}
+### Execution Order Constraints
+{Document if there are dependencies between tests}
 
-## 6. UC-テストケース トレーサビリティマトリクス
+## 6. UC-Test Case Traceability Matrix
 
-| UC番号 | 受け入れ条件 | テストケース | 種別 |
+| UC No. | Acceptance Criterion | Test Cases | Type |
 |--------|------------|------------|------|
-| UC-001 | {条件1} | TC-001, TC-002 | 単体, 統合 |
-| UC-001 | {条件2} | TC-003 | 統合 |
+| UC-001 | {criterion 1} | TC-001, TC-002 | unit, integration |
+| UC-001 | {criterion 2} | TC-003 | integration |
 ```
 
 ---
@@ -210,20 +210,20 @@ When `tester` reports test failures, test-designer performs root cause analysis 
 ### Correction Feedback Format
 
 ```
-## テスト失敗分析レポート（developer 向け）
+## Test Failure Analysis Report (for developer)
 
-### 原因分類
-{テストコードバグ / テスト環境 / 実装バグ / 仕様不備}
+### Root Cause Classification
+{test code bug / test environment / implementation bug / spec deficiency}
 
-### 失敗テスト: {テストケース名} (TC-XXX)
-- **対応UC:** UC-XXX
-- **テストファイル:** {パス}
-- **対象コード:** {テスト対象のファイルパス}:{行番号}
-- **期待値:** {expected}
-- **実際の値:** {actual}
-- **原因分析:** {なぜ失敗したかの詳細分析}
-- **修正方針:** {具体的にどう修正すべきか}
-- **影響範囲:** {修正による他テストへの影響}
+### Failed Test: {test case name} (TC-XXX)
+- **Corresponding UC:** UC-XXX
+- **Test file:** {path}
+- **Target code:** {target file path}:{line number}
+- **Expected:** {expected}
+- **Actual:** {actual}
+- **Root cause analysis:** {detailed analysis of why it failed}
+- **Fix approach:** {specifically how it should be fixed}
+- **Impact scope:** {impact of the fix on other tests}
 ```
 
 ---

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -104,7 +104,7 @@ def browser_context_args():
 from playwright.sync_api import Page, expect
 
 def test_login_success(page: Page):
-    """TC-E2E-001: ログイン成功フロー"""
+    """TC-E2E-001: Login success flow"""
     page.goto("/login")
     page.fill("[data-testid=email]", "test@example.com")
     page.fill("[data-testid=password]", "password123")
@@ -141,7 +141,7 @@ def app():
     app.kill()
 
 def test_menu_file_open(app):
-    """TC-GUI-001: ファイルメニューからファイルを開く"""
+    """TC-GUI-001: Open a file from the File menu"""
     main = app.window(title="App Name")
     main.menu_select("File->Open")
     assert main.child_window(title="Open File").exists()
@@ -158,12 +158,12 @@ import time
 @pytest.fixture
 def app_process():
     proc = subprocess.Popen(["path/to/app"])
-    time.sleep(2)  # アプリ起動待ち
+    time.sleep(2)  # wait for app to start
     yield proc
     proc.terminate()
 
 def test_button_click(app_process):
-    """TC-GUI-001: メインボタンのクリック操作"""
+    """TC-GUI-001: Main button click operation"""
     location = pyautogui.locateOnScreen("tests/gui/images/button.png")
     assert location is not None
     pyautogui.click(location)
@@ -190,7 +190,7 @@ Before running E2E tests, verify:
 6. Commit test code (follow .claude/rules/git-rules.md; use prefix `test:`)
    ```bash
    git add {test-files}
-   git commit -m "test: {テスト対象の概要}"
+   git commit -m "test: {summary of test target}"
    ```
 7. Execute tests and review results
 8. Cross-reference results with the traceability matrix in `TEST_PLAN.md`
@@ -203,20 +203,20 @@ When tests fail, in addition to `FAILED_TESTS` in the `AGENT_RESULT`, output the
 The flow orchestrator includes this content in the rollback instructions to `test-designer`.
 
 ```
-## テスト失敗レポート（test-designer 向け）
+## Test Failure Report (for test-designer)
 
-### 失敗テスト: {テスト名} (TC-XXX)
-- **テストファイル:** {パス}
-- **対象コード:** {テスト対象のファイルパス}:{行番号}
-- **期待値:** {expected}
-- **実際の値:** {actual}
-- **エラー出力:** {スタックトレース等の要約}
+### Failed Test: {test name} (TC-XXX)
+- **Test file:** {path}
+- **Target code:** {target file path}:{line number}
+- **Expected:** {expected}
+- **Actual:** {actual}
+- **Error output:** {summary of stack trace, etc.}
 
-### E2E テスト失敗時の追加フィールド
-- **対象画面:** SCR-XXX
-- **スクリーンショット:** {失敗時のスクリーンショットパス}
-- **トレース:** {Playwright トレースファイルパス}（Web E2E の場合）
-- **操作手順の再現:** {失敗に至る操作ステップ}
+### Additional Fields for E2E Test Failures
+- **Target screen:** SCR-XXX
+- **Screenshot:** {path to failure screenshot}
+- **Trace:** {Playwright trace file path} (for Web E2E)
+- **Operation steps to reproduce:** {operation steps that led to failure}
 ```
 
 ---
@@ -224,32 +224,32 @@ The flow orchestrator includes this content in the rollback instructions to `tes
 ## Test Completion Report Format
 
 ```
-## テスト完了レポート
+## Test Completion Report
 
-### 実行環境
-- ツール: {使用したテストフレームワーク}
-- 実行コマンド: {コマンド}
+### Execution Environment
+- Tool: {test framework used}
+- Execution command: {command}
 
-### テスト結果サマリー
-- 合計: {N} テスト
-- 成功: {N} ✅
-- 失敗: {N} ❌
-- スキップ: {N} ⏭️
+### Test Results Summary
+- Total: {N} tests
+- Passed: {N} ✅
+- Failed: {N} ❌
+- Skipped: {N} ⏭️
 
-### テストケース別結果
-| TC番号 | テストケース名 | 対応UC | 結果 |
+### Results by Test Case
+| TC No. | Test Case Name | Corresponding UC | Result |
 |--------|-------------|--------|------|
-| TC-001 | {テスト名} | UC-XXX | ✅/❌ |
+| TC-001 | {test name} | UC-XXX | ✅/❌ |
 
-### 失敗したテストの詳細（ある場合）
-#### {テスト名} (TC-XXX)
-- **期待値:**
-- **実際の値:**
-- **エラー出力:**
+### Details of Failed Tests (if any)
+#### {test name} (TC-XXX)
+- **Expected:**
+- **Actual:**
+- **Error output:**
 
-### 次のステップ
-→ 全テスト成功の場合: `reviewer` を起動してください
-→ 失敗がある場合: `test-designer` が原因分析後、`developer` で修正してください
+### Next Steps
+→ If all tests pass: launch `reviewer`
+→ If there are failures: `test-designer` will analyze the root cause, then fix with `developer`
 ```
 
 ---

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -84,74 +84,74 @@ Step 5. Design interactions and states
 **Important: Each screen section must be self-contained so that it can be pasted directly into an AI design tool and used as-is.**
 
 ```markdown
-# UI仕様書: {プロジェクト名}
+# UI Specification: {Project Name}
 
-> 参照元: SPEC.md ({バージョン or 最終更新日})
-> 参照元: CONCEPT_VALIDATION.md ({存在する場合})
-> 作成日: {日付}
+> Source: SPEC.md ({version or last updated date})
+> Source: CONCEPT_VALIDATION.md ({if it exists})
+> Created: {date}
 
-## 1. デザイン方針
+## 1. Design Policy
 
-### トーン & マナー
-### カラーパレット
-| 用途 | カラー | Hex | 使用箇所 |
+### Tone & Manner
+### Color Palette
+| Usage | Color | Hex | Where Used |
 |------|--------|-----|---------|
 
-### タイポグラフィ
-| 要素 | フォント | サイズ | ウェイト |
+### Typography
+| Element | Font | Size | Weight |
 |------|---------|--------|---------|
 
-### コンポーネントライブラリ
-### アイコン
+### Component Library
+### Icons
 
-## 2. 画面遷移フロー
+## 2. Screen Transition Flow
 ```
-{Mermaid 記法 または ASCII で画面遷移図}
+{Screen transition diagram using Mermaid or ASCII notation}
 ```
 
-## 3. 画面一覧
-| 画面ID | 画面名 | 対応UC | URL パス | 説明 |
+## 3. Screen List
+| Screen ID | Screen Name | Corresponding UC | URL Path | Description |
 |--------|--------|--------|---------|------|
 
-## 4. 画面詳細
+## 4. Screen Details
 
-### SCR-001: {画面名}
-**目的:** {ゴール}
-**対応UC:** UC-XXX
-**遷移元/遷移先:** {前後の画面}
-**URL パス:** /{path}
+### SCR-001: {screen name}
+**Purpose:** {goal}
+**Corresponding UC:** UC-XXX
+**Transitions from/to:** {preceding and following screens}
+**URL path:** /{path}
 
-#### レイアウト構成
+#### Layout Structure
 ```
-{ASCIIアートでワイヤーフレーム}
+{Wireframe as ASCII art}
 ```
 
-#### コンポーネント詳細
-| # | コンポーネント | 種別 | 状態 | 説明 |
+#### Component Details
+| # | Component | Type | State | Description |
 |---|--------------|------|------|------|
 
-#### インタラクション
-| トリガー | アクション | フィードバック |
+#### Interactions
+| Trigger | Action | Feedback |
 |---------|-----------|--------------|
 
-#### バリデーション（フォームがある場合）
-| フィールド | ルール | エラーメッセージ |
+#### Validation (if there is a form)
+| Field | Rule | Error Message |
 |-----------|--------|----------------|
 
-#### 状態パターン
-| 状態 | 条件 | 表示内容 |
+#### State Patterns
+| State | Condition | Display Content |
 |------|------|---------|
-| ローディング | {条件} | {表示} |
-| 空状態 | {条件} | {表示} |
-| エラー | {条件} | {表示} |
-| 通常 | {条件} | {表示} |
+| Loading | {condition} | {display} |
+| Empty state | {condition} | {display} |
+| Error | {condition} | {display} |
+| Default | {condition} | {display} |
 
-（画面数分繰り返す）
+(Repeat for each screen)
 
-## 5. 共通コンポーネント
-## 6. レスポンシブ対応方針
-## 7. アクセシビリティ要件
-## 8. アニメーション・トランジション
+## 5. Shared Components
+## 6. Responsive Design Policy
+## 7. Accessibility Requirements
+## 8. Animations / Transitions
 ```
 
 ---

--- a/.claude/commands/analyst.md
+++ b/.claude/commands/analyst.md
@@ -1,7 +1,8 @@
-analystエージェント（issue分析・方針決定）を起動してください。
+Launch the analyst agent (issue analysis and approach decision).
 
-バグ報告・機能追加・リファクタリングのissueを受け取り、方針決定とドキュメント更新を行ってください。
-既存のSPEC.mdやARCHITECTURE.mdを確認し、issueを分類・分析した上で、ユーザーに方針の承認を求めてください。
+Receive a bug report, feature addition, or refactoring issue, and determine the approach and update documentation.
+Review existing SPEC.md and ARCHITECTURE.md, classify and analyze the issue,
+and then request user approval of the proposed approach.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/codebase-analyzer.md
+++ b/.claude/commands/codebase-analyzer.md
@@ -1,7 +1,7 @@
-codebase-analyzerエージェント（既存コードベース分析）を起動してください。
+Launch the codebase-analyzer agent (existing codebase analysis).
 
-既存のコードベースを分析し、SPEC.md と ARCHITECTURE.md をリバースエンジニアリングで生成してください。
-生成後は analyst や delivery-flow で通常のワークフローに合流できます。
+Analyze the existing codebase and reverse-engineer SPEC.md and ARCHITECTURE.md.
+After generation, the project can join the standard workflow via analyst or delivery-flow.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/delivery-flow.md
+++ b/.claude/commands/delivery-flow.md
@@ -1,7 +1,9 @@
-Delivery Flowエージェント（設計・実装オーケストレーター）を起動してください。
+Launch the Delivery Flow agent (design and implementation orchestrator).
 
-プロジェクト特性に基づいてトリアージを実施し、Delivery領域のフロー（spec-designer → ux-designer → architect → scaffolder → developer → test-designer → tester → reviewer → security-auditor → doc-writer → releaser）を管理してください。
-各フェーズのエージェントを順番に起動し、フェーズ完了ごとにユーザーの承認を得てから次へ進めてください。
+Perform triage based on project characteristics and manage the Delivery domain flow
+(spec-designer → ux-designer → architect → scaffolder → developer → test-designer → tester → reviewer → security-auditor → doc-writer → releaser).
+Launch agents for each phase in sequence and obtain user approval at the completion of each phase
+before proceeding to the next.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/discovery-flow.md
+++ b/.claude/commands/discovery-flow.md
@@ -1,7 +1,9 @@
-Discovery Flowエージェント（要件探索オーケストレーター）を起動してください。
+Launch the Discovery Flow agent (requirements exploration orchestrator).
 
-プロジェクト特性をヒアリングしてトリアージを実施し、Discovery領域のフロー（interviewer → researcher → poc-engineer → concept-validator → rules-designer → scope-planner）を管理してください。
-各フェーズのエージェントを順番に起動し、フェーズ完了ごとにユーザーの承認を得てから次へ進めてください。
+Interview the user on project characteristics, perform triage, and manage the Discovery domain flow
+(interviewer → researcher → poc-engineer → concept-validator → rules-designer → scope-planner).
+Launch agents for each phase in sequence and obtain user approval at the completion of each phase
+before proceeding to the next.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/maintenance-flow.md
+++ b/.claude/commands/maintenance-flow.md
@@ -1,11 +1,12 @@
-Maintenance Flowエージェント（保守・変更オーケストレーター）を起動してください。
+Launch the Maintenance Flow agent (maintenance and change orchestrator).
 
-既存プロジェクトへの変更・保守トリガー（バグ・機能追加・技術的負債・パフォーマンス・セキュリティパッチ）を受け取り、
-Patch / Minor / Major のトリアージを実施してください。
-change-classifier → (codebase-analyzer if needed) → impact-analyzer → analyst → architect → developer → tester → reviewer
-の順で必要なエージェントを起動し、フェーズ完了ごとにユーザーの承認を得てから次へ進めてください。
+Receive a maintenance or change trigger for an existing project (bug, feature addition, technical debt,
+performance issue, or security patch), and perform Patch / Minor / Major triage.
+Launch the necessary agents in order —
+change-classifier → (codebase-analyzer if needed) → impact-analyzer → analyst → architect → developer → tester → reviewer —
+and obtain user approval at the completion of each phase before proceeding to the next.
 
-Patch / Minor は maintenance-flow 単独で完結させ、Major は delivery-flow へ引き渡してください。
+Patch and Minor plans complete within maintenance-flow standalone; Major hands off to delivery-flow.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/operations-flow.md
+++ b/.claude/commands/operations-flow.md
@@ -1,8 +1,10 @@
-Operations Flowエージェント（デプロイ・運用オーケストレーター）を起動してください。
+Launch the Operations Flow agent (deployment and operations orchestrator).
 
-DELIVERY_RESULT.mdを読み込み、Operations領域のフロー（infra-builder → db-ops → observability → ops-planner）を管理してください。
-PRODUCT_TYPE: service の場合のみ実行されます。
-各フェーズのエージェントを順番に起動し、フェーズ完了ごとにユーザーの承認を得てから次へ進めてください。
+Read DELIVERY_RESULT.md and manage the Operations domain flow
+(infra-builder → db-ops → observability → ops-planner).
+This flow runs only for PRODUCT_TYPE: service.
+Launch agents for each phase in sequence and obtain user approval at the completion of each phase
+before proceeding to the next.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/pm.md
+++ b/.claude/commands/pm.md
@@ -1,10 +1,11 @@
-Delivery Flowエージェント（設計・実装オーケストレーター）を起動してください。
+Launch the Delivery Flow agent (design and implementation orchestrator).
 
-以下のユーザー要件に基づいて、Aphelion ワークフローの Delivery 領域全体を管理してください。
-プロジェクト特性に基づいてトリアージを実施し、各フェーズのエージェントを順番に起動し、フェーズ完了ごとにユーザーの承認を得てから次へ進めてください。
+Manage the entire Delivery domain of the Aphelion workflow based on the following user requirements.
+Perform triage based on project characteristics, launch agents for each phase in sequence,
+and obtain user approval at the completion of each phase before proceeding to the next.
 
-※ 要件探索（Discovery）から始める場合は /discovery-pm を使用してください。
-※ デプロイ・運用（Operations）を行う場合は /operations-pm を使用してください。
+Note: To start from requirements exploration (Discovery), use /discovery-flow instead.
+Note: To deploy and operate (Operations), use /operations-flow instead.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/reviewer.md
+++ b/.claude/commands/reviewer.md
@@ -1,7 +1,8 @@
-reviewerエージェント（コードレビュー）を起動してください。
+Launch the reviewer agent (code review).
 
-実装コードを SPEC.md（仕様適合）と ARCHITECTURE.md（設計整合）の両面からレビューし、品質レポートを生成してください。
-コードの修正は行わず、CRITICAL / WARNING / SUGGESTION のレベルでフィードバックを提示してください。
+Review implementation code from both SPEC.md (spec conformance) and ARCHITECTURE.md (design consistency) perspectives,
+and generate a quality report.
+Do not modify the code; present feedback at CRITICAL / WARNING / SUGGESTION levels.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/rules-designer.md
+++ b/.claude/commands/rules-designer.md
@@ -1,5 +1,6 @@
-Rules Designerエージェント（プロジェクトルール策定）を起動してください。
+Launch the Rules Designer agent (project rules definition).
 
-INTERVIEW_RESULT.md を読み込み、ユーザーとの対話を通じてプロジェクト固有のコーディング規約・Git ルール・ビルドコマンドなどを決定し、プロジェクトルートに CLAUDE.md を生成してください。
+Read INTERVIEW_RESULT.md, and through dialogue with the user, determine project-specific coding conventions,
+Git rules, build commands, and other standards. Generate a CLAUDE.md file in the project root.
 
 $ARGUMENTS

--- a/.claude/commands/secrets-scan.md
+++ b/.claude/commands/secrets-scan.md
@@ -1,40 +1,40 @@
-ソースコード内にハードコードされた秘密情報がないかスキャンしてください。
+Scan the source code for hardcoded secrets.
 
-## 手順
+## Steps
 
-1. 以下のパターンを Grep ツールで検索する（`.env`, `.env.example`, `*.secret`, テストフィクスチャは除外）:
+1. Search for the following patterns using the Grep tool (exclude `.env`, `.env.example`, `*.secret`, and test fixtures):
 
-   - API キー: `api[_-]?key\s*[:=]\s*["'][^"']{8,}["']`
-   - パスワード: `password\s*[:=]\s*["'][^"']+["']`
-   - シークレット: `secret\s*[:=]\s*["'][^"']{8,}["']`
-   - トークン: `token\s*[:=]\s*["'][^"']{8,}["']`
-   - 接続文字列: `(mysql|postgres|mongodb|redis)://[^\s"']+`
-   - AWS アクセスキー: `AKIA[0-9A-Z]{16}`
-   - 秘密鍵: `-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----`
-   - Bearer トークン: `Bearer\s+[A-Za-z0-9\-._~+/]{20,}`
+   - API keys: `api[_-]?key\s*[:=]\s*["'][^"']{8,}["']`
+   - Passwords: `password\s*[:=]\s*["'][^"']+["']`
+   - Secrets: `secret\s*[:=]\s*["'][^"']{8,}["']`
+   - Tokens: `token\s*[:=]\s*["'][^"']{8,}["']`
+   - Connection strings: `(mysql|postgres|mongodb|redis)://[^\s"']+`
+   - AWS access keys: `AKIA[0-9A-Z]{16}`
+   - Private keys: `-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----`
+   - Bearer tokens: `Bearer\s+[A-Za-z0-9\-._~+/]{20,}`
 
-2. 検出された各項目について、以下を判定する:
-   - 本物の秘密情報か、プレースホルダー/サンプル値か
-   - 環境変数参照（`os.environ`, `process.env` 等）であれば安全と判定
+2. For each detected item, determine:
+   - Is it a real secret, or a placeholder/sample value?
+   - If it is an environment variable reference (`os.environ`, `process.env`, etc.), classify it as safe
 
-3. 結果を以下の形式で報告する:
+3. Report results in the following format:
 
 ```
-## 秘密情報スキャン結果
+## Secrets Scan Results
 
-- スキャン対象: {ファイル数} ファイル
-- 除外: .env, .env.example, テストフィクスチャ
-- 検出件数: {件数}
+- Files scanned: {file count}
+- Excluded: .env, .env.example, test fixtures
+- Issues found: {count}
 
-### 検出された項目（ある場合）
-| # | ファイル:行 | 種別 | 判定 | 内容（マスク済み） |
-|---|-----------|------|------|-----------------|
-| 1 | {path}:{line} | {API key / password / ...} | {要対応 / 安全} | {先頭4文字}**** |
+### Detected Items (if any)
+| # | File:Line | Type | Verdict | Value (masked) |
+|---|-----------|------|---------|----------------|
+| 1 | {path}:{line} | {API key / password / ...} | {action required / safe} | {first 4 chars}**** |
 
-### 推奨アクション
-{環境変数への移行方法など}
+### Recommended Actions
+{How to migrate to environment variables, etc.}
 ```
 
-4. 検出が 0 件の場合も「検出なし」と明示的に報告する
+4. If no items are detected, explicitly report "No secrets found"
 
 $ARGUMENTS

--- a/.claude/commands/tester.md
+++ b/.claude/commands/tester.md
@@ -1,7 +1,7 @@
-testerエージェント（テスト実行）を起動してください。
+Launch the tester agent (test execution).
 
-TEST_PLAN.md に従いテストコードを作成・実行し、品質を検証してください。
-TEST_PLAN.md が存在しない場合は Minimal プランとして簡易テスト計画の作成も行ってください。
+Create and run tests according to TEST_PLAN.md and verify quality.
+If TEST_PLAN.md does not exist, also create a simplified test plan under the Minimal plan.
 
-ユーザーの要件:
+User requirements:
 $ARGUMENTS

--- a/.claude/commands/vuln-scan.md
+++ b/.claude/commands/vuln-scan.md
@@ -1,36 +1,36 @@
-依存パッケージの脆弱性スキャンを実行してください。
+Run a vulnerability scan on the project's dependencies.
 
-## 手順
+## Steps
 
-1. プロジェクトの技術スタックを自動検出する（以下のファイルの存在で判定）:
+1. Auto-detect the project's tech stack by checking for the following files:
    - `pyproject.toml` / `requirements.txt` → Python
    - `package.json` → Node.js
    - `go.mod` → Go
    - `Cargo.toml` → Rust
 
-2. 検出した技術スタックに対応するスキャンツールを実行する:
+2. Run the scan tool that corresponds to the detected tech stack:
    - Python: `uv run pip-audit 2>/dev/null || pip-audit 2>/dev/null`
    - Node.js: `npm audit`
    - Go: `govulncheck ./...`
    - Rust: `cargo audit`
 
-3. ツールが未インストールの場合はその旨を報告し、インストール方法を案内する
+3. If the tool is not installed, report this and provide installation instructions
 
-4. 結果を以下の形式で報告する:
+4. Report results in the following format:
 
 ```
-## 脆弱性スキャン結果
+## Vulnerability Scan Results
 
-- 技術スタック: {検出結果}
-- スキャンツール: {使用ツール}
-- 脆弱性件数: {件数}
+- Tech stack: {detected result}
+- Scan tool: {tool used}
+- Vulnerabilities found: {count}
 
-### 検出された脆弱性（ある場合）
-| パッケージ | 現バージョン | 脆弱性 | 重大度 | 修正バージョン |
-|-----------|------------|--------|--------|-------------|
+### Detected Vulnerabilities (if any)
+| Package | Current Version | Vulnerability | Severity | Fixed Version |
+|---------|----------------|---------------|----------|---------------|
 
-### 推奨アクション
-{修正方法の提案}
+### Recommended Actions
+{Proposed remediation steps}
 ```
 
 $ARGUMENTS

--- a/.claude/orchestrator-rules.md
+++ b/.claude/orchestrator-rules.md
@@ -126,49 +126,49 @@ Each flow orchestrator validates required fields of the handoff file at startup.
 
 **DISCOVERY_RESULT.md required fields:**
 - `PRODUCT_TYPE` (one of: service / tool / library / cli)
-- "プロジェクト概要" section (must not be empty)
-- "要件サマリー" section (must not be empty)
+- "Project Overview" section (must not be empty)
+- "Requirements Summary" section (must not be empty)
 
 **DELIVERY_RESULT.md required fields:**
 - `PRODUCT_TYPE`
-- "成果物" section (must include SPEC.md and ARCHITECTURE.md status)
-- "技術スタック" section (must not be empty)
-- "テスト結果" section
-- "セキュリティ監査結果" section
+- "Artifacts" section (must include SPEC.md and ARCHITECTURE.md status)
+- "Tech Stack" section (must not be empty)
+- "Test Results" section
+- "Security Audit Results" section
 
 **OPS_RESULT.md required fields:**
-- "成果物一覧" table
-- "デプロイ準備状態" checklist
+- "Artifacts" table
+- "Deployment Readiness" checklist
 
 ### DISCOVERY_RESULT.md
 
 Final output of Discovery Flow. Input for Delivery Flow's `spec-designer`.
 
 ```markdown
-# Discovery Result: {プロジェクト名}
+# Discovery Result: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> Discovery プラン: {Minimal | Light | Standard | Full}
+> Created: {YYYY-MM-DD}
+> Discovery Plan: {Minimal | Light | Standard | Full}
 
-## プロジェクト概要
-{1〜3行の要約}
+## Project Overview
+{1–3 line summary}
 
-## 成果物の性質
+## Artifact Type
 PRODUCT_TYPE: {service | tool | library | cli}
 
-## 要件サマリー
-{構造化された要件の要約}
+## Requirements Summary
+{Structured requirements summary}
 
-## スコープ（確定している場合）
-- MVP: {最小スコープ}
-- IN: {含むもの}
-- OUT: {含まないもの}
+## Scope (if confirmed)
+- MVP: {minimum scope}
+- IN: {included}
+- OUT: {excluded}
 
-## 技術リスク・制約（調査済みの場合）
-{PoCの結果、外部依存の制約等}
+## Technical Risks / Constraints (if investigated)
+{PoC results, external dependency constraints, etc.}
 
-## 未解決事項
-{Delivery で解決すべき残課題}
+## Unresolved Items
+{Remaining issues to be resolved in Delivery}
 ```
 
 ### DELIVERY_RESULT.md
@@ -176,31 +176,31 @@ PRODUCT_TYPE: {service | tool | library | cli}
 Final output of Delivery Flow. Input for Operations Flow (for service type).
 
 ```markdown
-# Delivery Result: {プロジェクト名}
+# Delivery Result: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> Delivery プラン: {Minimal | Light | Standard | Full}
+> Created: {YYYY-MM-DD}
+> Delivery Plan: {Minimal | Light | Standard | Full}
 > PRODUCT_TYPE: {service | tool}
 
-## 成果物
-- SPEC.md: {あり/なし}
-- ARCHITECTURE.md: {あり/なし}
-- UI_SPEC.md: {あり/なし/該当なし}
-- TEST_PLAN.md: {あり/なし}
-- 実装コード: {ファイル数}
-- README.md: {あり/なし}
+## Artifacts
+- SPEC.md: {present/absent}
+- ARCHITECTURE.md: {present/absent}
+- UI_SPEC.md: {present/absent/N/A}
+- TEST_PLAN.md: {present/absent}
+- Implementation code: {file count}
+- README.md: {present/absent}
 
-## 技術スタック
-{確定した技術スタックの要約}
+## Tech Stack
+{Summary of confirmed tech stack}
 
-## テスト結果
-- 合計: {N} / 成功: {N} / 失敗: {N}
+## Test Results
+- Total: {N} / Pass: {N} / Fail: {N}
 
-## セキュリティ監査結果
+## Security Audit Results
 - CRITICAL: {N} / WARNING: {N}
 
-## Operations への引き継ぎ（service の場合）
-{デプロイに必要な情報、環境変数一覧、DB要件等}
+## Handoff to Operations (for service type)
+{Information required for deployment, environment variable list, DB requirements, etc.}
 ```
 
 ### OPS_RESULT.md
@@ -208,34 +208,34 @@ Final output of Delivery Flow. Input for Operations Flow (for service type).
 Final output of Operations Flow. Used for final deployment readiness confirmation.
 
 ```markdown
-# Operations Result: {プロジェクト名}
+# Operations Result: {Project Name}
 
-> 作成日: {YYYY-MM-DD}
-> Operations プラン: {Light | Standard | Full}
+> Created: {YYYY-MM-DD}
+> Operations Plan: {Light | Standard | Full}
 
-## 成果物一覧
-| ファイル | 内容 | 状態 |
-|---------|------|------|
-| Dockerfile | コンテナ定義 | あり/なし |
-| docker-compose.yml | コンテナ構成 | あり/なし |
-| .github/workflows/ci.yml | CI/CD | あり/なし |
-| .env.example | 環境変数テンプレート | あり/なし |
-| DB_OPS.md | DB運用ガイド | あり/なし |
-| OBSERVABILITY.md | 可観測性設計 | あり/なし |
-| OPS_PLAN.md | 運用計画書 | あり |
+## Artifacts
+| File | Description | Status |
+|------|-------------|--------|
+| Dockerfile | Container definition | present/absent |
+| docker-compose.yml | Container configuration | present/absent |
+| .github/workflows/ci.yml | CI/CD | present/absent |
+| .env.example | Environment variable template | present/absent |
+| DB_OPS.md | DB operations guide | present/absent |
+| OBSERVABILITY.md | Observability design | present/absent |
+| OPS_PLAN.md | Operations plan | present |
 
-## デプロイ準備状態
-- [ ] Dockerfile / docker-compose 作成済み
-- [ ] CI/CD パイプライン構築済み
-- [ ] 環境変数テンプレート作成済み
-- [ ] DB運用ガイド作成済み（該当する場合）
-- [ ] 可観測性設計完了（該当する場合）
-- [ ] デプロイ手順書作成済み
-- [ ] ロールバック手順策定済み
-- [ ] インシデント対応プレイブック作成済み
+## Deployment Readiness
+- [ ] Dockerfile / docker-compose created
+- [ ] CI/CD pipeline configured
+- [ ] Environment variable template created
+- [ ] DB operations guide created (if applicable)
+- [ ] Observability design complete (if applicable)
+- [ ] Deployment procedure documented
+- [ ] Rollback procedure defined
+- [ ] Incident response playbook created
 
-## 未対応事項
-{残タスクがあれば記載}
+## Unresolved Items
+{List any remaining tasks}
 ```
 
 ---
@@ -282,11 +282,11 @@ When `AUTO_APPROVE: true`:
 
 | Decision Point | Auto-Selected Option | Notes |
 |---------------|---------------------|-------|
-| Triage approval | "承認して開始" | Accept the auto-determined plan |
-| Phase approval gate | "承認して続行" | Proceed to next phase |
-| Existing file confirmation | "続きから始める" | Reuse existing artifacts |
-| Error handling | "再実行" | Retry up to 3 times per agent, then stop |
-| Session interruption | "再開する" | Resume automatically |
+| Triage approval | "Approve and start" | Accept the auto-determined plan |
+| Phase approval gate | "Approve and continue" | Proceed to next phase |
+| Existing file confirmation | "Continue from here" | Reuse existing artifacts |
+| Error handling | "Retry" | Retry up to 3 times per agent, then stop |
+| Session interruption | "Resume" | Resume automatically |
 
 #### Logging Requirement
 
@@ -326,19 +326,19 @@ If the file is empty, use default triage behavior and auto-approve the result.
 Each phase follows this common loop. Domain-specific steps (rollback checks, etc.) are additions on top of this template.
 
 ```
-[Phase N 開始]
-  1. フェーズ開始をユーザーに通知する
-     「▶ Phase N/{総フェーズ数}: {エージェント名} を起動します」
-  2. 前段の成果物パスを含む指示でエージェントを起動する
-  3. エージェントの AGENT_RESULT ブロックを確認する
-  4. STATUS を判定し、error / blocked / failure に対応する
-     （failure の場合はドメイン固有の差し戻しルールに従う）
-  5. AUTO_APPROVE: true の場合:
-     → 「承認して続行」を自動選択し、テキスト出力のみ行う（AskUserQuestion をスキップ）
-     AUTO_APPROVE: false の場合:
-     → 承認ゲート（下記「Approval Gate」参照）で停止しユーザーに承認を求める
-  6. AUTO_APPROVE: false の場合のみ: ユーザーの返答を待つ（絶対に自動で進まない）
-  7. 次フェーズへ
+[Phase N Start]
+  1. Notify the user that the phase is starting:
+     "▶ Phase N/{total phases}: launching {agent name}"
+  2. Launch the agent with instructions that include the preceding artifact paths
+  3. Verify the agent's AGENT_RESULT block
+  4. Evaluate STATUS and handle error / blocked / failure
+     (for failure, follow domain-specific rollback rules)
+  5. If AUTO_APPROVE: true:
+     → Auto-select "Approve and continue" and output text only (skip AskUserQuestion)
+     If AUTO_APPROVE: false:
+     → Stop at the approval gate (see "Approval Gate" below) and request user approval
+  6. Only if AUTO_APPROVE: false: wait for the user's response (never advance automatically)
+  7. Proceed to the next phase
 ```
 
 ---
@@ -352,13 +352,13 @@ When an agent returns `STATUS: error`, the orchestrator must:
 ```json
 {
   "questions": [{
-    "question": "{エージェント名} がエラーを報告しました。どう対応しますか？",
-    "header": "エラー対応",
+    "question": "{agent name} reported an error. How would you like to proceed?",
+    "header": "Error Handling",
     "options": [
-      {"label": "再実行", "description": "同じエージェントをもう一度実行する"},
-      {"label": "修正して再実行", "description": "修正内容を指示してから再実行する"},
-      {"label": "スキップ", "description": "このエージェントをスキップして次へ進む"},
-      {"label": "中断", "description": "ワークフローを停止する"}
+      {"label": "Retry", "description": "Run the same agent again"},
+      {"label": "Retry with fix", "description": "Provide correction instructions and re-run"},
+      {"label": "Skip", "description": "Skip this agent and proceed to the next"},
+      {"label": "Abort", "description": "Stop the workflow"}
     ],
     "multiSelect": false
   }]
@@ -366,7 +366,7 @@ When an agent returns `STATUS: error`, the orchestrator must:
 ```
 
 3. When `AUTO_APPROVE: false`: Never re-execute automatically without user instruction
-4. When `AUTO_APPROVE: true`: Automatically select "再実行". Track retry count per agent. If retry count exceeds 3, stop the workflow and output an error summary
+4. When `AUTO_APPROVE: true`: Automatically select "Retry". Track retry count per agent. If retry count exceeds 3, stop the workflow and output an error summary
 
 ---
 
@@ -379,13 +379,13 @@ Common approval gate format shared by all flow orchestrators. After each phase c
 1. First, output a phase completion summary as text:
 
 ```
-Phase {N} 完了: {エージェント名}
+Phase {N} complete: {agent name}
 
-【生成された成果物】
-  - {ファイルパス}: {概要}
+[Generated Artifacts]
+  - {file path}: {summary}
 
-【内容サマリー】
-{3〜5行で要約}
+[Content Summary]
+{3–5 line summary}
 ```
 
 2. Then request approval via `AskUserQuestion`:
@@ -393,12 +393,12 @@ Phase {N} 完了: {エージェント名}
 ```json
 {
   "questions": [{
-    "question": "Phase {N} の成果物を確認しました。次のフェーズに進みますか？",
+    "question": "Phase {N} artifacts reviewed. Proceed to the next phase?",
     "header": "Phase {N}",
     "options": [
-      {"label": "承認して続行", "description": "Phase {N+1}: {次のエージェント名} に進む"},
-      {"label": "修正を指示", "description": "このフェーズの成果物を修正してから進む"},
-      {"label": "中断", "description": "ワークフローを停止する"}
+      {"label": "Approve and continue", "description": "Proceed to Phase {N+1}: {next agent name}"},
+      {"label": "Request modification", "description": "Revise this phase's artifacts before proceeding"},
+      {"label": "Abort", "description": "Stop the workflow"}
     ],
     "multiSelect": false
   }]
@@ -409,9 +409,9 @@ Phase {N} 完了: {エージェント名}
 
 | User Selection | Orchestrator Action |
 |---------------|-----------|
-| "承認して続行" | Proceed to next phase |
-| "修正を指示" | Re-execute current phase agent based on modification instructions from the Other field |
-| "中断" | Stop the workflow and provide instructions for resuming |
+| "Approve and continue" | Proceed to next phase |
+| "Request modification" | Re-execute current phase agent based on modification instructions from the Other field |
+| "Abort" | Stop the workflow and provide instructions for resuming |
 
 ---
 

--- a/TASK.md
+++ b/TASK.md
@@ -12,7 +12,7 @@
 - [x] TASK-001: .claude/orchestrator-rules.md 英語化 | 対象ファイル: .claude/orchestrator-rules.md
 
 ### Phase 2: commands/ 英語化（12ファイル一括）
-- [ ] TASK-002: .claude/commands/*.md 英語化 | 対象ファイル: .claude/commands/secrets-scan.md, vuln-scan.md, pm.md, maintenance-flow.md, discovery-flow.md, delivery-flow.md, operations-flow.md, analyst.md, reviewer.md, rules-designer.md, codebase-analyzer.md, tester.md
+- [x] TASK-002: .claude/commands/*.md 英語化 | 対象ファイル: .claude/commands/secrets-scan.md, vuln-scan.md, pm.md, maintenance-flow.md, discovery-flow.md, delivery-flow.md, operations-flow.md, analyst.md, reviewer.md, rules-designer.md, codebase-analyzer.md, tester.md
 
 ### Phase 3: agents/ オーケストレーター系（4件）
 - [ ] TASK-003: agents/ オーケストレーター英語化 | 対象ファイル: .claude/agents/discovery-flow.md, delivery-flow.md, operations-flow.md, maintenance-flow.md

--- a/TASK.md
+++ b/TASK.md
@@ -15,7 +15,7 @@
 - [x] TASK-002: .claude/commands/*.md 英語化 | 対象ファイル: .claude/commands/secrets-scan.md, vuln-scan.md, pm.md, maintenance-flow.md, discovery-flow.md, delivery-flow.md, operations-flow.md, analyst.md, reviewer.md, rules-designer.md, codebase-analyzer.md, tester.md
 
 ### Phase 3: agents/ オーケストレーター系（4件）
-- [ ] TASK-003: agents/ オーケストレーター英語化 | 対象ファイル: .claude/agents/discovery-flow.md, delivery-flow.md, operations-flow.md, maintenance-flow.md
+- [x] TASK-003: agents/ オーケストレーター英語化 | 対象ファイル: .claude/agents/discovery-flow.md, delivery-flow.md, operations-flow.md, maintenance-flow.md
 
 ### Phase 4: agents/ Discovery系（6件）
 - [ ] TASK-004: agents/ Discovery系英語化 | 対象ファイル: .claude/agents/interviewer.md, researcher.md, poc-engineer.md, concept-validator.md, rules-designer.md, scope-planner.md

--- a/TASK.md
+++ b/TASK.md
@@ -1,14 +1,33 @@
 # TASK.md
 
-> 参照元: —
+> 参照元: Issue #32 Phase 2 (2026-04-24)
 
-## フェーズ: —
-最終更新: —
-ステータス: —
+## フェーズ: agent definitions 英語化
+最終更新: 2026-04-24
+ステータス: 進行中
 
 ## タスク一覧
 
-（次フェーズの実装開始時に developer が記入する）
+### Phase 1: orchestrator-rules.md 英語化
+- [x] TASK-001: .claude/orchestrator-rules.md 英語化 | 対象ファイル: .claude/orchestrator-rules.md
+
+### Phase 2: commands/ 英語化（12ファイル一括）
+- [ ] TASK-002: .claude/commands/*.md 英語化 | 対象ファイル: .claude/commands/secrets-scan.md, vuln-scan.md, pm.md, maintenance-flow.md, discovery-flow.md, delivery-flow.md, operations-flow.md, analyst.md, reviewer.md, rules-designer.md, codebase-analyzer.md, tester.md
+
+### Phase 3: agents/ オーケストレーター系（4件）
+- [ ] TASK-003: agents/ オーケストレーター英語化 | 対象ファイル: .claude/agents/discovery-flow.md, delivery-flow.md, operations-flow.md, maintenance-flow.md
+
+### Phase 4: agents/ Discovery系（6件）
+- [ ] TASK-004: agents/ Discovery系英語化 | 対象ファイル: .claude/agents/interviewer.md, researcher.md, poc-engineer.md, concept-validator.md, rules-designer.md, scope-planner.md
+
+### Phase 5: agents/ Delivery系（12件）
+- [ ] TASK-005: agents/ Delivery系英語化 | 対象ファイル: .claude/agents/spec-designer.md, architect.md, scaffolder.md, ux-designer.md, developer.md, test-designer.md, e2e-test-designer.md, tester.md, security-auditor.md, reviewer.md, doc-writer.md, releaser.md
+
+### Phase 6: agents/ Operations系（4件）
+- [ ] TASK-006: agents/ Operations系英語化 | 対象ファイル: .claude/agents/infra-builder.md, db-ops.md, observability.md, ops-planner.md
+
+### Phase 7: agents/ Maintenance+Standalone系（4件）
+- [ ] TASK-007: agents/ Maintenance+Standalone系英語化 | 対象ファイル: .claude/agents/change-classifier.md, impact-analyzer.md, analyst.md, codebase-analyzer.md
 
 ## 直近のコミット
 （タスク完了のたびに git log --oneline -3 を記録する）

--- a/TASK.md
+++ b/TASK.md
@@ -3,7 +3,7 @@
 > 参照元: Issue #32 Phase 2 (2026-04-24)
 
 ## フェーズ: agent definitions 英語化
-最終更新: 2026-04-24
+最終更新: 2026-04-24T(TASK-005完了)
 ステータス: 進行中
 
 ## タスク一覧
@@ -21,7 +21,7 @@
 - [x] TASK-004: agents/ Discovery系英語化 | 対象ファイル: .claude/agents/interviewer.md, researcher.md, poc-engineer.md, concept-validator.md, rules-designer.md, scope-planner.md
 
 ### Phase 5: agents/ Delivery系（12件）
-- [ ] TASK-005: agents/ Delivery系英語化 | 対象ファイル: .claude/agents/spec-designer.md, architect.md, scaffolder.md, ux-designer.md, developer.md, test-designer.md, e2e-test-designer.md, tester.md, security-auditor.md, reviewer.md, doc-writer.md, releaser.md
+- [x] TASK-005: agents/ Delivery系英語化 | 対象ファイル: .claude/agents/spec-designer.md, architect.md, scaffolder.md, ux-designer.md, developer.md, test-designer.md, e2e-test-designer.md, tester.md, security-auditor.md, reviewer.md, doc-writer.md, releaser.md
 
 ### Phase 6: agents/ Operations系（4件）
 - [ ] TASK-006: agents/ Operations系英語化 | 対象ファイル: .claude/agents/infra-builder.md, db-ops.md, observability.md, ops-planner.md
@@ -30,7 +30,9 @@
 - [ ] TASK-007: agents/ Maintenance+Standalone系英語化 | 対象ファイル: .claude/agents/change-classifier.md, impact-analyzer.md, analyst.md, codebase-analyzer.md
 
 ## 直近のコミット
-（タスク完了のたびに git log --oneline -3 を記録する）
+ac1d723 refactor: translate Discovery agent definitions to English (TASK-004)
+e8b709c refactor: translate orchestrator agent definitions to English (TASK-003)
+d7404e0 refactor: translate commands/*.md to English (TASK-002)
 
 ## 中断時のメモ
 （セッション中断時に状況をここに記録する）

--- a/TASK.md
+++ b/TASK.md
@@ -24,7 +24,7 @@
 - [x] TASK-005: agents/ Delivery系英語化 | 対象ファイル: .claude/agents/spec-designer.md, architect.md, scaffolder.md, ux-designer.md, developer.md, test-designer.md, e2e-test-designer.md, tester.md, security-auditor.md, reviewer.md, doc-writer.md, releaser.md
 
 ### Phase 6: agents/ Operations系（4件）
-- [ ] TASK-006: agents/ Operations系英語化 | 対象ファイル: .claude/agents/infra-builder.md, db-ops.md, observability.md, ops-planner.md
+- [x] TASK-006: agents/ Operations系英語化 | 対象ファイル: .claude/agents/infra-builder.md, db-ops.md, observability.md, ops-planner.md
 
 ### Phase 7: agents/ Maintenance+Standalone系（4件）
 - [ ] TASK-007: agents/ Maintenance+Standalone系英語化 | 対象ファイル: .claude/agents/change-classifier.md, impact-analyzer.md, analyst.md, codebase-analyzer.md

--- a/TASK.md
+++ b/TASK.md
@@ -4,7 +4,7 @@
 
 ## フェーズ: agent definitions 英語化
 最終更新: 2026-04-24T(TASK-005完了)
-ステータス: 進行中
+ステータス: 完了
 
 ## タスク一覧
 
@@ -27,12 +27,12 @@
 - [x] TASK-006: agents/ Operations系英語化 | 対象ファイル: .claude/agents/infra-builder.md, db-ops.md, observability.md, ops-planner.md
 
 ### Phase 7: agents/ Maintenance+Standalone系（4件）
-- [ ] TASK-007: agents/ Maintenance+Standalone系英語化 | 対象ファイル: .claude/agents/change-classifier.md, impact-analyzer.md, analyst.md, codebase-analyzer.md
+- [x] TASK-007: agents/ Maintenance+Standalone系英語化 | 対象ファイル: .claude/agents/change-classifier.md, impact-analyzer.md, analyst.md, codebase-analyzer.md
 
 ## 直近のコミット
+f696e2c refactor: translate Operations agent definitions to English (TASK-006)
+c443409 refactor: translate Delivery agent definitions to English (TASK-005)
 ac1d723 refactor: translate Discovery agent definitions to English (TASK-004)
-e8b709c refactor: translate orchestrator agent definitions to English (TASK-003)
-d7404e0 refactor: translate commands/*.md to English (TASK-002)
 
 ## 中断時のメモ
 （セッション中断時に状況をここに記録する）

--- a/TASK.md
+++ b/TASK.md
@@ -18,7 +18,7 @@
 - [x] TASK-003: agents/ オーケストレーター英語化 | 対象ファイル: .claude/agents/discovery-flow.md, delivery-flow.md, operations-flow.md, maintenance-flow.md
 
 ### Phase 4: agents/ Discovery系（6件）
-- [ ] TASK-004: agents/ Discovery系英語化 | 対象ファイル: .claude/agents/interviewer.md, researcher.md, poc-engineer.md, concept-validator.md, rules-designer.md, scope-planner.md
+- [x] TASK-004: agents/ Discovery系英語化 | 対象ファイル: .claude/agents/interviewer.md, researcher.md, poc-engineer.md, concept-validator.md, rules-designer.md, scope-planner.md
 
 ### Phase 5: agents/ Delivery系（12件）
 - [ ] TASK-005: agents/ Delivery系英語化 | 対象ファイル: .claude/agents/spec-designer.md, architect.md, scaffolder.md, ux-designer.md, developer.md, test-designer.md, e2e-test-designer.md, tester.md, security-auditor.md, reviewer.md, doc-writer.md, releaser.md

--- a/TASK.md
+++ b/TASK.md
@@ -1,38 +1,3 @@
 # TASK.md
 
-> 参照元: Issue #32 Phase 2 (2026-04-24)
-
-## フェーズ: agent definitions 英語化
-最終更新: 2026-04-24T(TASK-005完了)
-ステータス: 完了
-
-## タスク一覧
-
-### Phase 1: orchestrator-rules.md 英語化
-- [x] TASK-001: .claude/orchestrator-rules.md 英語化 | 対象ファイル: .claude/orchestrator-rules.md
-
-### Phase 2: commands/ 英語化（12ファイル一括）
-- [x] TASK-002: .claude/commands/*.md 英語化 | 対象ファイル: .claude/commands/secrets-scan.md, vuln-scan.md, pm.md, maintenance-flow.md, discovery-flow.md, delivery-flow.md, operations-flow.md, analyst.md, reviewer.md, rules-designer.md, codebase-analyzer.md, tester.md
-
-### Phase 3: agents/ オーケストレーター系（4件）
-- [x] TASK-003: agents/ オーケストレーター英語化 | 対象ファイル: .claude/agents/discovery-flow.md, delivery-flow.md, operations-flow.md, maintenance-flow.md
-
-### Phase 4: agents/ Discovery系（6件）
-- [x] TASK-004: agents/ Discovery系英語化 | 対象ファイル: .claude/agents/interviewer.md, researcher.md, poc-engineer.md, concept-validator.md, rules-designer.md, scope-planner.md
-
-### Phase 5: agents/ Delivery系（12件）
-- [x] TASK-005: agents/ Delivery系英語化 | 対象ファイル: .claude/agents/spec-designer.md, architect.md, scaffolder.md, ux-designer.md, developer.md, test-designer.md, e2e-test-designer.md, tester.md, security-auditor.md, reviewer.md, doc-writer.md, releaser.md
-
-### Phase 6: agents/ Operations系（4件）
-- [x] TASK-006: agents/ Operations系英語化 | 対象ファイル: .claude/agents/infra-builder.md, db-ops.md, observability.md, ops-planner.md
-
-### Phase 7: agents/ Maintenance+Standalone系（4件）
-- [x] TASK-007: agents/ Maintenance+Standalone系英語化 | 対象ファイル: .claude/agents/change-classifier.md, impact-analyzer.md, analyst.md, codebase-analyzer.md
-
-## 直近のコミット
-f696e2c refactor: translate Operations agent definitions to English (TASK-006)
-c443409 refactor: translate Delivery agent definitions to English (TASK-005)
-ac1d723 refactor: translate Discovery agent definitions to English (TASK-004)
-
-## 中断時のメモ
-（セッション中断時に状況をここに記録する）
+<!-- 次のdeveloperセッション開始時にここにタスクを記載してください -->


### PR DESCRIPTION
## Summary

- Translates all agent definition body text from Japanese to English across 44 files (`.claude/orchestrator-rules.md`, all `.claude/commands/*.md`, all `.claude/agents/*.md`)
- Follows the translation policy in Issue #32: role descriptions, responsibilities, processing procedures, section headings, table headings, explanatory text, notes/warnings, and output file templates are translated
- Preserves untranslated: `$ARGUMENTS` placeholder contexts, AGENT_RESULT block keys/values, code identifiers, command names

## Changes by commit

| Commit | Scope |
|--------|-------|
| TASK-001 | `orchestrator-rules.md` — handoff file templates, phase execution loop, approval gate |
| TASK-002 | `commands/*.md` (12 files) — invocation descriptions |
| TASK-003 | Orchestrator agents (4 files) — flow diagrams, rollback templates, progress display |
| TASK-004 | Discovery agents (6 files) — AskUserQuestion dialogs, output file templates |
| TASK-005 | Delivery agents (12 files) — SPEC/ARCHITECTURE/UI_SPEC/TASK/TEST_PLAN/SECURITY_AUDIT/review report templates |
| TASK-006 | Operations agents (4 files) — .env.example, DB_OPS.md, OBSERVABILITY.md, OPS_PLAN.md, OPS_RESULT.md templates |
| TASK-007 | Maintenance + Standalone agents (4 files) — approval gates, issue/PR body templates, codebase analysis output templates |

## Test plan

- [x] Grep verification: no Japanese characters remain in any translated file (`grep -Prl '[\x{3040}-\x{9FFF}]' .claude/` returns empty)
- [x] All 7 commits present and clean
- [ ] Spot-check agent definition files to confirm translated text is accurate and idiomatic English

🤖 Generated with [Claude Code](https://claude.com/claude-code)