### PR TITLE
chore: fix repo consistency findings from review (MAJ-001, MAJ-003, MAJ-004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- `docs/issues/` reorganised: 17 closed planning documents moved into
-  `docs/issues/archived/` so the active directory only lists work in flight.
-  Cross-references in active wiki / rule files updated to the new paths.
-  Inter-archive references kept as the original relative paths (read-only
-  policy). `docs/issues/archived/README.md` documents the convention.
-- `docs/wiki/{en,ja}/Contributing.md`: new "Archiving closed planning docs"
-  subsection.
-
 ### Added
 
 - `.github/workflows/archive-closed-plans.yml` — fires on `pull_request:
   opened` / `edited` / `synchronize`. Parses the PR body for `Closes #N` /
   `Fixes #N` / `Resolves #N` keywords, finds the matching planning doc by
   its `GitHub Issue: [#N]` header reference, `git mv`'s it into
-  `docs/issues/archived/`, and pushes the resulting commit back to the PR
-  branch. The archive move ships **in the same PR as the work** (no
+  `docs/design-notes/archived/`, and pushes the resulting commit back to the
+  PR branch. The archive move ships **in the same PR as the work** (no
   follow-up PR), eliminating the PR-proliferation problem of trigger-on-
   merge approaches. Idempotent (already-archived docs cause a no-op) plus
   an actor filter prevents the bot's own pushes from looping.
+- `/aphelion-init` and `/aphelion-help` slash commands (#39 / #49)
+
+### Changed
+
+- `docs/design-notes/` (formerly `docs/issues/`) reorganised: 17 closed
+  planning documents moved into `docs/design-notes/archived/` so the active
+  directory only lists work in flight. Cross-references in active wiki / rule
+  files updated to the new paths. Inter-archive references kept as the
+  original relative paths (read-only policy).
+  `docs/design-notes/archived/README.md` documents the convention.
+- `docs/wiki/{en,ja}/Contributing.md`: new "Archiving closed planning docs"
+  subsection.
+- Renamed `docs/issues/` → `docs/design-notes/` and updated archive workflow
+  accordingly (#51 / #52)
+- Restructured `analyst` to absorb intake responsibilities; `/issue-new`
+  shortcut removed (#62 / #63, #66)
+- Shrank `analyst` scope to design-only — branch/PR/commit creation now
+  handled downstream by developer (#66)
+- Compressed `README.md` and `README.ja.md` (208/202 → 75 lines each),
+  deferring deep content to the wiki (#53 / #69)
+- Converted residual Japanese strings in agent-emitted document templates to
+  English (#57 / #68)
+
+### Removed
+
+- `/issue-new` slash command (replaced by enhanced `/analyst`) (#62 / #63)
+- `/pm` slash command (functionally identical to `/delivery-flow`) (#55 / #67)
+
+### Fixed
+
+- Committed orphan design notes for #53–#58 that were never `git add`-ed by
+  the legacy `/issue-new` (#61 / #64)
 
 ### Notes
 
@@ -44,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/aphelion-init` slash command that launches `rules-designer` for first-run
   project rules setup. Use immediately after `npx aphelion-agents init` to
   populate `.claude/rules/project-rules.md` interactively. (#39)
-- `/aphelion-help` slash command listing all 14 Aphelion slash commands grouped
+- `/aphelion-help` slash command listing all 13 Aphelion slash commands grouped
   by category (Orchestrators / Shortcuts / Standalone agents / Safety helpers /
   Discoverability). Static markdown table — Claude Code built-ins (`/init`,
   `/help`, `/clear`, `/agents`, etc.) are intentionally omitted; run `/help`

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Aphelion — Frontier AI Agents
 
-Claude Code 向け AI コーディングエージェント定義集です。29 の専門エージェントがプロジェクトの全工程を自動化します。
+Claude Code 向け AI コーディングエージェント定義集です。31 の専門エージェントがプロジェクトの全工程を自動化します。
 
 [![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.pages.dev-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.pages.dev/)
 
@@ -66,7 +66,7 @@ cd /path/to/your-project && claude
 - [Getting Started](docs/wiki/ja/Getting-Started.md) — 初回実行ウォークスルー、利用シナリオ、トラブルシューティング
 - [Architecture: Domain Model](docs/wiki/ja/Architecture-Domain-Model.md) — 3領域モデルとハンドオフファイル
 - [Triage System](docs/wiki/ja/Triage-System.md) — プランティアとエージェント選択
-- [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 29 エージェント
+- [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 31 エージェント
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aphelion — Frontier AI Agents
 
-A collection of AI coding agent definitions for Claude Code that automates the entire project lifecycle with 29 specialized agents.
+A collection of AI coding agent definitions for Claude Code that automates the entire project lifecycle with 31 specialized agents.
 
 [![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.pages.dev-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.pages.dev/)
 
@@ -66,7 +66,7 @@ All commands: run `/aphelion-help` after init, or see [Getting Started](docs/wik
 - [Getting Started](docs/wiki/en/Getting-Started.md) — first-run walkthrough, scenarios, troubleshooting
 - [Architecture: Domain Model](docs/wiki/en/Architecture-Domain-Model.md) — 3-domain model & handoff files
 - [Triage System](docs/wiki/en/Triage-System.md) — plan tiers & agent selection
-- [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 29 agents
+- [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 31 agents
 
 ---
 

--- a/docs/wiki/en/Getting-Started.md
+++ b/docs/wiki/en/Getting-Started.md
@@ -240,6 +240,11 @@ You can invoke any agent directly without a flow:
 | `/analyst {issue}` | Analyze bugs/features for existing projects | Projects with SPEC.md |
 | `/maintenance-flow {trigger}` | Maintenance triage and execution (Patch/Minor/Major) for existing project | Projects with SPEC.md + ARCHITECTURE.md |
 | `/codebase-analyzer {instruction}` | Reverse-engineer specs from existing code | Projects without SPEC.md |
+| `/reviewer` | Code review against SPEC.md and ARCHITECTURE.md | Projects with SPEC.md |
+| `/tester` | Run or generate tests against TEST_PLAN.md | Projects with TEST_PLAN.md |
+| `/rules-designer` | Generate or update `.claude/rules/project-rules.md` interactively | Any project |
+| `/secrets-scan` | Grep-based scan for hardcoded secrets in the repo | Any project |
+| `/vuln-scan` | Dependency vulnerability scan (tech-stack auto-detected) | Any project |
 
 > These commands are defined as slash commands in `.claude/commands/*.md` (Claude Code).
 > Run `/aphelion-help` for the canonical, always-up-to-date listing.

--- a/docs/wiki/en/Home.md
+++ b/docs/wiki/en/Home.md
@@ -19,7 +19,7 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 | Project overview and motivation | [Architecture: Domain Model](./Architecture-Domain-Model.md): 3-domain model and session isolation |
 | Quick Start commands | [Getting Started](./Getting-Started.md): Claude Code setup, first-run walkthrough, scenarios, troubleshooting |
 | Triage plan table (summary) | [Triage System](./Triage-System.md): selection logic, conditions, and agent matrices |
-| Agent list (names only) | Agents Reference (split by domain): [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — all 29 agents with inputs, outputs, NEXT conditions |
+| Agent list (names only) | Agents Reference (split by domain): [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — all 31 agents with inputs, outputs, NEXT conditions |
 | — | [Rules Reference](./Rules-Reference.md): 9 behavior rules with scope and customization notes |
 | — | [Contributing](./Contributing.md): how to add agents, rules, and maintain the wiki |
 
@@ -34,7 +34,7 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 | [Getting Started](./Getting-Started.md) | Claude Code setup, first run, usage scenarios, command reference | New users |
 | Architecture (3 pages) | [Domain Model](./Architecture-Domain-Model.md), [Protocols](./Architecture-Protocols.md), [Operational Rules](./Architecture-Operational-Rules.md) — 3-domain model, handoff files, AGENT_RESULT protocol, runtime rules | Agent developers |
 | [Triage System](./Triage-System.md) | 4-tier plan selection logic, per-domain agent matrices, mandatory agents | All users |
-| Agents Reference (5 pages) | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — all 29 agents | Agent developers |
+| Agents Reference (5 pages) | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — all 31 agents | Agent developers |
 | [Rules Reference](./Rules-Reference.md) | All 9 behavior rules: scope, auto-load, interactions | Agent developers |
 | [Contributing](./Contributing.md) | Adding agents, rules; bilingual sync workflow | Agent developers |
 

--- a/docs/wiki/ja/Getting-Started.md
+++ b/docs/wiki/ja/Getting-Started.md
@@ -227,6 +227,11 @@ Deliveryが完了した後（serviceプロジェクトの場合）：
 | `/analyst {issue}` | 既存プロジェクトのバグ・機能を分析 | SPEC.mdがあるプロジェクト |
 | `/maintenance-flow {トリガー}` | 既存プロジェクトの保守トリアージと実行 (Patch/Minor/Major) | SPEC.md + ARCHITECTURE.md があるプロジェクト |
 | `/codebase-analyzer {指示}` | 既存コードから仕様を逆生成 | SPEC.mdがないプロジェクト |
+| `/reviewer` | SPEC.md と ARCHITECTURE.md に基づくコードレビュー | SPEC.mdがあるプロジェクト |
+| `/tester` | TEST_PLAN.md に基づいてテストを実行または生成 | TEST_PLAN.mdがあるプロジェクト |
+| `/rules-designer` | `.claude/rules/project-rules.md` を対話的に生成・更新 | 任意のプロジェクト |
+| `/secrets-scan` | リポジトリ内のハードコードされたシークレットを grep で検出 | 任意のプロジェクト |
+| `/vuln-scan` | 依存関係の脆弱性スキャン（技術スタックを自動検出） | 任意のプロジェクト |
 
 > これらのコマンドは `.claude/commands/*.md` でスラッシュコマンドとして定義されています（Claude Code）。
 > 常に最新の一覧は `/aphelion-help` で確認できます。

--- a/docs/wiki/ja/Home.md
+++ b/docs/wiki/ja/Home.md
@@ -20,7 +20,7 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 | プロジェクト概要と背景 | [Architecture: Domain Model](./Architecture-Domain-Model.md): 3 ドメインモデルとセッション分離 |
 | クイックスタートコマンド | [Getting Started](./Getting-Started.md): Claude Code セットアップ、初回実行ウォークスルー、シナリオ、トラブルシューティング |
 | トリアージプラン表（概要） | [Triage System](./Triage-System.md): 選択ロジック、条件、エージェントマトリクス |
-| エージェント一覧（名前のみ） | Agents Reference（ドメイン別）: [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — 29 エージェントの入出力と NEXT 条件 |
+| エージェント一覧（名前のみ） | Agents Reference（ドメイン別）: [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — 31 エージェントの入出力と NEXT 条件 |
 | — | [Rules Reference](./Rules-Reference.md): 9 つの行動ルールのスコープとカスタマイズ方法 |
 | — | [Contributing](./Contributing.md): エージェント・ルールの追加方法、Wiki メンテナンス |
 
@@ -35,7 +35,7 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 | [Getting Started](./Getting-Started.md) | Claude Code セットアップ、初回実行、利用シナリオ、コマンドリファレンス | 新規ユーザー |
 | Architecture（3 ページ） | [Domain Model](./Architecture-Domain-Model.md), [Protocols](./Architecture-Protocols.md), [Operational Rules](./Architecture-Operational-Rules.md) — 3 ドメインモデル、ハンドオフファイル、`AGENT_RESULT` プロトコル、ランタイム挙動 | エージェント開発者 |
 | [Triage System](./Triage-System.md) | 4 ティアプラン選択ロジック、ドメイン別エージェントマトリクス、必須エージェント | 全ユーザー |
-| Agents Reference（5 ページ） | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — 29 エージェント全件 | エージェント開発者 |
+| Agents Reference（5 ページ） | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — 31 エージェント全件 | エージェント開発者 |
 | [Rules Reference](./Rules-Reference.md) | 9 つの行動ルール: スコープ・自動ロード・相互関係 | エージェント開発者 |
 | [Contributing](./Contributing.md) | エージェント・ルールの追加、バイリンガル同期ワークフロー | エージェント開発者 |
 


### PR DESCRIPTION
## Summary

- **MAJ-001**: Updated hardcoded agent count from 29 to 31 across README.md, README.ja.md, docs/wiki/en/Home.md, and docs/wiki/ja/Home.md. Verified with `ls .claude/agents/*.md | wc -l == 31`.
- **MAJ-003**: Updated `CHANGELOG.md` `[Unreleased]` section to reflect changes from #39/#49, #51/#52, #55/#62/#63/#66/#67, #61/#64, #53/#69, #57/#68. Fixed `14 slash commands` → `13 slash commands` in the 0.3.2 entry (reflecting `/pm` removal). Updated archive workflow path references from `docs/issues/archived/` to `docs/design-notes/archived/`.
- **MAJ-004**: Synced Command Reference table in `docs/wiki/en/Getting-Started.md` and `docs/wiki/ja/Getting-Started.md` with `aphelion-help.md`. Added 5 missing commands (`/reviewer`, `/tester`, `/rules-designer`, `/secrets-scan`, `/vuln-scan`). Both tables now list 13 commands, matching the canonical source.

## Test plan

- [x] \`grep -rn "29 agents\|29 specialized\|29 エージェント" README*.md docs/wiki/\` returns 0 results
- [x] \`grep -n "14 slash commands\|14 Aphelion" CHANGELOG.md\` returns 0 results
- [x] \`ls .claude/agents/*.md | wc -l\` returns 31
- [x] \`grep -E '^\| \`/[a-z-]' docs/wiki/en/Getting-Started.md | wc -l\` returns 13 (matches aphelion-help.md)

Found by main-branch consistency review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)