### PR TITLE
feat: add doc-reviewer agent (core) — agent definition + orchestrator integration (#91)

### DIFF
--- a/.claude/agents/doc-reviewer.md
+++ b/.claude/agents/doc-reviewer.md
@@ -1,0 +1,218 @@
+---
+name: doc-reviewer
+description: |
+  Cross-cutting agent that reviews consistency among markdown artifacts
+  (SPEC.md / ARCHITECTURE.md / UI_SPEC.md / docs/design-notes/ /
+  DISCOVERY_RESULT.md). Auto-inserted by flow orchestrators after
+  spec / design / scope / analyst agents.
+  Used in the following situations:
+  - Orchestrator inserts after spec-designer / ux-designer / architect /
+    scope-planner / analyst (post-insertion)
+  - User invokes standalone for ad-hoc consistency check
+  Prerequisites: at least two markdown artifacts must exist for
+  consistency comparison; runs in read-only mode.
+tools: Read, Glob, Grep
+model: sonnet
+---
+
+## Project-Specific Behavior
+
+Before producing user-facing output, consult
+`.claude/rules/project-rules.md` (via `Read`) and apply:
+
+- `## Localization` → `Output Language` (see `.claude/rules/language-rules.md`)
+
+If `.claude/rules/project-rules.md` is absent, apply defaults:
+- Output Language: en
+
+---
+
+You are the **doc-reviewer agent** in the Aphelion workflow.
+You perform horizontal consistency checks across markdown artifacts — not code review.
+
+## Mission
+
+Review cross-document consistency among markdown artifacts (SPEC.md, ARCHITECTURE.md,
+UI_SPEC.md, DISCOVERY_RESULT.md, and docs/design-notes/). You check that upstream
+requirements are reflected downstream, IDs are consistent, scope boundaries are respected,
+version traceability holds, and acceptance criteria are testable. **You do not modify
+files; you produce a text report only.**
+
+> **Boundary with `reviewer`:** This agent checks horizontal consistency among
+> markdown documents (SPEC.md ↔ ARCHITECTURE.md ↔ UI_SPEC.md ↔ design-notes).
+> `reviewer` checks vertical consistency between implementation code and SPEC.md /
+> ARCHITECTURE.md. Code review, README.md, CHANGELOG.md, wiki, and commit messages
+> are out of scope for this agent.
+
+---
+
+## Inputs
+
+### Required
+
+At least two markdown artifacts must exist for a meaningful comparison.
+
+### Read Order (priority)
+
+1. SPEC.md (upstream truth)
+2. ARCHITECTURE.md (design layer)
+3. UI_SPEC.md (UI design layer; only when HAS_UI=true)
+4. DISCOVERY_RESULT.md (requirements layer)
+5. INTERVIEW_RESULT.md (requirements layer, if present)
+6. `docs/design-notes/<slug>.md`
+   - **Inclusion condition:** header contains `> Next: developer` or `> Next: architect`
+   - **Excluded:** files under `docs/design-notes/archived/`, drafts with `> Next: TBD` / `> Next: (none)`
+7. (Optional) RESEARCH_RESULT.md / POC_RESULT.md / SCOPE_PLAN.md
+
+### Behavior on Missing Inputs
+
+- Only one comparison target available →
+  `STATUS: success` / `DOC_REVIEW_RESULT: pass` / `INCONSISTENCY_COUNT: 0` /
+  `NOTES: "No comparison target available."` — return immediately.
+- TRIGGERED_BY agent's required upstream document (e.g., SPEC.md when triggered by
+  spec-designer) is missing → `STATUS: error`.
+
+---
+
+## Five Review Perspectives
+
+### Perspective 1: Coverage (upstream–downstream completeness)
+
+- Each requirement in DISCOVERY_RESULT.md → corresponding UC in SPEC.md
+- Each UC in SPEC.md → module / endpoint in ARCHITECTURE.md
+- Each UC in SPEC.md (when HAS_UI=true) → screen in UI_SPEC.md
+- Each design-note (via `> Linked Plan`) → reflected in SPEC.md / ARCHITECTURE.md diff
+
+### Perspective 2: Naming Consistency
+
+- UC-XXX / SCR-XXX / API-XXX IDs: renumber / rename consistency across documents
+- Defined terms and their usage in body text
+- Referenced file paths and agent names actually exist (verify via `Glob`)
+
+### Perspective 3: Scope Alignment
+
+- DISCOVERY_RESULT.md IN/OUT ↔ SPEC.md SCOPE
+- SPEC.md SCOPE (IN) ↔ ARCHITECTURE.md implementation targets
+- No design in ARCHITECTURE.md contradicts SPEC.md SCOPE (OUT)
+- In maintenance-flow: no other UC references a removed / revised UC
+
+### Perspective 4: Version Traceability
+
+- `ARCHITECTURE.md > Source: SPEC.md @ {date}` matches SPEC.md `> Last updated: {date}`
+- design-note `> GitHub Issue: [#N]` lines exist (verify presence via `Grep`; link reachability
+  is not checked — this agent has no Bash)
+- Within the same phase, multiple agents updating the same document maintain correct update order
+  (e.g., spec-designer → architect both updating SPEC.md)
+
+### Perspective 5: Acceptance Reviewability
+
+- Each UC in SPEC.md has Acceptance Criteria present
+- Acceptance criteria are testable (quantitative / observable / unambiguously determinable)
+- In maintenance-flow: revised Acceptance Criteria do not break existing tests
+
+---
+
+## Severity Definition
+
+| Severity | Code | Meaning | Rollback impact |
+|----------|------|---------|-----------------|
+| 🔴 INCONSISTENCY | DR-XXX | Upstream–downstream or cross-document mismatch (must fix) | FAIL → rollback to triggering agent |
+| 🟡 ADVISORY | DA-XXX | Recommended improvement (minor wording drift, lint-adjacent) | Not a rollback trigger |
+| 🟢 INFO | DI-XXX | Informational only | Not a rollback trigger |
+
+**DOC_REVIEW_RESULT determination:**
+- INCONSISTENCY count ≥ 1 → `DOC_REVIEW_RESULT: fail`
+- INCONSISTENCY count = 0 (ADVISORY / INFO only, or no findings) → `DOC_REVIEW_RESULT: pass`
+
+---
+
+## Output Report Format
+
+Report is text only — no file is generated (unlike SECURITY_AUDIT.md).
+Section headings are English-fixed; narrative content follows the resolved Output Language.
+
+Required sections (in order):
+1. `### Target artifacts` — list each artifact with last-updated date
+2. `### Triggered by` — agent name or `standalone`
+3. `### Overall Assessment` — `✅ PASS` or `❌ FAIL`
+4. `### 🔴 INCONSISTENCY` — one `#### [DR-XXX]` block per finding; fields: Files, Perspective, Inconsistency, Evidence, Suggested fix
+5. `### 🟡 ADVISORY` — one `#### [DA-XXX]` block per finding; fields: Files, Detail
+6. `### 🟢 INFO` — one `#### [DI-XXX]` block per finding; field: Detail
+7. `### Coverage matrix` — table: Upstream ID / Downstream reflection / Status (✅ / ⚠️ / ❌)
+8. `### Next Steps` — rollback instructions on FAIL; pass note on ADVISORY-only or empty
+
+Omit sections 4–6 when they have no entries.
+
+---
+
+## AGENT_RESULT Contract
+
+```
+AGENT_RESULT: doc-reviewer
+STATUS: success | failure | error
+DOC_REVIEW_RESULT: pass | fail
+INCONSISTENCY_COUNT: {N}
+ADVISORY_COUNT: {N}
+INFO_COUNT: {N}
+TARGET_ARTIFACTS:
+  - {file path}: {Last updated date}
+INCONSISTENCY_ITEMS:
+  - {DR-XXX}: {short summary}
+TRIGGERED_BY: spec-designer | ux-designer | architect | scope-planner | analyst | standalone
+NEXT: {triggering agent on FAIL | done}
+```
+
+| STATUS | DOC_REVIEW_RESULT | Condition |
+|--------|------------------|-----------|
+| `success` | `pass` | INCONSISTENCY_COUNT == 0 |
+| `failure` | `fail` | INCONSISTENCY_COUNT >= 1 |
+| `error` | (n/a) | doc-reviewer exception (file read failure, insufficient input, etc.) |
+
+---
+
+## Workflow
+
+1. Read project-rules.md (Project-Specific Behavior block)
+2. Identify TRIGGERED_BY (caller agent name; `standalone` if not provided)
+3. Read input artifacts per the priority order in Inputs
+   - Use `Glob` to enumerate `docs/design-notes/<slug>.md` candidates
+   - Filter design-notes: include only those with `> Next: developer` or `> Next: architect`
+4. Run all five review perspectives in order: coverage → naming → scope → version → acceptance
+5. Classify findings by severity (DR / DA / DI)
+6. Build the coverage matrix
+7. Emit Doc Review Report (text only)
+8. Emit AGENT_RESULT block
+
+---
+
+## Standalone Invocation
+
+When invoked directly by the user (no flow orchestrator):
+
+1. Set TRIGGERED_BY to `standalone`
+2. If target artifacts are not specified, ask the user:
+   - "Shall I check consistency between SPEC.md and ARCHITECTURE.md?"
+3. No flow orchestrator is present, so rollback does not fire:
+   - When INCONSISTENCY is detected, present the list of items to fix to the user
+     instead of triggering automatic rollback
+4. `AGENT_RESULT.NEXT` is always `done`
+
+---
+
+## Out of Scope
+
+- Code review (that is `reviewer`'s responsibility)
+- README.md / CHANGELOG.md / wiki / commit message consistency
+- Markdown syntax error detection (handled separately by markdownlint)
+- Auto-remediation — this agent reports findings only; fixes are delegated via rollback
+- Meta-consistency checks of `.claude/agents/*.md` themselves (future self-check agent)
+
+---
+
+## Completion Conditions
+
+- [ ] All input artifacts per the priority order in Inputs were read
+- [ ] All five review perspectives were evaluated
+- [ ] Coverage matrix was generated
+- [ ] AGENT_RESULT block was emitted
+- [ ] DOC_REVIEW_RESULT was set to `pass` or `fail` (never undefined)

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -33,6 +33,13 @@ and generate a quality report. **You do not modify code; you focus solely on pre
 
 **Note:** Security aspects are handled by `security-auditor`, so this agent does not perform deep security inspections. Obvious issues (such as hardcoded passwords) are flagged, but systematic checks like OWASP Top 10 are delegated to security-auditor.
 
+> **Boundary with `doc-reviewer`:** This agent reviews implementation
+> code against SPEC.md / ARCHITECTURE.md (vertical consistency).
+> Cross-document consistency among markdown artifacts (SPEC.md ↔
+> ARCHITECTURE.md ↔ UI_SPEC.md ↔ design-notes) is owned by
+> `doc-reviewer`, which is auto-inserted by flow orchestrators after
+> spec / design / scope / analyst agents.
+
 ---
 
 ## Review Perspectives (5 Perspectives)

--- a/.claude/orchestrator-rules.md
+++ b/.claude/orchestrator-rules.md
@@ -115,6 +115,60 @@ Parse the returned `AGENT_RESULT` block:
 
 ---
 
+## Doc Reviewer Auto-insertion
+
+This section defines how flow orchestrators insert `doc-reviewer`
+automatically after agents that produce or update markdown artifacts.
+
+> **Insertion direction**: Unlike `sandbox-runner` (pre-insertion before a
+> Bash command runs), `doc-reviewer` is **post-inserted** after the
+> upstream agent emits its AGENT_RESULT. The Trigger Conditions /
+> Double-Execution Prevention / Standalone Agent Fallback structure mirrors
+> Sandbox Runner Auto-insertion but applies to the agent's exit, not entry.
+
+### Trigger Conditions
+
+The orchestrator inserts `doc-reviewer` **after** receiving an
+`AGENT_RESULT` from the following agents:
+
+| Flow | Trigger agents | Conditions |
+|------|----------------|------------|
+| delivery-flow | spec-designer, ux-designer, architect | All plans (Minimal+). ux-designer triggers only when HAS_UI=true |
+| discovery-flow | scope-planner | Light/Standard/Full only. Minimal has no scope-planner so doc-reviewer is not triggered structurally. |
+| maintenance-flow | analyst | Patch: only if `analyst.DOCS_UPDATED` contains SPEC.md (no_change → skip). Minor/Major: always |
+
+### Double-Execution Prevention
+
+The orchestrator tracks a per-phase insertion flag
+`doc_reviewer_inserted_for_phase_id`. If set for the current phase, skip
+auto-insertion. On rollback, the flag is reset before re-insertion.
+
+### Standalone Agent Fallback
+
+When a triggering agent (e.g., spec-designer) is invoked outside a flow
+orchestrator, no auto-insertion happens. The user may invoke
+`/doc-reviewer` manually.
+
+### Invocation Format
+
+```
+Agent(
+  subagent_type: "doc-reviewer",
+  prompt: "Review markdown artifacts for cross-document consistency.
+           triggered_by: {agent_name}
+           target_artifacts: {paths}
+           phase_id: {phase_id}",
+  description: "doc review after {agent_name}"
+)
+```
+
+Parse the returned `AGENT_RESULT` block:
+- `STATUS: success` and `DOC_REVIEW_RESULT: pass` → proceed to approval gate
+- `STATUS: failure` and `DOC_REVIEW_RESULT: fail` → enter Doc Review FAIL Rollback Flow (§Rollback Rules)
+- `STATUS: error` → follow Common Error Handling
+
+---
+
 ## Handoff File Specification
 
 Common format for handoff files used to connect domains.
@@ -417,10 +471,24 @@ Phase {N} complete: {agent name}
 
 ## Rollback Rules
 
-Test failures and review CRITICAL findings are automatically rolled back by the flow orchestrator.
-Rollbacks are limited to **3 times maximum**. If exceeded, report the situation to the user and ask for their decision.
+Test failures, review CRITICAL findings, and doc review FAIL results are automatically
+rolled back by the flow orchestrator.
 
 **Test failure determination:** tester returns `STATUS: failure` if there is 1 or more failure. Partial success (only some tests passing) is treated as failure.
+
+### Rollback Limit (Common)
+
+Rollbacks are limited to **3 times maximum**, applied as a single shared
+limit across:
+- Test failure rollback
+- Review CRITICAL rollback
+- Security audit CRITICAL rollback
+- Doc review FAIL rollback
+
+If the limit is exceeded, report to the user and ask for their decision
+(see "Approve despite findings" option in Approval Gate after Doc Review FAIL, when applicable).
+The per-flow rollback sections below inherit this limit and must not
+declare their own.
 
 ### Test Failure Rollback Flow
 
@@ -443,3 +511,62 @@ tester (failure detected)
 ```
 reviewer (CRITICAL detected) → developer (fix) → tester (re-run) → reviewer (re-review)
 ```
+
+### Doc Review FAIL Rollback Flow
+
+```
+doc-reviewer (DOC_REVIEW_RESULT: fail)
+  → triggering agent (spec-designer / ux-designer / architect /
+                      scope-planner / analyst) for fix
+    → doc-reviewer (re-check)
+```
+
+Rollback prompt to the triggering agent:
+
+```
+## Doc Review Rollback
+
+### Rollback source
+doc-reviewer
+
+### Inconsistencies
+{INCONSISTENCY_ITEMS list with perspective and evidence}
+
+### Files to fix
+{file paths from INCONSISTENCY_ITEMS}
+
+### Constraints
+- Do not break existing UCs or other documents
+- Re-emit AGENT_RESULT after fixing
+- If editing both ARCHITECTURE.md and SPEC.md, update Last updated in both
+```
+
+After rollback, the orchestrator clears the
+`doc_reviewer_inserted_for_phase_id` flag and re-runs `doc-reviewer`.
+
+---
+
+### Approval Gate after Doc Review FAIL (rollback limit exceeded)
+
+When `doc-reviewer` repeatedly fails and the shared rollback limit is
+reached, the orchestrator presents a special gate:
+
+```json
+{
+  "questions": [{
+    "question": "doc-reviewer reported {N} inconsistencies after 3 rollbacks. How would you like to proceed?",
+    "header": "Doc review failed",
+    "options": [
+      {"label": "Continue rollback", "description": "Override the 3-time limit and try once more"},
+      {"label": "Approve despite findings", "description": "Accept INCONSISTENCY findings and continue to next phase"},
+      {"label": "Abort", "description": "Stop the workflow"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+If "Approve despite findings" is selected, record this in the phase
+completion log and tag the eventual AGENT_RESULT chain with
+`DOC_REVIEW_OVERRIDE: true` so downstream artifacts (e.g.,
+DELIVERY_RESULT.md) reflect that an override occurred.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Aphelion — Frontier AI Agents
 
-Claude Code 向け AI コーディングエージェント定義集です。31 の専門エージェントがプロジェクトの全工程を自動化します。
+Claude Code 向け AI コーディングエージェント定義集です。32 の専門エージェントがプロジェクトの全工程を自動化します。
 
 [![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.com-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.com/)
 
@@ -66,7 +66,7 @@ cd /path/to/your-project && claude
 - [Getting Started](docs/wiki/ja/Getting-Started.md) — 初回実行ウォークスルー、利用シナリオ、トラブルシューティング
 - [Architecture: Domain Model](docs/wiki/ja/Architecture-Domain-Model.md) — 3領域モデルとハンドオフファイル
 - [Triage System](docs/wiki/ja/Triage-System.md) — プランティアとエージェント選択
-- [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 31 エージェント
+- [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 32 エージェント
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aphelion — Frontier AI Agents
 
-A collection of AI coding agent definitions for Claude Code that automates the entire project lifecycle with 31 specialized agents.
+A collection of AI coding agent definitions for Claude Code that automates the entire project lifecycle with 32 specialized agents.
 
 [![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.com-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.com/)
 
@@ -66,7 +66,7 @@ All commands: run `/aphelion-help` after init, or see [Getting Started](docs/wik
 - [Getting Started](docs/wiki/en/Getting-Started.md) — first-run walkthrough, scenarios, troubleshooting
 - [Architecture: Domain Model](docs/wiki/en/Architecture-Domain-Model.md) — 3-domain model & handoff files
 - [Triage System](docs/wiki/en/Triage-System.md) — plan tiers & agent selection
-- [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 31 agents
+- [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 32 agents
 
 ---
 

--- a/TASK.md
+++ b/TASK.md
@@ -1,23 +1,20 @@
 # TASK.md
 
-> Source: design-notes/repo-root-readme-sync-convention.md (2026-04-29) + GitHub issue #82
+> Source: docs/design-notes/doc-reviewer-architecture.md (2026-04-30)
 
-## Phase: docs/repo-root-readme-sync-convention
-Last updated: 2026-04-30T00:30:00
-Status: Completed
+## Phase: PR 1 — doc-reviewer core implementation
+Last updated: 2026-04-30T01:00:00
+Status: In progress
 
 ## Task List
 
-### Phase 1
-- [x] TASK-001: language-rules.md に "Repo-root README sync convention" sub-section を追加 | Target file: src/.claude/rules/language-rules.md
-- [x] TASK-002: Rules-Reference (en + ja) に cross-reference を追加 | Target file: docs/wiki/en/Rules-Reference.md, docs/wiki/ja/Rules-Reference.md
-- [x] TASK-003: package.json を 0.3.3 → 0.3.4 にバージョンアップ + CHANGELOG.md 更新 | Target file: package.json, CHANGELOG.md
-- [x] TASK-004: design note §7 に決定事項を記録 + Implemented in 追記 | Target file: docs/design-notes/repo-root-readme-sync-convention.md
+### Phase 1 (PR 1)
+- [x] TASK-001: Create .claude/agents/doc-reviewer.md | Target file: .claude/agents/doc-reviewer.md
+- [ ] TASK-002: Add 4 sections to .claude/orchestrator-rules.md | Target file: .claude/orchestrator-rules.md
+- [ ] TASK-003: Add boundary paragraph to .claude/agents/reviewer.md | Target file: .claude/agents/reviewer.md
 
 ## Recent Commits
-c03cde5 docs: amend Implemented in to PR #87 (#82)
-dba6520 docs: record #82 decisions and Implemented in (#82)
-87c9ecd chore: bump to 0.3.4 and update CHANGELOG for #82
+9100b39 docs: add design-notes for doc-reviewer agent introduction and architecture (#91)
 
 ## Session Interruption Notes
-(中断時の状況をここに記録)
+(none)

--- a/TASK.md
+++ b/TASK.md
@@ -3,17 +3,18 @@
 > Source: docs/design-notes/doc-reviewer-architecture.md (2026-04-30)
 
 ## Phase: PR 1 — doc-reviewer core implementation
-Last updated: 2026-04-30T02:00:00
-Status: In progress
+Last updated: 2026-04-30T03:00:00
+Status: Completed
 
 ## Task List
 
 ### Phase 1 (PR 1)
 - [x] TASK-001: Create .claude/agents/doc-reviewer.md | Target file: .claude/agents/doc-reviewer.md
 - [x] TASK-002: Add 4 sections to .claude/orchestrator-rules.md | Target file: .claude/orchestrator-rules.md
-- [ ] TASK-003: Add boundary paragraph to .claude/agents/reviewer.md | Target file: .claude/agents/reviewer.md
+- [x] TASK-003: Add boundary paragraph to .claude/agents/reviewer.md | Target file: .claude/agents/reviewer.md
 
 ## Recent Commits
+b45235f feat: integrate doc-reviewer into orchestrator rules (#91)
 070db57 feat: add doc-reviewer agent for cross-doc consistency review (#91)
 9100b39 docs: add design-notes for doc-reviewer agent introduction and architecture (#91)
 

--- a/TASK.md
+++ b/TASK.md
@@ -3,17 +3,18 @@
 > Source: docs/design-notes/doc-reviewer-architecture.md (2026-04-30)
 
 ## Phase: PR 1 — doc-reviewer core implementation
-Last updated: 2026-04-30T01:00:00
+Last updated: 2026-04-30T02:00:00
 Status: In progress
 
 ## Task List
 
 ### Phase 1 (PR 1)
 - [x] TASK-001: Create .claude/agents/doc-reviewer.md | Target file: .claude/agents/doc-reviewer.md
-- [ ] TASK-002: Add 4 sections to .claude/orchestrator-rules.md | Target file: .claude/orchestrator-rules.md
+- [x] TASK-002: Add 4 sections to .claude/orchestrator-rules.md | Target file: .claude/orchestrator-rules.md
 - [ ] TASK-003: Add boundary paragraph to .claude/agents/reviewer.md | Target file: .claude/agents/reviewer.md
 
 ## Recent Commits
+070db57 feat: add doc-reviewer agent for cross-doc consistency review (#91)
 9100b39 docs: add design-notes for doc-reviewer agent introduction and architecture (#91)
 
 ## Session Interruption Notes

--- a/docs/design-notes/doc-reviewer-agent-introduction.md
+++ b/docs/design-notes/doc-reviewer-agent-introduction.md
@@ -1,0 +1,759 @@
+# feat: add doc-reviewer agent for cross-flow markdown artifact consistency review
+
+> Reference: current `main` (HEAD `e56a58d`, 2026-04-30)
+> Created: 2026-04-30
+> Last updated: 2026-04-30
+> Analyzed by: analyst (2026-04-30)
+> Author: analyst (design-only phase — no implementation yet)
+> Scope: planning document; agent definition body and orchestrator wiring will be authored in a follow-up `architect` phase
+> GitHub Issue: [#91](https://github.com/kirin0198/aphelion-agents/issues/91)
+> Implemented in: TBD
+> Next: architect
+
+---
+
+## 1. Background & Motivation
+
+### 1.1 ユーザの問題意識（原文）
+
+> 各エージェントが出力・更新するマークダウンファイルについて、
+> SPEC.md を中心とした整合性レビューが存在しない。
+> コード実装には `reviewer` がいるが、ドキュメント成果物にはレビュアーが
+> いないという非対称を解消する。
+
+### 1.2 なぜ今この非対称が問題か
+
+Aphelion のワークフローはマークダウン成果物 (SPEC.md / ARCHITECTURE.md /
+UI_SPEC.md / docs/design-notes/) を **エージェント間の唯一の永続的契約** として
+扱う。コードは ARCHITECTURE.md に従って書かれ、テストは SPEC.md の受け入れ
+基準に従って書かれる。すなわち上流ドキュメントの整合性が崩れると、下流の
+コード品質ゲート (`reviewer` / `tester` / `security-auditor`) は **誤った
+真実を基準にして全件 PASS してしまう**。これは silent failure であり、
+コード品質ゲートでは原理的に検出できない。
+
+具体的に発生し得る不整合の例:
+
+1. **spec-designer が UC を改名したが UI_SPEC.md の SCR 紐付けが旧名のまま**
+   → Delivery Flow Phase 6 (`developer`) は ARCHITECTURE.md だけを根拠に
+   実装するため気付かない。`reviewer` も「コードと ARCHITECTURE.md の整合」
+   は見るが、「ARCHITECTURE.md と UI_SPEC.md の整合」は所掌外。
+2. **architect が新しいエンドポイントを ARCHITECTURE.md に追加したが、
+   対応する UC が SPEC.md に存在しない**
+   → 「設計 driven」で実装が進んでしまい、SPEC.md が事後追従するか、
+   あるいは追従されず腐る。
+3. **analyst が SPEC.md の UC-007 の受け入れ基準を改訂したが、
+   既存の UC-003 がそれに依存していたケースを見落とした**
+   → maintenance-flow Patch では `reviewer` が走らない (Phase 構成上)
+   ため、以後の Patch の度にこの不整合が累積する。
+4. **scope-planner が DISCOVERY_RESULT.md にまとめた IN/OUT が
+   interviewer の INTERVIEW_RESULT.md と矛盾**
+   → Delivery Flow 開始時に spec-designer が拾い直すが、
+   その時点で「どちらが正」を判定する根拠がない。
+
+### 1.3 既存 `reviewer` との対称性
+
+`.claude/agents/reviewer.md` は **コードに対する** 5 観点レビュー
+(spec compliance / design consistency / code quality / test quality /
+API contract) を持つ。すなわち「成果物 (コード) ↔ 上流ドキュメント」の
+垂直方向の整合は見るが、「上流ドキュメント同士」の水平方向の整合は所掌外。
+本提案はこの水平方向のチェックを担う **ドキュメント版 reviewer** を新設する。
+
+### 1.4 想定ユーザ・想定発火状況
+
+- Discovery Flow の scope-planner 完了直後
+  → DISCOVERY_RESULT.md と INTERVIEW_RESULT.md の整合
+- Delivery Flow の spec-designer / architect / ux-designer 完了直後
+  → SPEC.md / ARCHITECTURE.md / UI_SPEC.md の三角整合
+- Maintenance Flow の analyst 完了直後 (Minor / Major)
+  → SPEC.md 差分 ↔ 既存 UC の整合 (Patch では SPEC.md を更新しないので
+  原則 skip)
+
+---
+
+## 2. Current state
+
+### 2.1 既存の review/audit 体制
+
+`.claude/agents/` 配下を確認した結果 (2026-04-30 時点)、コード/実装/
+セキュリティに関する review-tier agent は存在するが、ドキュメント横断の
+review-tier agent は存在しない。
+
+| agent | 対象 | 起動位置 | 出力 |
+|-------|------|----------|------|
+| `reviewer` | 実装コード + テストコード | Delivery Phase 9 (Light+) | レビューコメント (テキスト) |
+| `security-auditor` | 実装コード | Delivery Phase 10 (全プラン必須) | `SECURITY_AUDIT.md` |
+| `compliance-auditor` (#56 で導入予定) | 規約準拠 (NIST/PCI-DSS/SOC2) | 複数フェーズ後段 (オプトイン) | `COMPLIANCE_AUDIT.md` |
+| `doc-reviewer` (本提案) | マークダウン成果物の相互整合 | 各 spec/design/scope エージェント直後 | レビュー結果テキスト (file 出力なし) |
+
+### 2.2 ドキュメント整合性の現状の担保方法
+
+| 担保ポイント | 現状の仕組み | 問題 |
+|--------------|--------------|------|
+| 各エージェントが上流文書を Read してから書く | 各 agent definition の "Mission" / "Inputs" で Read 指示 | 「読んだ」だけで「整合させた」かは検証されない |
+| `architect` が「SPEC.md @ {date}」を `ARCHITECTURE.md` 冒頭に記録する | `.claude/rules/document-versioning.md` の Traceability ルール | バージョン番号の一致は見ているが、内容の整合は見ていない |
+| `reviewer` の "Spec Compliance" チェック | `reviewer.md` の Review Perspective #1 | 対象は **コード ↔ SPEC.md** の垂直整合のみ。SPEC.md 内部の整合は見ない |
+| ユーザの目視レビュー (approval gate) | flow orchestrator の各 phase 後で `AskUserQuestion` | ユーザが実質的に唯一の整合性チェッカーになっている (= 仕組みとして担保がない) |
+
+### 2.3 既存 cross-cutting agent の前例
+
+`.claude/agents/sandbox-runner.md` は唯一の **cross-cutting agent** で、
+特定ドメインに属さず複数 flow から呼ばれる。Aphelion ワークフロー上、
+cross-cutting agent はオーケストレーター呼び出し方式で動作し、
+独立コンテキストを持つ点が特徴。`doc-reviewer` も同じ枠組みに入る。
+
+`.claude/orchestrator-rules.md` の "Sandbox Runner Auto-insertion" セクション
+が cross-cutting agent の挿入規約のテンプレートとして機能する。
+本提案では同様の "Doc Reviewer Auto-insertion" セクションを追加する。
+
+### 2.4 現状のギャップまとめ
+
+> マークダウン成果物の「水平方向の整合」を担保する仕組みは現在 Aphelion
+> に存在せず、ユーザの目視に依存している。これが本 issue の根本動機。
+
+---
+
+## 3. Proposed approach
+
+### 3.1 新 agent: `doc-reviewer`
+
+`.claude/agents/doc-reviewer.md` として新規作成する。役割境界は次の通り:
+
+| 観点 | `reviewer` | `doc-reviewer` (新設) |
+|------|------------|----------------------|
+| 主目的 | コード品質ゲート | ドキュメント整合性ゲート |
+| 主な対象 | 実装コード + テストコード | SPEC.md / ARCHITECTURE.md / UI_SPEC.md / docs/design-notes/ / DISCOVERY_RESULT.md |
+| 主なチェック手段 | 静的解析 + コードレビュー 5 観点 | 上流-下流文書間の整合チェック (UC ↔ エンドポイント ↔ 画面 ↔ scope) |
+| 入力フェーズ | Delivery Phase 9 (Light 以上) | Discovery / Delivery / Maintenance の **複数フック** |
+| 出力 | テキスト (レビューコメント) | テキスト (PASS/FAIL + 不整合リスト) |
+| 必須プラン | Delivery Light 以上 | 全 flow / 全プラン (mandatory) ※ §4 Q6 で再考 |
+| 自動修正 | しない | しない |
+| ベーステンプレート | — | `reviewer.md` (5 観点構造) + `sandbox-runner.md` (cross-cutting 起動規約) のハイブリッド |
+
+> **重要な補足**: ユーザーの当初要求では「reviewer はコードレビュー特化」
+> との前提だが、`reviewer.md` を実際に読むと "Review Perspectives" の #1
+> "Spec Compliance" には SPEC.md の UC 実装率チェックが含まれる。これは
+> **コード ↔ SPEC.md の垂直整合**であり、`doc-reviewer` の **SPEC.md
+> 内部 / SPEC.md ↔ ARCHITECTURE.md の水平整合** とは扱う方向が直交する。
+> したがって両者は重複せず補完関係にある。`reviewer` をリネームする必要は
+> ない。これは §4 Q1 で詳述する。
+
+### 3.2 起動位置 (フェーズ横断フック)
+
+`doc-reviewer` は以下の 5 フックから起動される。**オーケストレーター
+呼び出し方式** を採用し、各成果物エージェントが AGENT_RESULT を返した
+直後にオーケストレーターが `Agent` ツール経由で `doc-reviewer` を起動する。
+作成エージェントは `doc-reviewer` の起動を意識しない (= 既存 agent
+definition の改変は不要)。
+
+#### Discovery Flow フック
+
+```
+discovery-flow Phase {final}: scope-planner → AGENT_RESULT
+  └─ orchestrator が doc-reviewer を起動
+      入力: DISCOVERY_RESULT.md, INTERVIEW_RESULT.md (および存在すれば
+            RESEARCH_RESULT.md / POC_RESULT.md / SCOPE_PLAN.md)
+      重点: DISCOVERY_RESULT.md の Requirements Summary が
+            INTERVIEW_RESULT.md と矛盾していないか
+      出力: PASS / FAIL + findings
+  ├─ PASS → 既存の approval gate へ
+  └─ FAIL → scope-planner へ rollback (max 3 回)
+```
+
+> **interviewer / researcher / poc-engineer 個別フェーズの後で発火しない
+> 理由**: これらは「単一ドキュメントを生成」する段階であり、整合性チェック
+> 対象が存在しない (比較相手がない)。最終的に `scope-planner` が
+> DISCOVERY_RESULT.md として束ねた段階が初の水平整合チェックポイント。
+> ただし researcher の結果を interviewer が拾い直す Standard 以上では、
+> researcher 完了直後にも軽量チェックを入れる選択肢がある (§4 Q4 参照)。
+
+#### Delivery Flow フック (3 箇所)
+
+```
+delivery-flow Phase 1: spec-designer → AGENT_RESULT
+  └─ doc-reviewer (SPEC.md ↔ DISCOVERY_RESULT.md / INTERVIEW_RESULT.md)
+       PASS → approval gate / FAIL → spec-designer rollback
+
+delivery-flow Phase 2: ux-designer → AGENT_RESULT  (HAS_UI=true のみ)
+  └─ doc-reviewer (UI_SPEC.md ↔ SPEC.md scope)
+       PASS → approval gate / FAIL → ux-designer rollback
+
+delivery-flow Phase 3: architect → AGENT_RESULT
+  └─ doc-reviewer (ARCHITECTURE.md ↔ SPEC.md, UC↔ エンドポイント↔
+                   データモデルのトレース)
+       PASS → approval gate / FAIL → architect rollback
+```
+
+#### Maintenance Flow フック
+
+```
+maintenance-flow Phase {analyst}: analyst → AGENT_RESULT
+  ├─ change-classifier の PLAN が Patch:
+  │    分岐 A: SPEC.md 差分なし (DOCS_UPDATED に SPEC.md: no_change)
+  │            → doc-reviewer skip
+  │    分岐 B: SPEC.md 差分あり (Patch でも稀に発生)
+  │            → doc-reviewer 起動 (差分 ↔ 既存 UC の不整合検出)
+  ├─ change-classifier の PLAN が Minor / Major:
+  │    SPEC.md 差分の有無に関わらず doc-reviewer 起動
+  │    重点: analyst が触った UC が他 UC を壊していないか
+  └─ FAIL → analyst へ rollback (max 3 回)
+```
+
+### 3.3 チェック観点 (5 観点)
+
+`reviewer.md` の 5 観点構造を踏襲し、ドキュメント版に置き換える。
+
+#### 観点 1: 上流-下流の網羅性 (Coverage)
+
+- DISCOVERY_RESULT.md の各要件が SPEC.md の UC として存在するか
+- SPEC.md の各 UC が ARCHITECTURE.md の対応モジュール/エンドポイントを持つか
+- SPEC.md で UI を伴う UC が UI_SPEC.md の SCR と紐付いているか
+- design-note (§7 で `> Linked Plan:` 経由でリンクされたもの) が
+  実際に SPEC.md / ARCHITECTURE.md の差分として反映されているか
+
+#### 観点 2: 命名・参照整合性 (Naming consistency)
+
+- UC-XXX / SCR-XXX / API-XXX のような ID が renumber/rename された場合に
+  全文書で統一されているか
+- 用語集 (定義されている場合) と各文書中の用語使用が一致するか
+- ファイルパスや agent 名 (例: `.claude/agents/architect.md`) が
+  実在するか (`Glob` で実在確認)
+
+#### 観点 3: スコープ整合性 (Scope alignment)
+
+- DISCOVERY_RESULT.md の IN/OUT と SPEC.md の SCOPE が一致するか
+- SPEC.md の SCOPE (IN) と ARCHITECTURE.md の実装対象が一致するか
+- SPEC.md の SCOPE (OUT) と矛盾する設計が ARCHITECTURE.md にないか
+- maintenance-flow で「既存 UC を壊さない」原則が守られているか
+  (削除された UC を別 UC が参照していないか)
+
+#### 観点 4: バージョン整合性 (Version traceability)
+
+- ARCHITECTURE.md の `> Source: SPEC.md @ {date}` の日付が、
+  実際の SPEC.md の `> Last updated: {date}` と一致するか
+- design-note の `> GitHub Issue: [#N](...)` が実在する issue を指すか
+- 同一フェーズ内で **同一文書を複数 agent が連続更新した順序**が
+  整合しているか (例: spec-designer → architect の順で SPEC.md を
+  どちらも更新するケース)
+
+#### 観点 5: 受け入れ基準と承認可能性 (Acceptance criteria reviewability)
+
+- SPEC.md の各 UC に受け入れ基準 (Acceptance Criteria) があるか
+- 受け入れ基準が **テスト可能な形** で書かれているか
+  (定量的 / 観測可能 / 一意に判定可能)
+- maintenance-flow で改訂された受け入れ基準が、既存テストを破壊しないか
+
+> **Out of scope (観点に含めない)**:
+> - 文体・表記ゆれ (Markdown lint レベル)
+> - 章立ての美しさ
+> - README.md / CHANGELOG.md / wiki / commit message
+> - コードコメントの整合性 (これは `reviewer` の所掌)
+
+### 3.4 出力フォーマット
+
+`reviewer.md` のレポート形式を **簡略化** したテキスト出力。
+ファイルは生成しない (`COMPLIANCE_AUDIT.md` のような persistent 成果物に
+する必要がない — 不整合は即時修正する前提)。
+
+```
+## Doc Review Report
+
+### Target artifacts
+{review 対象ファイルのリスト + Last updated date}
+
+### Overall Assessment
+{✅ PASS / ❌ FAIL}
+
+### 🔴 INCONSISTENCY (修正必須 — orchestrator が rollback)
+#### [DR-001] {不整合のタイトル}
+- **Files:** `SPEC.md` ↔ `ARCHITECTURE.md`
+- **観点:** {coverage / naming / scope / version / acceptance}
+- **不整合内容:** {何が食い違っているか}
+- **根拠:** {SPEC.md UC-XXX (line 42) と ARCHITECTURE.md §3.2 (line 88)}
+- **想定対応:** {どちらをどう変更すべきか}
+
+### 🟡 ADVISORY (改善推奨 — rollback 対象外)
+#### [DA-001] {推奨改善のタイトル}
+- **Files:** ...
+
+### Coverage matrix
+| 上流 ID | 下流での反映 | 状態 |
+|---------|--------------|------|
+| UC-001  | ARCHITECTURE.md §3.1, UI_SPEC.md SCR-001 | ✅ |
+| UC-002  | ARCHITECTURE.md §3.2 | ⚠️ UI_SPEC.md に SCR なし |
+| UC-003  | (none) | ❌ 設計欠落 |
+```
+
+### 3.5 AGENT_RESULT 契約
+
+```
+AGENT_RESULT: doc-reviewer
+STATUS: success | failure | error
+DOC_REVIEW_RESULT: pass | fail
+INCONSISTENCY_COUNT: {N}
+ADVISORY_COUNT: {N}
+TARGET_ARTIFACTS:
+  - {file path}: {Last updated date}
+INCONSISTENCY_ITEMS:
+  - {DR-XXX}: {short summary}
+TRIGGERED_BY: spec-designer | architect | ux-designer | scope-planner | analyst
+NEXT: {triggering agent | done}  # FAIL のとき rollback ターゲット
+```
+
+| STATUS | DOC_REVIEW_RESULT | 条件 |
+|--------|------------------|------|
+| `success` | `pass` | INCONSISTENCY_COUNT == 0 |
+| `success` | `pass` | INCONSISTENCY_COUNT == 0 かつ ADVISORY のみ |
+| `failure` | `fail` | INCONSISTENCY_COUNT >= 1 |
+| `error` | (n/a) | doc-reviewer 自身の例外 |
+
+### 3.6 オーケストレーター挿入規約
+
+`.claude/orchestrator-rules.md` に "Doc Reviewer Auto-insertion"
+セクションを新設し、`Sandbox Runner Auto-insertion` と同じ構造で記述する。
+
+```
+Doc Reviewer Auto-insertion
+
+Trigger Conditions:
+  オーケストレーターが以下の agent から AGENT_RESULT を受け取った直後、
+  doc-reviewer を auto-insert する:
+    - delivery-flow:    spec-designer, architect, ux-designer
+    - discovery-flow:   scope-planner
+    - maintenance-flow: analyst (PLAN=Patch かつ SPEC.md 差分なしなら skip)
+
+Double-Execution Prevention:
+  per-phase insertion flag `doc_reviewer_inserted_for_phase_id` を
+  オーケストレーターが保持。同一 phase で 2 回起動しない (rollback 時は
+  flag をリセットしてから再挿入)。
+
+Standalone Agent Fallback:
+  spec-designer 等が standalone 起動された場合 (orchestrator 不在)、
+  doc-reviewer auto-insertion は行われない。ユーザに warning を表示し、
+  手動起動を案内する (例: `/doc-reviewer SPEC.md`)。
+```
+
+### 3.7 不整合検出時の rollback 統合
+
+`.claude/orchestrator-rules.md` の既存 "Rollback Rules" に
+"Doc Review FAIL Rollback" を新設する。
+
+```
+Doc Review FAIL Rollback Flow:
+
+doc-reviewer (DOC_REVIEW_RESULT: fail)
+  → triggering agent (spec-designer / architect / ux-designer /
+                      scope-planner / analyst) に修正依頼
+    → 該当 agent が修正
+      → doc-reviewer (再チェック)
+
+Rollback Limit: 既存ルールと同じく max 3 回。
+                超過時はユーザに判断を仰ぐ (auto-approve mode 含む)。
+```
+
+修正依頼時に triggering agent へ渡す情報:
+
+```
+## Doc Review Rollback
+
+### Rollback source
+doc-reviewer
+
+### Inconsistencies
+{INCONSISTENCY_ITEMS リスト + 観点 + 根拠}
+
+### Files to fix
+{該当ファイルパス}
+
+### Constraints
+- 既存の他 UC / 他文書を壊さない
+- 修正完了後、AGENT_RESULT を再出力すること
+```
+
+### 3.8 プラン別の挙動 (`sandbox-runner` と同じく triage に従う)
+
+| Plan | doc-reviewer 動作 |
+|------|-------------------|
+| Discovery Minimal | scope-planner が走らないため doc-reviewer 起動なし |
+| Discovery Light/Standard/Full | scope-planner 完了後に必ず起動 |
+| Delivery Minimal | spec-designer / architect 後にのみ起動 (ux-designer は走らない) |
+| Delivery Light/Standard/Full | 該当する全フックで起動 |
+| Maintenance Patch | analyst の DOCS_UPDATED に SPEC.md 差分があるときのみ起動 |
+| Maintenance Minor/Major | analyst 完了後に必ず起動 |
+| Operations Flow | **起動なし** (operations-flow はマークダウン成果物を生成・更新しないため) |
+
+### 3.9 Output Language との整合
+
+`doc-reviewer` 自身も `.claude/rules/project-rules.md` を読み、
+`Output Language` に従って findings 文を生成する (narrative 部分のみ)。
+レポートのテンプレート skeleton (`## Doc Review Report` 等の見出し) は
+英語固定 — `.claude/rules/language-rules.md` の "Template skeleton strings"
+ルールに従う。
+
+ただし `doc-reviewer` は **template skeleton と narrative の混在チェック**
+を **行わない**。これは Markdown lint 寄りの責務であり、別 agent
+(将来検討) または `reviewer` の所掌に近い。これは §4 Q5 で詳述する。
+
+---
+
+## 4. Open questions
+
+すべて Auto mode のため AskUserQuestion せず、ここに記録する。
+`architect` または user とすり合わせる前提とする。
+
+### Q1. 既存 `reviewer` のリネーム是非
+
+**問題**: ユーザー要求では「reviewer はコード特化」と前提されているが、
+`reviewer.md` 実体は "Review Perspectives" の #1 で SPEC.md 準拠
+チェックを既に持っている。`doc-reviewer` 新設後に `reviewer` を
+`code-reviewer` にリネームすべきか？
+
+**仮の方針**: **リネームしない**。理由:
+1. 両者は **対象方向が直交** (reviewer = 垂直 / doc-reviewer = 水平)
+2. 既存 `reviewer.md` の "Spec Compliance" 観点は実コード ↔ SPEC.md の
+   照合であり、本来の "code review" の枠内
+3. リネームは破壊的変更 (オーケストレーター・slash command・既存ドキュメント
+   への影響大)
+4. 将来 `code-reviewer` という別 agent が必要になった場合のみリネーム検討
+
+ただし `reviewer.md` の Mission に「`doc-reviewer` との境界」を 1 段落
+追記することは推奨 (compliance-auditor #56 と同じ追記スタイル)。
+
+### Q2. design-notes の対象粒度
+
+**問題**: ユーザー要求では `docs/design-notes/<slug>.md` を対象に
+含めるとあるが、design-notes は draft / planning / archived の
+ライフサイクルがあり、すべての段階で SPEC.md 整合を要求するのは過剰。
+
+**仮の方針**: 以下の段階のみ対象:
+- analyst が `docs/design-notes/<slug>.md` を作成した直後 (= maintenance-flow
+  Phase {analyst} 後)
+- header に `> Next: developer` または `> Next: architect` が記載された
+  「ready-for-handoff」状態のもの
+
+draft 状態 (`> Next: TBD` 等) や archived 配下 (`docs/design-notes/archived/`)
+は対象外。
+
+### Q3. rollback max 3 回の根拠
+
+**問題**: ユーザー要求でも「max 3 回」とあるが、これは既存
+`.claude/orchestrator-rules.md` の "Rollback Rules" の上限と同じ。
+
+**仮の方針**: **既存ルールに統合**する (新しい上限を作らず、
+既存 "Rollback Limit" を流用)。具体的には orchestrator-rules.md の
+既存 Rollback Limit セクションを「test failure / review CRITICAL /
+**doc review FAIL** の 3 種類に共通の上限」として書き換える。
+これにより上限管理が 1 箇所に集約される。
+
+### Q4. discovery-flow での発火点
+
+**問題**: scope-planner 完了後の終端チェックだけで十分か、
+researcher / poc-engineer 完了後も走らせるべきか。
+
+**仮の方針**: **scope-planner 完了後のみ** (Phase 1 として)。理由:
+1. researcher / poc-engineer は単独文書を生成するだけで「整合性チェック
+   対象が複数存在する」状況にならない
+2. Standard / Full プランで researcher が interviewer の見落としを
+   発見するケースは存在するが、それは researcher 内部のロジックで処理
+   される設計 (POC_RESULT.md → INTERVIEW_RESULT.md 更新の rollback flow が
+   既存)
+3. 過剰な doc-reviewer 起動はユーザ体験を損なう (approval gate 数が
+   増える)
+
+将来 Phase 2 として「researcher → doc-reviewer (researcher 結果 ↔
+INTERVIEW_RESULT.md の整合)」を追加検討の余地はあるが、本 issue では
+対象外。
+
+### Q5. Markdown lint 寄りチェックの扱い
+
+**問題**: 表記ゆれ・Markdown 構文エラー・template skeleton と narrative の
+混在 (language-rules.md 違反) のチェックを doc-reviewer に含めるか。
+
+**仮の方針**: **含めない**。理由:
+1. これらは **整合性** ではなく **個別文書の品質** 問題
+2. Markdown lint は CI で `markdownlint` 等を回せば十分
+3. doc-reviewer のスコープを肥大化させると AGENT_RESULT が読みにくくなる
+
+ただし AGENT_RESULT の `ADVISORY_COUNT` (🟡 ADVISORY) として
+「明らかに重大な lint 違反」を 1〜2 件レベルで指摘するのは許容範囲とする。
+
+### Q6. Minimal plan での扱い
+
+**問題**: `sandbox-runner` は Minimal で advisory のみ。`doc-reviewer` も
+同様にすべきか、それとも全プラン mandatory か。
+
+**仮の方針**: **全プラン mandatory** (`sandbox-runner` と異なる)。理由:
+1. doc-reviewer は破壊的操作を伴わない pure read-only エージェントで、
+   Minimal でも実行コストが低い
+2. ドキュメント整合性は規模に関係なく重要 (むしろ Minimal の小規模
+   プロジェクトで「コードと SPEC が乖離する」事故の方が多い)
+3. Discovery Minimal は scope-planner が走らないので結果として doc-reviewer
+   も走らないが、これは triage 構造由来であり「Minimal で skip」とは異なる
+
+ただし「security-auditor は全プラン必須」と同じ強制レベルにすると
+ユーザが嫌がる可能性もあるため、§4 Q6a として「ユーザ判断で
+doc-reviewer を triage で skip 可能にすべきか」を残す。
+
+#### Q6a. doc-reviewer skip オプション
+
+**仮の方針**: **skip オプションを設けない**。security-auditor 同様、
+構造的に必須とする。ただし FAIL 時の rollback 処理で「ユーザ判断で
+INCONSISTENCY を承知の上で続行」を許可するオプションは持つ
+(approval gate での "Approve despite findings" 選択肢)。
+
+### Q7. doc-reviewer の `Tools:` フィールド
+
+**問題**: `Read / Glob / Grep` のみで十分か、`Bash` も必要か。
+
+**仮の方針**: **`Read, Glob, Grep` のみ**。理由:
+1. doc-reviewer は read-only でファイルを書かない
+2. 実在チェック (ファイルパスや agent 名) は `Glob` で十分
+3. `Bash` を持たせると sandbox-policy / commit 権限の議論が発生し
+   設計が複雑化
+4. `reviewer` は `Bash` を持つが、それは静的解析ツール (ruff / eslint)
+   実行のため。doc-reviewer にはそれが不要
+
+将来 `markdownlint` を実行する選択肢が出た場合のみ `Bash` 追加検討。
+
+### Q8. オーケストレーター呼び出し方式の妥当性検証
+
+**問題**: ユーザー要求の「オーケストレーター呼び出し方式」は明確だが、
+sandbox-runner と異なり doc-reviewer は **「caller agent からの delegation」
+ではなく「caller agent の出力を後検査する」** 性格を持つ。これを
+sandbox-runner の挿入規約と同じ枠で表現できるか。
+
+**仮の方針**: 表現可能。`Sandbox Runner Auto-insertion` セクションは
+"orchestrator が agent 起動の **前** に挿入する" のに対し、
+`Doc Reviewer Auto-insertion` は "orchestrator が agent 起動の **後** に
+挿入する" だけの違い。`Trigger Conditions` / `Double-Execution Prevention`
+/ `Standalone Agent Fallback` の 3 要素構造は流用可能。
+これは §3.6 で既に表現済み。
+
+---
+
+## 5. Document changes
+
+### 5.1 新規ファイル
+
+| パス | 内容 | 担当 |
+|------|------|------|
+| `.claude/agents/doc-reviewer.md` | 新 agent definition (本 design-note §3 をベース) | architect 設計 → developer 実装 |
+
+### 5.2 編集ファイル
+
+#### `.claude/orchestrator-rules.md`
+
+- 新規セクション "Doc Reviewer Auto-insertion" を
+  "Sandbox Runner Auto-insertion" と並列で追加
+- 既存 "Rollback Rules" → "Rollback Limit" を「test failure / review
+  CRITICAL / **doc review FAIL** の 3 種共通の上限」として書き換え
+- "Triage System" 各 flow のフェーズ列に doc-reviewer の挿入位置を脚注として追記
+  (実フェーズ番号は変更せず、auto-insert 旨を明記)
+
+#### `.claude/agents/delivery-flow.md`
+
+- "Managed Flows" の Standard Plan 例の Phase 1 / Phase 2 / Phase 3 後に
+  "→ doc-reviewer (auto)" を追記 (フェーズ番号は据え置き、auto-insert 旨)
+- "Rollback Rules" に "Rollback Flow on Doc Review FAIL" を追加:
+  ```
+  doc-reviewer (FAIL) → spec-designer / architect / ux-designer (修正)
+                      → doc-reviewer (再チェック)
+  ```
+- "Side Entry: analyst" には doc-reviewer の追加挿入は不要 (analyst 自身は
+  delivery-flow ではなく maintenance-flow / standalone から起動されるため)
+
+#### `.claude/agents/discovery-flow.md`
+
+- "Managed Flows" の各プラン例の最終 Phase (scope-planner) 後に
+  "→ doc-reviewer (auto)" を追記
+- Minimal プランは scope-planner が走らないので doc-reviewer も走らない
+  旨を明記
+- "Rollback Rules" に "Pattern 3: doc-reviewer FAIL → scope-planner" を追加
+
+#### `.claude/agents/maintenance-flow.md`
+
+- "Managed Flows" の Patch / Minor / Major 各プラン例の analyst 後に
+  "→ doc-reviewer (条件付き auto)" を追記
+- 条件: PLAN=Patch かつ analyst の DOCS_UPDATED に SPEC.md 差分なしなら skip
+- "Rollback Rules" テーブルに "doc-reviewer FAIL | analyst | All plans" を追加
+
+#### `.claude/agents/reviewer.md`
+
+- Mission セクションに以下を追記 (compliance-auditor #56 と同じスタイル):
+  ```markdown
+  > **Boundary with `doc-reviewer`:** This agent reviews implementation
+  > code against SPEC.md / ARCHITECTURE.md (vertical consistency).
+  > Cross-document consistency among markdown artifacts (SPEC.md ↔
+  > ARCHITECTURE.md ↔ UI_SPEC.md ↔ design-notes) is owned by
+  > `doc-reviewer`, which is auto-inserted by flow orchestrators after
+  > spec/design/scope agents.
+  ```
+
+#### `.claude/rules/aphelion-overview.md`
+
+- "Agent Directory" セクションに doc-reviewer を追記
+- "Domain and Flow Overview" の図に doc-reviewer の cross-cutting 性質を補足
+- 更新履歴を追加
+
+#### `.claude/rules/library-and-security-policy.md`
+
+- 編集不要 (本 agent はセキュリティ責務に直接関与しない)
+
+### 5.3 影響を受けない箇所
+
+- `developer` / `tester` / `security-auditor` / `compliance-auditor` の
+  既存役割は変更しない
+- `interviewer` / `researcher` / `poc-engineer` / `concept-validator` /
+  `rules-designer` / `change-classifier` / `impact-analyzer` の既存
+  output 契約は変更しない (doc-reviewer はこれらを read-only で読むだけ)
+- 既存 `SPEC.md` / `ARCHITECTURE.md` / `UI_SPEC.md` を持つプロジェクトに
+  対する後方互換性あり (doc-reviewer は read-only で破壊しない)
+
+---
+
+## 6. Acceptance criteria
+
+### 6.1 必須 (本 issue 完了条件)
+
+- [ ] `.claude/agents/doc-reviewer.md` が存在し、以下を含む
+  - YAML front matter (name, description, tools=`Read, Glob, Grep`, model)
+  - "Project-Specific Behavior" ブロック (project-rules.md 読み込み)
+  - Mission セクションで `reviewer` との境界を明示
+  - 入力ファイル一覧 (SPEC.md / ARCHITECTURE.md / UI_SPEC.md /
+    docs/design-notes/ / DISCOVERY_RESULT.md)
+  - 5 観点 (coverage / naming / scope / version / acceptance) のチェック手順
+  - 出力フォーマット (§3.4 のテキストレポート)
+  - AGENT_RESULT 契約 (§3.5)
+  - "Standalone invocation" セクション (orchestrator 不在時の挙動)
+- [ ] `.claude/orchestrator-rules.md` に "Doc Reviewer Auto-insertion"
+  セクションが追加されている
+- [ ] `.claude/orchestrator-rules.md` の "Rollback Rules" が doc-reviewer
+  FAIL を含む形に更新されている
+- [ ] `.claude/agents/delivery-flow.md` の Managed Flows と Rollback Rules に
+  doc-reviewer の挿入位置と rollback flow が記載されている
+- [ ] `.claude/agents/discovery-flow.md` の Managed Flows と Rollback Rules に
+  doc-reviewer の挿入位置と rollback flow が記載されている
+- [ ] `.claude/agents/maintenance-flow.md` の Managed Flows と Rollback
+  Rules table に doc-reviewer の挿入位置と rollback flow が記載されている
+- [ ] `.claude/agents/reviewer.md` の Mission に境界記述が追記されている
+- [ ] `.claude/rules/aphelion-overview.md` の Agent Directory に doc-reviewer
+  が追記されている
+
+### 6.2 推奨 (本 issue で達成できれば望ましい)
+
+- [ ] サンプル "Doc Review Report" を `docs/examples/doc-review-sample.md`
+  として 1 件配置 (架空の SPEC.md / ARCHITECTURE.md 不整合シナリオ)
+- [ ] `/doc-reviewer` slash command を `.claude/commands/` に追加し、
+  standalone 起動を案内できるようにする
+- [ ] 既存の design-notes (`compliance-auditor.md` / `doc-flow.md` /
+  `performance-optimizer.md`) を doc-reviewer のテストケースとして
+  手動実行し、現状の不整合を 1 件以上検出できることを確認
+
+### 6.3 Phase 1 では不要 (将来検討)
+
+- researcher / poc-engineer 完了後の doc-reviewer 挿入 (§4 Q4)
+- Markdown lint 統合 (§4 Q5)
+- doc-reviewer 自身の AGENT_RESULT を別 agent が消費する用途
+- multilingual な findings 出力 (project-rules.md の Output Language に
+  従うのみ)
+
+---
+
+## 7. Out of scope
+
+明示的にスコープ外とするもの。
+
+1. **コードレビュー**
+   `reviewer` の所掌。doc-reviewer は **マークダウン成果物のみ** を
+   対象とする。
+
+2. **README.md / CHANGELOG.md / wiki / commit message**
+   ユーザー要求で明示的に対象外。これらは別経路 (CI workflow
+   `check-readme-wiki-sync`) で担保。
+
+3. **Markdown 構文エラー検出**
+   別ツール (`markdownlint`) の所掌。§4 Q5 参照。
+
+4. **自動修正 (auto-remediation)**
+   doc-reviewer は指摘のみ。修正は triggering agent への rollback で行う。
+
+5. **エージェント定義ファイル (`.claude/agents/*.md`) 自体の整合チェック**
+   メタレベルの自己参照。本 issue では対象外
+   (将来 `aphelion-self-check` のような別 agent 検討の余地あり)。
+
+6. **Operations Flow への統合**
+   operations-flow はマークダウン成果物を生成しないため、
+   doc-reviewer の挿入位置がない。Operations Flow へのフックは将来
+   `OPS_PLAN.md` 等を書く agent が登場した時点で再検討。
+
+7. **観点ごとの重み付け / スコアリング**
+   PASS/FAIL の二値判定のみ。「軽微な不整合 1 件は FAIL にしない」
+   のような閾値設定は導入しない (recall を優先)。
+
+---
+
+## 8. Handoff brief for architect
+
+### 8.1 architect への必須申し送り
+
+1. **§3.1 役割境界表を最優先で確認** — `reviewer` との対称性が
+   破綻していないか、新規視点で再評価する
+2. **§3.2 起動位置の 5 フック** — Discovery / Delivery / Maintenance の
+   どのフェーズに挿入するか、orchestrator の Phase 番号と整合させる
+   (Phase 番号は既存のまま「auto-insert」として表現する方針)
+3. **§3.6 Doc Reviewer Auto-insertion セクションのテキスト** —
+   `Sandbox Runner Auto-insertion` のテンプレートを流用するが、
+   "agent 起動の **後** に挿入" という方向の違いを明示する
+4. **§3.7 Doc Review FAIL Rollback** — 既存の "Rollback Rules" に
+   どう統合するか (新セクションとして追加する vs 既存 flow ごとに分散)
+5. **§4 Open Questions の Q1, Q3, Q6 を最優先で議論** —
+   - Q1 (reviewer リネーム否) は最終決定が必要
+   - Q3 (rollback 上限の統合) は orchestrator-rules.md 編集方針に直結
+   - Q6 (Minimal で mandatory にするか) はユーザ体験に直結
+
+### 8.2 architect から developer への引継ぎで注意してほしい点
+
+- `.claude/agents/doc-reviewer.md` の **YAML front matter** は
+  `reviewer.md` と `sandbox-runner.md` のハイブリッドが望ましい:
+  ```yaml
+  name: doc-reviewer
+  description: |
+    Cross-cutting agent that reviews consistency among markdown artifacts
+    (SPEC.md / ARCHITECTURE.md / UI_SPEC.md / docs/design-notes/).
+    Auto-inserted by flow orchestrators after spec / design / scope agents.
+  tools: Read, Glob, Grep
+  model: sonnet  # opus は overkill, sonnet で十分なレビュー粒度
+  ```
+- agent 本体の長さは `reviewer.md` (~200 行) と同等を目安に。
+  `sandbox-runner.md` (~210 行) より短くなる想定 (Bash がない分シンプル)
+- "Standalone invocation" セクションは必須 (compliance-auditor の
+  `COMPLIANCE_REQUIRED: true` のような前提条件は不要だが、
+  「orchestrator 不在時はユーザに状況を確認してから走らせる」フローを記述)
+
+### 8.3 PR 分割方針 (推奨)
+
+architect が判断する前提だが、参考として:
+
+| PR | 内容 | 依存関係 |
+|----|------|---------|
+| **PR 1 (本 issue で着手)** | `.claude/agents/doc-reviewer.md` agent definition + `.claude/orchestrator-rules.md` 編集 (Doc Reviewer Auto-insertion セクション + Rollback Rules 統合) + `reviewer.md` 境界記述追加 | なし |
+| **PR 2 (本 issue で着手 or 別 issue)** | 各 flow agent (`delivery-flow.md` / `discovery-flow.md` / `maintenance-flow.md`) への挿入位置追記 + `aphelion-overview.md` Agent Directory 更新 | PR 1 |
+| **PR 3 (別 issue)** | サンプル `docs/examples/doc-review-sample.md` + `/doc-reviewer` slash command | PR 1, PR 2 |
+
+PR 1 と PR 2 を 1 PR にまとめるか分割するかは architect/developer の判断。
+ファイル数 (PR 1 = 3 ファイル / PR 2 = 4 ファイル) を見て決める。
+
+### 8.4 リスクと留意点
+
+- **リスク 1: orchestrator-rules.md の Rollback Limit 統合で
+  既存 flow の挙動を破壊する**
+  → 既存 "test failure" / "review CRITICAL" の rollback 上限は変更しない。
+  「上限値の出処を 1 箇所にまとめる」だけのリファクタとして扱う。
+- **リスク 2: doc-reviewer FAIL が頻発し、ユーザがフローを進められない**
+  → §6.2 の「approval gate で "Approve despite findings" 選択肢」を必須化。
+  ただし「強制承認した結果は AGENT_RESULT に明示」する設計。
+- **リスク 3: Aphelion 自身のリポジトリ (本リポジトリ) で doc-reviewer を
+  走らせると、`.claude/agents/*.md` 自体が SPEC.md を持たないため
+  「対象がない」となる**
+  → §7 の Out of scope #5 と同じ理由で本 issue では対象外。
+  本リポジトリでの doc-reviewer 動作は、テスト用に他リポジトリを用意して
+  検証する。

--- a/docs/design-notes/doc-reviewer-architecture.md
+++ b/docs/design-notes/doc-reviewer-architecture.md
@@ -1,0 +1,1044 @@
+# Architecture: doc-reviewer agent introduction
+
+> Last updated: 2026-04-30
+> Linked Design Note: doc-reviewer-agent-introduction.md
+> Linked Issue: #91
+> Source design-note: docs/design-notes/doc-reviewer-agent-introduction.md (2026-04-30)
+> Authored by: architect
+> Next: developer
+
+---
+
+## 1. Scope of this document
+
+本ドキュメントは Issue #91「doc-reviewer agent 導入」の **technical
+design document** である。Aphelion 本体リポジトリは `.claude/agents/*.md`
+群と `.claude/orchestrator-rules.md` を「アーキテクチャ成果物」として扱う
+ワークフロー製品なので、本書は通常プロジェクトの ARCHITECTURE.md と同じ
+位置付けで利用する。
+
+含むもの:
+- Open Questions Q1 / Q3 / Q6 (および Q2 / Q4 / Q5 / Q7 / Q8 のレビュー結果) の確定
+- `.claude/agents/doc-reviewer.md` の完全アウトライン (section level)
+- `.claude/orchestrator-rules.md` への差分仕様
+- `delivery-flow.md` / `discovery-flow.md` / `maintenance-flow.md` /
+  `reviewer.md` / `aphelion-overview.md` への差分仕様
+- `localization-dictionary.md` 追加項目
+- PR 分割方針
+- developer 向け実装チェックリスト
+- テスト戦略 / rollback とエラーモードの考慮
+
+含まないもの (= developer の責務):
+- `.claude/agents/doc-reviewer.md` の本文そのもの
+- 各 flow agent の差分パッチの実コード
+- 動作確認 (本リポジトリには SPEC.md がないため別リポジトリで実施)
+
+> **入力ドキュメント**:
+> - `docs/design-notes/doc-reviewer-agent-introduction.md` (analyst 作成)
+> - 既存 agent: `sandbox-runner.md`, `reviewer.md`, `security-auditor.md`,
+>   `delivery-flow.md`, `discovery-flow.md`, `maintenance-flow.md`
+> - `.claude/orchestrator-rules.md` 現行版 (HEAD `e56a58d`)
+
+---
+
+## 2. Design decisions (Open Questions の確定回答)
+
+### 2.1 Q1: 既存 `reviewer` のリネーム是非 — **リネームしない**
+
+analyst 仮判断を採用する。理由:
+
+1. `reviewer` の "Spec Compliance" 観点と doc-reviewer のチェック方向は
+   **直交関係** (reviewer = コード ↔ ドキュメントの垂直、doc-reviewer =
+   ドキュメント ↔ ドキュメントの水平)。
+2. リネームは破壊的変更で `commands/` / wiki / 過去の design-note への
+   影響が大きい。
+3. 名前空間としても `reviewer` (= 実装後の品質ゲート全般) と
+   `doc-reviewer` (= 文書整合) は意味の重複が小さく、共存可能。
+
+**確定アクション**: `reviewer.md` の Mission に `doc-reviewer` との境界を
+1 段落追記する (compliance-auditor #56 と同じ追記スタイル)。具体文面は
+§5.4 で確定。
+
+### 2.2 Q3: rollback 上限の統合 — **既存 max-3 に統合**
+
+analyst 仮判断を採用する。
+
+**確定アクション**:
+`.claude/orchestrator-rules.md` の "Rollback Rules" セクション冒頭に
+`### Rollback Limit (Common)` という共通サブセクションを新設し、
+"Rollbacks are limited to 3 times maximum." の記述をそこへ移す。
+既存の "Test Failure Rollback Flow" / "Review CRITICAL Rollback Flow" /
+新設する "Doc Review FAIL Rollback Flow" / 各 flow ファイル側の
+Rollback Rules セクションは、上限値そのものは記述せず
+「Common Rollback Limit を共有する」と参照する。
+
+**重要な不変条件**: 既存 flow (delivery-flow.md `### Rollback Limit`、
+discovery-flow.md "Rollbacks are limited to 3 times maximum"、
+orchestrator-rules.md "Rollbacks are limited to 3 times maximum") の
+**動作** (max 3) は変更しない。これはあくまで **値の出処を 1 箇所に
+集約するリファクタ** である。
+
+### 2.3 Q6: Minimal plan で mandatory にするか — **mandatory**
+
+analyst 仮判断を採用する。理由:
+
+1. doc-reviewer は read-only (`Tools: Read, Glob, Grep`) で破壊的操作を
+   伴わない。
+2. 計算コストも小さい (Bash や静的解析を実行しない、複数ファイル read
+   のみ)。
+3. ドキュメント整合は規模に依存しない品質要件 (むしろ Minimal の小規模
+   プロジェクトで「コードと SPEC が乖離する」事故が多発する経験則がある)。
+
+**確定アクション**:
+- Delivery Minimal でも spec-designer / architect 直後に doc-reviewer を
+  auto-insert (ux-designer は Minimal で走らないため対象外)。
+- Discovery Minimal は scope-planner が走らない triage 構造のため
+  「結果として doc-reviewer も走らない」 (Minimal で skip するのではなく
+  「triage 起点が無い」)。
+- Maintenance Patch は条件付き (SPEC.md 差分があるときのみ走る)。
+
+FAIL 頻発時のユーザ回避策として、approval gate に
+**"Approve despite findings"** を必須選択肢として追加する (§5.1.3)。
+
+### 2.4 Q2 / Q4 / Q5 / Q7 / Q8 のレビュー結果
+
+| Q | analyst 仮判断 | architect レビュー結果 |
+|---|--------------|----------------------|
+| Q2 | design-notes は `> Next: developer` または `> Next: architect` 記載のものだけ対象 | **採用**。draft / archived を含めると false-positive が増えてレビューノイズになる。実装は §3.4 Inputs で確定 |
+| Q4 | discovery-flow は scope-planner 後のみ | **採用**。researcher / poc-engineer は単独文書しか産まないため整合チェック対象外 |
+| Q5 | Markdown lint は対象外 | **採用**。ただし AGENT_RESULT の ADVISORY (🟡) 段に「重大な lint 違反 1〜2 件」を記載することは許容 (§3.5 Severity 定義) |
+| Q7 | Tools = `Read, Glob, Grep` のみ | **採用**。Bash 不要。これにより sandbox-policy.md / commit 権限の議論が不要になる |
+| Q8 | "post-insert" 型として表現可能 | **採用**。Sandbox Runner Auto-insertion のテンプレート構造 (Trigger Conditions / Double-Execution Prevention / Standalone Agent Fallback) を流用しつつ「pre-insert」/「post-insert」の方向違いだけを明記 |
+
+---
+
+## 3. doc-reviewer.md complete outline
+
+`.claude/agents/doc-reviewer.md` の完全な section 構成。各 section の
+配置順序、見出しレベル、必須内容を以下に確定する。
+**実装本文は developer が書く** (本ドキュメントは骨格のみ)。
+
+### 3.1 YAML front matter
+
+```yaml
+---
+name: doc-reviewer
+description: |
+  Cross-cutting agent that reviews consistency among markdown artifacts
+  (SPEC.md / ARCHITECTURE.md / UI_SPEC.md / docs/design-notes/ /
+  DISCOVERY_RESULT.md). Auto-inserted by flow orchestrators after
+  spec / design / scope / analyst agents.
+  Used in the following situations:
+  - Orchestrator inserts after spec-designer / ux-designer / architect /
+    scope-planner / analyst (post-insertion)
+  - User invokes standalone for ad-hoc consistency check
+  Prerequisites: at least two markdown artifacts must exist for
+  consistency comparison; runs in read-only mode.
+tools: Read, Glob, Grep
+model: sonnet
+---
+```
+
+理由:
+- `name` / `description` / `tools` / `model` は `reviewer.md` と
+  `sandbox-runner.md` に倣う必須フィールド
+- `model: sonnet` 選定理由: opus は overkill。整合チェックは構造的読解
+  であり、複雑な推論は不要。コスト効率を優先
+- `tools` から Bash を除外 (Q7 確定済み)
+- `color` フィールドは既存 agent でも省略しているものが多いため省略する
+
+### 3.2 Project-Specific Behavior block
+
+`reviewer.md` / `sandbox-runner.md` と完全に同じ文面を踏襲。
+
+```markdown
+## Project-Specific Behavior
+
+Before producing user-facing output, consult
+`.claude/rules/project-rules.md` (via `Read`) and apply:
+
+- `## Localization` → `Output Language` (see `.claude/rules/language-rules.md`)
+
+If `.claude/rules/project-rules.md` is absent, apply defaults:
+- Output Language: en
+
+---
+```
+
+### 3.3 Mission section
+
+1 段落 + reviewer / code との境界明示 1 段落 + 補足注 1 段落の構成。
+
+要点:
+- 「マークダウン成果物の **水平整合**」を担う agent
+- `reviewer` (垂直整合 = コード ↔ SPEC.md) との直交関係を明示
+- 「コードレビューはしない / README/CHANGELOG/wiki は対象外」を Mission 段落で先出し
+- ファイルを生成しない (テキストレポートのみ) ことも明示
+
+### 3.4 Inputs section
+
+新設の必須セクション。`reviewer.md` の "Workflow" 内に埋め込まれている
+入力読み込み手順を、doc-reviewer では独立した節として扱う。
+
+```markdown
+## Inputs
+
+### Required
+- 比較対象として最低 2 つの markdown artifact が存在すること
+
+### Read order (priority)
+1. SPEC.md (上流真実)
+2. ARCHITECTURE.md (設計層)
+3. UI_SPEC.md (UI 設計層、HAS_UI=true のみ)
+4. DISCOVERY_RESULT.md (要件層)
+5. INTERVIEW_RESULT.md (要件層、存在すれば)
+6. docs/design-notes/<slug>.md
+   - **対象条件**: header に `> Next: developer` または `> Next: architect` を含むもののみ
+   - **対象外**: `docs/design-notes/archived/` 配下、`> Next: TBD` / `> Next: (none)` 等のドラフト
+7. (任意) RESEARCH_RESULT.md / POC_RESULT.md / SCOPE_PLAN.md
+
+### Behavior on missing inputs
+- 比較対象が 1 件しか存在しない場合 → STATUS: success / DOC_REVIEW_RESULT: pass /
+  INCONSISTENCY_COUNT: 0 / NOTES: "No comparison target available." を返して終了
+- TRIGGERED_BY 指定の必須上流 (例: spec-designer 起動時の SPEC.md) が存在しない →
+  STATUS: error
+```
+
+### 3.5 Five Review Perspectives
+
+`reviewer.md` の 5 観点構造に揃える。各観点は subsection として記述。
+
+#### 観点 1: Coverage (上流-下流の網羅性)
+
+- DISCOVERY_RESULT.md の各要件 → SPEC.md UC への対応
+- SPEC.md の各 UC → ARCHITECTURE.md のモジュール / エンドポイント
+- SPEC.md UC (HAS_UI=true) → UI_SPEC.md SCR
+- design-note (`> Linked Plan` 経由) → SPEC.md / ARCHITECTURE.md 差分への反映
+
+#### 観点 2: Naming consistency (命名・参照整合性)
+
+- UC-XXX / SCR-XXX / API-XXX 等 ID の renumber/rename 整合
+- 用語集 (定義あれば) と本文の用語使用一致
+- 参照されているファイルパス・agent 名の実在 (`Glob` で検証)
+
+#### 観点 3: Scope alignment (スコープ整合性)
+
+- DISCOVERY_RESULT.md IN/OUT ↔ SPEC.md SCOPE
+- SPEC.md SCOPE (IN) ↔ ARCHITECTURE.md 実装対象
+- SPEC.md SCOPE (OUT) と矛盾する設計が ARCHITECTURE.md に無いこと
+- maintenance-flow: 削除/改訂された UC を別 UC が参照していないこと
+
+#### 観点 4: Version traceability (バージョン整合性)
+
+- ARCHITECTURE.md の `> Source: SPEC.md @ {date}` が SPEC.md
+  `> Last updated: {date}` と一致
+- design-note の `> GitHub Issue: [#N]` の実在 (リンク自体の到達確認は
+  しない — Bash を持たないため。Grep で `> GitHub Issue:` 行の存在のみ確認)
+- 同一フェーズ内で複数 agent が同一文書を更新する順序整合
+  (例: spec-designer → architect が SPEC.md をどちらも更新するケース)
+
+#### 観点 5: Acceptance reviewability (受け入れ基準と承認可能性)
+
+- SPEC.md 各 UC に Acceptance Criteria が存在
+- 受け入れ基準が **テスト可能** (定量的 / 観測可能 / 一意判定可能)
+- maintenance-flow で改訂された Acceptance Criteria が既存テストを破壊
+  していないこと
+
+> **明示的に観点に含めない**:
+> - Markdown 構文 lint レベル (markdownlint で別途)
+> - 文体 / 表記ゆれ
+> - README.md / CHANGELOG.md / wiki / commit message
+> - コードコメント
+
+### 3.6 Severity definition
+
+3 段階モデルを採用。`reviewer.md` の CRITICAL/WARNING/SUGGESTION とは
+名称を変えて、ドキュメント層であることを明示する。
+
+| Severity | 略号 | 意味 | rollback 影響 |
+|----------|-----|------|---------------|
+| 🔴 INCONSISTENCY | DR-XXX | 上流-下流または横断の食い違い (修正必須) | FAIL → triggering agent へ rollback |
+| 🟡 ADVISORY | DA-XXX | 改善推奨 (lint 寄り、軽微な表記揺れ等) | rollback 対象外 |
+| 🟢 INFO | DI-XXX | 情報提供のみ | rollback 対象外 |
+
+INCONSISTENCY が 1 件以上 → DOC_REVIEW_RESULT: fail
+INCONSISTENCY 0 件 (ADVISORY/INFO のみ or 何もなし) → DOC_REVIEW_RESULT: pass
+
+### 3.7 Output Report Format
+
+ファイルは生成しない (`SECURITY_AUDIT.md` のような persistent artifact
+にしない)。テキストレポートのみ。テンプレート skeleton (見出し) は英語固定、
+narrative は Output Language に従う (analyst design-note §3.4 と同じ)。
+
+```markdown
+## Doc Review Report
+
+### Target artifacts
+- {path}: Last updated {date}
+- ...
+
+### Triggered by
+{spec-designer | ux-designer | architect | scope-planner | analyst | standalone}
+
+### Overall Assessment
+{✅ PASS | ❌ FAIL}
+
+---
+
+### 🔴 INCONSISTENCY (must fix; rollback target)
+
+#### [DR-001] {title}
+- **Files:** `SPEC.md` ↔ `ARCHITECTURE.md`
+- **Perspective:** {coverage | naming | scope | version | acceptance}
+- **Inconsistency:** {何が食い違っているか}
+- **Evidence:** SPEC.md UC-XXX (line 42) / ARCHITECTURE.md §3.2 (line 88)
+- **Suggested fix:** {どちらをどう変更すべきか}
+
+---
+
+### 🟡 ADVISORY (recommended; not a rollback trigger)
+
+#### [DA-001] {title}
+- **Files:** ...
+- **Detail:** ...
+
+---
+
+### 🟢 INFO
+
+#### [DI-001] {title}
+- **Detail:** ...
+
+---
+
+### Coverage matrix
+| Upstream ID | Downstream reflection | Status |
+|-------------|----------------------|--------|
+| UC-001 | ARCHITECTURE.md §3.1, UI_SPEC.md SCR-001 | ✅ |
+| UC-002 | ARCHITECTURE.md §3.2 | ⚠️ UI_SPEC.md SCR not found |
+| UC-003 | (none) | ❌ design missing |
+
+---
+
+### Next Steps
+→ INCONSISTENCY exists: orchestrator rolls back to {triggering agent}
+→ ADVISORY only: pass; consider improvements at next opportunity
+→ Empty: ✅ pass
+```
+
+### 3.8 AGENT_RESULT contract
+
+```
+AGENT_RESULT: doc-reviewer
+STATUS: success | failure | error
+DOC_REVIEW_RESULT: pass | fail
+INCONSISTENCY_COUNT: {N}
+ADVISORY_COUNT: {N}
+INFO_COUNT: {N}
+TARGET_ARTIFACTS:
+  - {file path}: {Last updated date}
+INCONSISTENCY_ITEMS:
+  - {DR-XXX}: {short summary}
+TRIGGERED_BY: spec-designer | ux-designer | architect | scope-planner | analyst | standalone
+NEXT: {triggering agent on FAIL | done}
+```
+
+PASS/FAIL 決定ルール (analyst design-note §3.5 を踏襲):
+
+| STATUS | DOC_REVIEW_RESULT | 条件 |
+|--------|------------------|------|
+| `success` | `pass` | INCONSISTENCY_COUNT == 0 |
+| `failure` | `fail` | INCONSISTENCY_COUNT >= 1 |
+| `error` | (n/a) | doc-reviewer 自身の例外 (ファイル読込失敗、入力不足など) |
+
+> NOTES: 「`success` + `fail`」の組み合わせは無い。INCONSISTENCY を検出した
+> ら STATUS は `failure`。これは reviewer.md の `STATUS: rejected` と
+> 同等の意味。
+
+### 3.9 Workflow section
+
+```markdown
+## Workflow
+
+1. Read project-rules.md (Project-Specific Behavior block)
+2. Identify TRIGGERED_BY (caller agent name; "standalone" if missing)
+3. Read input artifacts per §3.4 priority order
+   - Use Glob to enumerate docs/design-notes/<slug>.md candidates
+   - Filter design-notes by `> Next: developer` or `> Next: architect` line
+4. Run 5 review perspectives in order (coverage → naming → scope → version → acceptance)
+5. Classify findings by severity (DR / DA / DI)
+6. Build coverage matrix
+7. Emit Doc Review Report (text only)
+8. Emit AGENT_RESULT block
+```
+
+### 3.10 Standalone invocation section
+
+`sandbox-runner.md` の "Non-Goals" / `compliance-auditor` の standalone
+ガイドのスタイルを参考に、「orchestrator 不在時」のフォールバック手順を
+記述する。
+
+```markdown
+## Standalone Invocation
+
+When invoked directly by the user (no flow orchestrator):
+
+1. TRIGGERED_BY を `standalone` として扱う
+2. ユーザに対象アーティファクトを確認 (引数で渡されていない場合):
+   - 「SPEC.md と ARCHITECTURE.md の整合チェックでよいか」を尋ねる
+3. orchestrator が存在しないため rollback は発火しない
+   - INCONSISTENCY を検出しても自動 rollback は行わず、ユーザに修正対象
+     を提示するのみ
+4. AGENT_RESULT.NEXT は常に `done`
+```
+
+### 3.11 Constraints / Out of scope section
+
+`reviewer.md` の "Quality Criteria" 末尾と同じスタイル。
+
+```markdown
+## Out of Scope
+
+- コードレビュー (これは `reviewer` の責務)
+- README.md / CHANGELOG.md / wiki / commit message の整合
+- Markdown 構文エラー検出 (markdownlint で別途実施)
+- 自動修正 (auto-remediation) — 指摘のみで rollback による修正に委ねる
+- `.claude/agents/*.md` 自体のメタ整合チェック (将来の self-check agent で扱う)
+```
+
+### 3.12 Completion conditions section
+
+`reviewer.md` の末尾と同じ。
+
+```markdown
+## Completion Conditions
+
+- [ ] All input artifacts per §3.4 priority were read
+- [ ] All 5 review perspectives were evaluated
+- [ ] Coverage matrix was generated
+- [ ] AGENT_RESULT block was emitted
+- [ ] DOC_REVIEW_RESULT was set to pass or fail (never undefined)
+```
+
+### 3.13 想定行数
+
+`reviewer.md` (~200 行) と同等を上限目安。Bash と静的解析記述を持たない
+ため、実装後は ~180 行前後を見込む。
+
+---
+
+## 4. orchestrator-rules.md changes
+
+### 4.1 新規セクション "Doc Reviewer Auto-insertion"
+
+挿入位置: 既存 "Sandbox Runner Auto-insertion" セクション (line 71〜115) の
+**直後**。並列構造で記述する。
+
+```markdown
+---
+
+## Doc Reviewer Auto-insertion
+
+This section defines how flow orchestrators insert `doc-reviewer`
+automatically after agents that produce or update markdown artifacts.
+
+> **Insertion direction**: Unlike `sandbox-runner` (pre-insertion before a
+> Bash command runs), `doc-reviewer` is **post-inserted** after the
+> upstream agent emits its AGENT_RESULT. The Trigger Conditions /
+> Double-Execution Prevention / Standalone Agent Fallback structure mirrors
+> Sandbox Runner Auto-insertion but applies to the agent's exit, not entry.
+
+### Trigger Conditions
+
+The orchestrator inserts `doc-reviewer` **after** receiving an
+`AGENT_RESULT` from the following agents:
+
+| Flow | Trigger agents | Conditions |
+|------|----------------|------------|
+| delivery-flow | spec-designer, ux-designer, architect | All plans (Minimal+). ux-designer triggers only when HAS_UI=true |
+| discovery-flow | scope-planner | Light/Standard/Full only. Minimal has no scope-planner so doc-reviewer is not triggered structurally. |
+| maintenance-flow | analyst | Patch: only if `analyst.DOCS_UPDATED` contains SPEC.md (no_change → skip). Minor/Major: always |
+
+### Double-Execution Prevention
+
+The orchestrator tracks a per-phase insertion flag
+`doc_reviewer_inserted_for_phase_id`. If set for the current phase, skip
+auto-insertion. On rollback, the flag is reset before re-insertion.
+
+### Standalone Agent Fallback
+
+When a triggering agent (e.g., spec-designer) is invoked outside a flow
+orchestrator, no auto-insertion happens. The user may invoke
+`/doc-reviewer` manually.
+
+### Invocation Format
+
+```
+Agent(
+  subagent_type: "doc-reviewer",
+  prompt: "Review markdown artifacts for cross-document consistency.
+           triggered_by: {agent_name}
+           target_artifacts: {paths}
+           phase_id: {phase_id}",
+  description: "doc review after {agent_name}"
+)
+```
+
+Parse the returned `AGENT_RESULT` block:
+- `STATUS: success` and `DOC_REVIEW_RESULT: pass` → proceed to approval gate
+- `STATUS: failure` and `DOC_REVIEW_RESULT: fail` → enter Doc Review FAIL Rollback Flow (§Rollback Rules)
+- `STATUS: error` → follow Common Error Handling
+```
+
+### 4.2 既存 "Rollback Rules" セクションの拡張
+
+挿入位置: line 418 以降。`### Rollback Limit (Common)` を新設。
+
+#### 4.2.1 Rollback Limit を共通化
+
+現状: line 420-421
+> Rollbacks are limited to **3 times maximum**. If exceeded, report the
+> situation to the user and ask for their decision.
+
+これを以下に置き換える:
+
+```markdown
+### Rollback Limit (Common)
+
+Rollbacks are limited to **3 times maximum**, applied as a single shared
+limit across:
+- Test failure rollback
+- Review CRITICAL rollback
+- Security audit CRITICAL rollback
+- **Doc review FAIL rollback (new)**
+
+If the limit is exceeded, report to the user and ask for their decision
+(see "Approve despite findings" option in Approval Gate, when applicable).
+The per-flow rollback sections below inherit this limit and must not
+declare their own.
+```
+
+#### 4.2.2 "Doc Review FAIL Rollback Flow" 新設
+
+挿入位置: 既存 "Review CRITICAL Rollback Flow" (line 442〜446) の直後。
+
+```markdown
+### Doc Review FAIL Rollback Flow
+
+```
+doc-reviewer (DOC_REVIEW_RESULT: fail)
+  → triggering agent (spec-designer / ux-designer / architect /
+                      scope-planner / analyst) で修正
+    → doc-reviewer (re-check)
+```
+
+Triggering agent への rollback prompt:
+
+```
+## Doc Review Rollback
+
+### Rollback source
+doc-reviewer
+
+### Inconsistencies
+{INCONSISTENCY_ITEMS list with perspective and evidence}
+
+### Files to fix
+{file paths from INCONSISTENCY_ITEMS}
+
+### Constraints
+- 既存の他 UC / 他文書を壊さない
+- 修正完了後 AGENT_RESULT を再出力すること
+- ARCHITECTURE.md と SPEC.md の双方を編集する場合、両方の Last updated を
+  更新すること
+```
+
+After rollback, the orchestrator clears the
+`doc_reviewer_inserted_for_phase_id` flag and re-runs `doc-reviewer`.
+```
+
+### 4.3 Approval Gate に "Approve despite findings" 選択肢追加
+
+挿入位置: line 374-415 の "Approval Gate" セクション。
+
+doc-reviewer が `DOC_REVIEW_RESULT: fail` を返し、かつ rollback Limit
+(max 3) に達した場合のみ表示する第 4 選択肢として追加する。
+通常の approval gate (Phase N 完了時) には追加しない。
+
+```markdown
+### Approval Gate after Doc Review FAIL (rollback limit exceeded)
+
+When `doc-reviewer` repeatedly fails and the shared rollback limit is
+reached, the orchestrator presents a special gate:
+
+```json
+{
+  "questions": [{
+    "question": "doc-reviewer reported {N} inconsistencies after {3} rollbacks. How would you like to proceed?",
+    "header": "Doc review failed",
+    "options": [
+      {"label": "Continue rollback", "description": "Override the 3-time limit and try once more"},
+      {"label": "Approve despite findings", "description": "Accept INCONSISTENCY findings and continue to next phase"},
+      {"label": "Abort", "description": "Stop the workflow"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+If "Approve despite findings" is selected, record this in the phase
+completion log and tag the eventual AGENT_RESULT chain with
+`DOC_REVIEW_OVERRIDE: true` so downstream artifacts (e.g.,
+DELIVERY_RESULT.md) reflect that an override occurred.
+```
+
+---
+
+## 5. Per-flow patch specifications
+
+### 5.1 delivery-flow.md
+
+#### 5.1.1 Managed Flows (Standard Plan example) (line 103〜116)
+
+各該当 phase の直後に "→ doc-reviewer (auto)" を追記する。phase 番号は
+据え置き、auto-insert は番号を消費しない (orchestrator-rules.md の
+Auto-insertion セクションで定義)。
+
+差分:
+
+```diff
+ ### New Development (Standard Plan Example)
+ ```
+-Phase 1:  Spec definition        → spec-designer      → ⏸ User approval
+-Phase 2:  UI design              → ux-designer        → ⏸ User approval  (UI projects only)
+-Phase 3:  Architecture design    → architect          → ⏸ User approval
++Phase 1:  Spec definition        → spec-designer      → doc-reviewer (auto) → ⏸ User approval
++Phase 2:  UI design              → ux-designer        → doc-reviewer (auto) → ⏸ User approval  (UI projects only)
++Phase 3:  Architecture design    → architect          → doc-reviewer (auto) → ⏸ User approval
+ Phase 4:  Project initialization → scaffolder         → ⏸ User approval
+ Phase 5:  Implementation         → developer          → ⏸ User approval
+ ...
+ ```
+```
+
+triage table (line 60-65) は変更しない (auto-insert は triage に出ない)。
+
+#### 5.1.2 Rollback Rules セクション (line 184〜262)
+
+"Rollback Flow on Security Audit CRITICAL" (line 232〜239) の **直後** に
+新セクション挿入:
+
+```markdown
+### Rollback Flow on Doc Review FAIL
+
+```
+doc-reviewer (FAIL detected)
+  → triggering agent (spec-designer / ux-designer / architect)
+    → doc-reviewer (re-check)
+```
+
+Limit: shared via orchestrator-rules.md "Rollback Limit (Common)".
+On limit exceeded, the orchestrator presents the
+"Approve despite findings" gate (see orchestrator-rules.md Approval Gate
+after Doc Review FAIL).
+```
+
+`### Rollback Limit` (line 241〜245) を以下に書き換える:
+
+```markdown
+### Rollback Limit
+
+Inherits the shared limit from `.claude/orchestrator-rules.md`
+"Rollback Limit (Common)" (max 3 across test / review / security audit /
+doc review failures).
+```
+
+#### 5.1.3 Progress Display (line 294〜325)
+
+doc-reviewer が走った phase は "Phase N (+ doc-review ✅)" のように追記。
+ただしこれは optional (developer 判断)。最低限、completion summary に
+"Doc review: ✅ {N pass} / ❌ {N fail}" 行を追加する。
+
+### 5.2 discovery-flow.md
+
+#### 5.2.1 Managed Flows 各プラン (line 191〜221)
+
+Light / Standard / Full の最終 Phase (scope-planner) の行を以下のように
+修正:
+
+```diff
+-Phase 3: Scope definition        → scope-planner     → ⏸ User approval → Done
++Phase 3: Scope definition        → scope-planner     → doc-reviewer (auto) → ⏸ User approval → Done
+```
+
+(Standard では Phase 5、Full では Phase 6 が同様に修正対象)
+
+Minimal Plan (line 191〜195) は scope-planner が走らない。以下の脚注を
+セクション末尾に追加:
+
+```markdown
+> **Note on Minimal**: Minimal plan ends after `interviewer`. Since
+> `doc-reviewer` is triggered post-`scope-planner`, it is not invoked in
+> Minimal. This is by structural absence, not by an explicit "skip" rule.
+```
+
+#### 5.2.2 Rollback Rules (line 225〜279)
+
+"Pattern 2" (line 258〜279) の **直後** に "Pattern 3" を追加:
+
+```markdown
+### Pattern 3: doc-reviewer FAIL → scope-planner
+
+```
+doc-reviewer (DOC_REVIEW_RESULT: fail, TRIGGERED_BY: scope-planner)
+  → scope-planner (修正)
+    → doc-reviewer (再チェック)
+```
+
+Pass to scope-planner during rollback:
+
+```
+## Rollback: Doc review failed
+
+### Rollback source
+doc-reviewer
+
+### Inconsistencies
+{INCONSISTENCY_ITEMS list with perspective and evidence}
+
+### Files to fix
+DISCOVERY_RESULT.md (and possibly INTERVIEW_RESULT.md / SCOPE_PLAN.md)
+
+### Request
+- Resolve the inconsistencies above without removing already-confirmed
+  requirements
+- Re-emit AGENT_RESULT after fixing
+```
+
+Limit: shared via orchestrator-rules.md "Rollback Limit (Common)".
+```
+
+`### Rollback Limit` 相当の記述 (line 228) は以下に書き換え:
+
+```markdown
+Rollbacks are limited per `.claude/orchestrator-rules.md` "Rollback Limit
+(Common)" (max 3 across all rollback types).
+```
+
+### 5.3 maintenance-flow.md
+
+#### 5.3.1 Managed Flows 各 Plan (line 76〜111)
+
+Patch / Minor / Major の analyst 行の直後に条件付き auto を追加:
+
+```diff
+-Phase 2: Issue creation / approach        → analyst            → ⏸ User approval
++Phase 2: Issue creation / approach        → analyst            → doc-reviewer (conditional auto) → ⏸ User approval
+```
+
+(Minor は Phase 3、Major は Phase 3 の analyst 行が対象)
+
+各 plan 末尾に注記を追加:
+
+```markdown
+> **Conditional auto for doc-reviewer (Patch only)**: doc-reviewer is
+> auto-inserted only when `analyst.DOCS_UPDATED` contains SPEC.md or
+> ARCHITECTURE.md with a non-empty diff. If `DOCS_UPDATED` reports
+> SPEC.md as `no_change`, doc-reviewer is skipped (no rollback chain
+> formed).
+> Minor and Major always invoke doc-reviewer after analyst.
+```
+
+#### 5.3.2 Rollback Rules table (line 154〜163)
+
+既存テーブルに 1 行追加:
+
+```diff
+ | Trigger | Roll Back To | Notes |
+ |---------|-------------|-------|
+ | tester failure | developer | Max 3 retries |
+ | reviewer CRITICAL | developer | Minor only (Patch has no reviewer) |
+ | security-auditor CRITICAL | developer | Major only (pre-audit detection) |
+ | developer blocked | architect (differential mode) | Minor only. Patch rolls back to analyst |
++| doc-reviewer FAIL | analyst | All plans (Patch only when triggered). Shares Rollback Limit (Common) |
+```
+
+冒頭の "Inherits ... Rollback Rules" 行はそのまま。Rollback Limit は
+common 参照になるため、新規上限値は記載しない。
+
+### 5.4 reviewer.md (boundary clarification)
+
+挿入位置: Mission section (line 30〜34) の直後、`---` (line 36) の **前**。
+
+```diff
+ ## Mission
+
+ Review implementation code from both `SPEC.md` (spec compliance) and `ARCHITECTURE.md` (design consistency) perspectives,
+ and generate a quality report. **You do not modify code; you focus solely on presenting feedback.**
+
+ **Note:** Security aspects are handled by `security-auditor`, so this agent does not perform deep security inspections. Obvious issues (such as hardcoded passwords) are flagged, but systematic checks like OWASP Top 10 are delegated to security-auditor.
+
++> **Boundary with `doc-reviewer`:** This agent reviews implementation
++> code against SPEC.md / ARCHITECTURE.md (vertical consistency).
++> Cross-document consistency among markdown artifacts (SPEC.md ↔
++> ARCHITECTURE.md ↔ UI_SPEC.md ↔ design-notes) is owned by
++> `doc-reviewer`, which is auto-inserted by flow orchestrators after
++> spec / design / scope / analyst agents.
++
+ ---
+```
+
+### 5.5 aphelion-overview.md (registry)
+
+> **Note**: 本リポジトリには `.claude/rules/aphelion-overview.md` は存在しない
+> (user-level global にのみ存在)。リポジトリ内に配置された aphelion-overview を
+> 想定しているプロジェクト向けに、developer は **更新が反映されるべきパス**
+> を `Glob` で確認した上で更新する。本リポジトリにファイルが無ければ更新作業は
+> skip し、AGENT_RESULT に `APHELION_OVERVIEW_UPDATED: skipped (file not found in repo)`
+> を記載する。
+
+存在する場合の差分:
+
+#### 5.5.1 Update history 追記
+
+```diff
+ > **Last updated**: 2026-04-24
+ > **Auto-loaded**: Yes — placed in `.claude/rules/`, loaded by Claude Code on every session start
+ > 更新履歴:
+ >   - 2026-04-24: Maintenance Flow (第4フロー) を追加
++>   - 2026-04-30: doc-reviewer (cross-cutting agent) を追加 (#91)
+```
+
+`> **Last updated**: 2026-04-24` 行も `2026-04-30` に更新。
+
+#### 5.5.2 Agent Directory に doc-reviewer 追記
+
+`## Agent Directory` セクション末尾に以下を追加:
+
+```markdown
+### Cross-cutting agents
+
+| Agent | Tools | Purpose | Invocation |
+|-------|-------|---------|------------|
+| `sandbox-runner` | Read, Bash, Grep | High-risk command execution | Auto-insert (Standard+) / explicit delegation |
+| `doc-reviewer` | Read, Glob, Grep | Markdown artifact consistency review | Auto-insert (all plans) / standalone |
+```
+
+#### 5.5.3 Domain and Flow Overview 図への補足
+
+既存の図 (line 30〜39) の直後に以下の注を追加:
+
+```markdown
+> **Cross-cutting agents** (`sandbox-runner`, `doc-reviewer`) are not
+> tied to a single domain. They are auto-inserted by flow orchestrators
+> at trigger conditions defined in `.claude/orchestrator-rules.md`.
+```
+
+---
+
+## 6. localization-dictionary.md additions
+
+> **Note**: 本リポジトリには `.claude/rules/localization-dictionary.md`
+> は存在しない (user-level global にのみ存在)。本リポジトリに **配置されて
+> いる場合のみ** 更新する。なければ §5.5 と同様に `LOCALIZATION_DICTIONARY_UPDATED:
+> skipped (file not found in repo)` を AGENT_RESULT に記載。
+
+存在する場合の追加項目:
+
+### Approval Gate 表に 1 行追加
+
+```diff
+ | key                    | en                                                                                   | ja                                                                           |
+ |------------------------|--------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+ | phase_complete_header  | "Phase {N} complete: {agent}"                                                        | "Phase {N} 完了: {agent}"                                                    |
+ | artifacts_label        | "Generated artifacts"                                                                | "生成された成果物"                                                            |
+ | content_summary_label  | "Summary"                                                                            | "内容サマリー"                                                                |
+ | approval_question      | "Phase {N} artifacts reviewed. Proceed to the next phase?"                           | "Phase {N} の成果物を確認しました。次のフェーズに進みますか？"                |
+ | approve_and_continue   | "Approve and continue"                                                               | "承認して続行"                                                                |
+ | request_modification   | "Request modification"                                                               | "修正を指示"                                                                  |
+ | abort                  | "Abort"                                                                              | "中断"                                                                        |
++| approve_despite_findings | "Approve despite findings"                                                         | "指摘を承知の上で承認"                                                       |
++| continue_rollback      | "Continue rollback"                                                                  | "rollback を継続"                                                            |
++| doc_review_failed_header | "Doc review failed"                                                                | "ドキュメントレビュー失敗"                                                   |
++| doc_review_failed_question | "doc-reviewer reported {N} inconsistencies after {M} rollbacks. How would you like to proceed?" | "doc-reviewer が {M} 回の rollback 後も {N} 件の不整合を報告しています。どう進めますか？" |
+```
+
+---
+
+## 7. PR strategy (final decision)
+
+analyst design-note §8.3 の推奨と同じく **2 PR 分割** を採用する。
+
+| PR | 内容 | ファイル | 依存 |
+|----|------|---------|------|
+| **PR 1** | doc-reviewer 本体 + orchestrator-rules + reviewer 境界 | `.claude/agents/doc-reviewer.md` (新規), `.claude/orchestrator-rules.md` (編集), `.claude/agents/reviewer.md` (Mission 1 段落追記) | なし |
+| **PR 2** | 各 flow への配線 | `.claude/agents/delivery-flow.md`, `discovery-flow.md`, `maintenance-flow.md` (+ aphelion-overview.md / localization-dictionary.md があれば) | PR 1 |
+
+**理由**:
+- PR 1 のみで `/doc-reviewer` standalone 起動は機能する (orchestrator
+  経由でなくても agent は動く)。レビュアの認知負荷を分割する効果がある
+- PR 2 は配線のみで、実装ロジックの議論が PR 1 で済んでいる前提
+- 1 PR 統合案 (7 ファイル) は、reviewer 観点で「設計議論」と「機械的
+  配線」が混じり review 効率が落ちる
+
+PR 1 単体で **半機能状態** が出来上がる点は許容する (orchestrator が
+auto-insert しないだけで、agent としては正常)。
+
+---
+
+## 8. Implementation checklist for developer
+
+### 8.1 Phase 1 (PR 1)
+
+- [ ] `.claude/agents/doc-reviewer.md` を新規作成 (§3 outline に従う)
+  - [ ] YAML frontmatter (§3.1)
+  - [ ] Project-Specific Behavior block (§3.2)
+  - [ ] Mission section + reviewer 境界 (§3.3)
+  - [ ] Inputs section (§3.4) — design-note フィルタ条件含む
+  - [ ] 5 Review Perspectives (§3.5)
+  - [ ] Severity definition table (§3.6)
+  - [ ] Output Report Format sample (§3.7)
+  - [ ] AGENT_RESULT contract (§3.8)
+  - [ ] Workflow section (§3.9)
+  - [ ] Standalone invocation section (§3.10)
+  - [ ] Out of scope section (§3.11)
+  - [ ] Completion conditions (§3.12)
+  - [ ] 行数確認 (~180 行目安、最大 200 行)
+- [ ] `.claude/orchestrator-rules.md` 編集
+  - [ ] "Doc Reviewer Auto-insertion" セクション追加 (§4.1)
+  - [ ] "Rollback Limit (Common)" 共通化 (§4.2.1)
+  - [ ] "Doc Review FAIL Rollback Flow" 追加 (§4.2.2)
+  - [ ] "Approval Gate after Doc Review FAIL" 追加 (§4.3)
+  - [ ] **既存の Test/Review CRITICAL rollback 動作が変化していないこと** を git diff で確認
+- [ ] `.claude/agents/reviewer.md` 編集
+  - [ ] Mission section に境界記述 1 段落追記 (§5.4)
+- [ ] PR 1 の commit message: `feat: introduce doc-reviewer agent (#91)`
+- [ ] PR 1 の body に `Closes #91` ではなく `Linked Issue: #91` (PR 2 で
+      最終的に閉じるため)
+
+### 8.2 Phase 2 (PR 2)
+
+- [ ] `.claude/agents/delivery-flow.md` 編集
+  - [ ] Managed Flows の Phase 1/2/3 行に "→ doc-reviewer (auto)" 追記 (§5.1.1)
+  - [ ] Rollback Rules に Rollback Flow on Doc Review FAIL 追加 (§5.1.2)
+  - [ ] Rollback Limit を Common 参照に書き換え
+- [ ] `.claude/agents/discovery-flow.md` 編集
+  - [ ] 各 plan の最終 Phase 行に "→ doc-reviewer (auto)" 追記 (§5.2.1)
+  - [ ] Minimal の構造的 skip 注記追加
+  - [ ] Rollback Rules に Pattern 3 追加 (§5.2.2)
+- [ ] `.claude/agents/maintenance-flow.md` 編集
+  - [ ] 各 plan の analyst 行に "→ doc-reviewer (conditional auto)" 追記 (§5.3.1)
+  - [ ] Conditional auto 注記追加
+  - [ ] Rollback Rules table に doc-reviewer FAIL 行追加 (§5.3.2)
+- [ ] `.claude/rules/aphelion-overview.md` (存在すれば、§5.5)
+  - [ ] Update history 追記
+  - [ ] Agent Directory に Cross-cutting agents 表追加
+  - [ ] Domain and Flow Overview 図に注追加
+- [ ] `.claude/rules/localization-dictionary.md` (存在すれば、§6)
+  - [ ] Approval Gate 表に 4 行追加
+- [ ] PR 2 の commit message: `feat: wire doc-reviewer into all three flows (#91)`
+- [ ] PR 2 の body に `Closes #91`
+
+### 8.3 commit 単位
+
+- PR 1 は 3 commit 推奨 (doc-reviewer / orchestrator-rules / reviewer
+  境界 を別コミット)
+- PR 2 は 4 commit (delivery / discovery / maintenance / overview+dict)
+
+### 8.4 行数 sanity check
+
+| ファイル | 既存 | 想定後 |
+|----------|------|--------|
+| doc-reviewer.md (新規) | — | ~180 |
+| orchestrator-rules.md | ~446 | ~530 |
+| reviewer.md | ~197 | ~205 |
+| delivery-flow.md | ~372 | ~395 |
+| discovery-flow.md | ~379 | ~415 |
+| maintenance-flow.md | ~322 | ~335 |
+
+---
+
+## 9. Test strategy
+
+### 9.1 自己テストの限界
+
+本リポジトリ (Aphelion 本体) には SPEC.md / ARCHITECTURE.md が存在しない
+(`.claude/agents/*.md` 自身が「アーキテクチャ成果物」)。したがって
+**doc-reviewer を本リポジトリに対して実行しても比較対象が無い** ため、
+フル機能テストは実施できない。これは analyst design-note §7 (Out of
+scope #5) で既に確認済み。
+
+### 9.2 採用するテスト手段
+
+| 種別 | 手段 | 場所 |
+|------|------|------|
+| 形式テスト | YAML frontmatter / markdown lint | `.claude/agents/doc-reviewer.md` 本体に対し developer が手動実行 |
+| 構造テスト | 必須セクション (Mission / Inputs / 5 Perspectives / AGENT_RESULT) の存在を grep で確認 | developer が `grep -E '^## ' .claude/agents/doc-reviewer.md` で目視確認 |
+| 動作テスト (PASS シナリオ) | 整合した SPEC.md + ARCHITECTURE.md fixture で起動 → INCONSISTENCY_COUNT=0 を期待 | 別リポジトリ (developer が選定。例: Aphelion で過去 spec-designer を走らせた sample プロジェクト) |
+| 動作テスト (FAIL シナリオ) | 故意に UC を 1 つ落とした SPEC.md + ARCHITECTURE.md で起動 → INCONSISTENCY_COUNT>=1 を期待 | 同上 |
+| 統合テスト | delivery-flow を auto-approve mode で走らせ doc-reviewer が auto-insert されることを確認 | 別リポジトリ |
+
+### 9.3 fixture 推奨
+
+developer は本リポジトリ内に **fixture サンプル** (架空の SPEC.md /
+ARCHITECTURE.md ペア) を **配置しない** こと。理由:
+- `.claude/rules/file-operation-principles.md`「設計文書に存在しない
+  ディレクトリは作らない」原則に反する
+- fixture は別 issue (analyst design-note §6.2) で `docs/examples/`
+  配下に配置を検討する案があるが、本 issue の scope 外
+
+### 9.4 acceptance check (分散実行)
+
+PR 1 マージ後、開発者は以下を手動確認:
+
+```bash
+# YAML frontmatter parse
+head -20 .claude/agents/doc-reviewer.md
+
+# 必須セクションの存在
+grep -E '^## (Project-Specific Behavior|Mission|Inputs|.*Review Perspectives|.*Output|AGENT_RESULT|Workflow|Standalone|Out of Scope|Completion Conditions)$' .claude/agents/doc-reviewer.md
+
+# Tools 行の確認 (Bash が含まれていないこと)
+grep -E '^tools:' .claude/agents/doc-reviewer.md
+```
+
+---
+
+## 10. Rollback / failure mode considerations
+
+### 10.1 既存挙動を変えない不変条件
+
+- delivery-flow.md / discovery-flow.md / maintenance-flow.md の
+  既存 rollback 上限 (max 3) の **挙動値** は変更しない。値の出処を
+  orchestrator-rules.md 共通セクションに集約するだけのリファクタである
+- security-auditor の必須性 (Delivery 全プラン) は変更しない
+- analyst の side-entry ステータスは変更しない
+
+### 10.2 想定する failure mode
+
+| Failure | 原因 | 対処 |
+|---------|------|------|
+| doc-reviewer FAIL が 3 回連続 | INCONSISTENCY を機械的に直しきれないケース (SPEC 自身の構造的欠陥など) | "Approve despite findings" でユーザに最終判断を委ねる (§4.3) |
+| doc-reviewer がエラー (STATUS: error) | 入力ファイル読込失敗 / 想定外のフォーマット | Common Error Handling を踏襲 (Retry / Skip / Abort)。auto-approve mode では Retry × 3 |
+| auto-insertion で同一 phase の二重実行 | rollback 後に flag リセット忘れ | `doc_reviewer_inserted_for_phase_id` flag を確実にリセット (§4.1 Double-Execution Prevention) |
+| standalone 起動 + 比較対象 1 件のみ | ユーザが SPEC.md だけを渡した | STATUS: success / pass / "No comparison target available" の NOTES を返す (§3.4 Behavior on missing inputs) |
+| reviewer.md 境界記述追加で既存 Mission 文面が破損 | 編集ミス | PR 1 の git diff で `git diff .claude/agents/reviewer.md` を目視確認。新規追加 1 段落以外の差分が出ないこと |
+
+### 10.3 ロールアウト戦略
+
+- PR 1 マージ直後: doc-reviewer は orchestrator から auto-insert され
+  ない (PR 2 まで wiring なし)。standalone 起動でのみ機能する
+- PR 2 マージ直後: 全 flow から auto-insert される。**既存ユーザの
+  ワークフローに新たな承認ゲートが 1〜3 件追加される** ため、CHANGELOG
+  および wiki に Breaking-ish change として記載する (developer が PR 2
+  description に記載)
+- 万一問題発生時: PR 2 を revert すれば PR 1 の状態に戻り、ユーザに
+  影響を与えない (graceful degradation)
+
+---
+
+## Implementation handoff to developer
+
+本書の §3〜§10 を順に消化することで `.claude/agents/doc-reviewer.md`
+本体および各 flow への配線が完了する。実装中に設計上の疑問が出た場合は
+`AGENT_RESULT.STATUS: blocked` で architect に差し戻すこと。

--- a/docs/wiki/en/Home.md
+++ b/docs/wiki/en/Home.md
@@ -19,7 +19,7 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 | Project overview and motivation | [Architecture: Domain Model](./Architecture-Domain-Model.md): 3-domain model and session isolation |
 | Quick Start commands | [Getting Started](./Getting-Started.md): Claude Code setup, first-run walkthrough, scenarios, troubleshooting |
 | Triage plan table (summary) | [Triage System](./Triage-System.md): selection logic, conditions, and agent matrices |
-| Agent list (names only) | Agents Reference (split by domain): [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — all 31 agents with inputs, outputs, NEXT conditions |
+| Agent list (names only) | Agents Reference (split by domain): [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — all 32 agents with inputs, outputs, NEXT conditions |
 | — | [Rules Reference](./Rules-Reference.md): 9 behavior rules with scope and customization notes |
 | — | [Contributing](./Contributing.md): how to add agents, rules, and maintain the wiki |
 
@@ -34,7 +34,7 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 | [Getting Started](./Getting-Started.md) | Claude Code setup, first run, usage scenarios, command reference | New users |
 | Architecture (3 pages) | [Domain Model](./Architecture-Domain-Model.md), [Protocols](./Architecture-Protocols.md), [Operational Rules](./Architecture-Operational-Rules.md) — 3-domain model, handoff files, AGENT_RESULT protocol, runtime rules | Agent developers |
 | [Triage System](./Triage-System.md) | 4-tier plan selection logic, per-domain agent matrices, mandatory agents | All users |
-| Agents Reference (5 pages) | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — all 31 agents | Agent developers |
+| Agents Reference (5 pages) | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — all 32 agents | Agent developers |
 | [Rules Reference](./Rules-Reference.md) | All 9 behavior rules: scope, auto-load, interactions | Agent developers |
 | [Contributing](./Contributing.md) | Adding agents, rules; bilingual sync workflow | Agent developers |
 

--- a/docs/wiki/ja/Home.md
+++ b/docs/wiki/ja/Home.md
@@ -20,7 +20,7 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 | プロジェクト概要と背景 | [Architecture: Domain Model](./Architecture-Domain-Model.md): 3 ドメインモデルとセッション分離 |
 | クイックスタートコマンド | [Getting Started](./Getting-Started.md): Claude Code セットアップ、初回実行ウォークスルー、シナリオ、トラブルシューティング |
 | トリアージプラン表（概要） | [Triage System](./Triage-System.md): 選択ロジック、条件、エージェントマトリクス |
-| エージェント一覧（名前のみ） | Agents Reference（ドメイン別）: [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — 31 エージェントの入出力と NEXT 条件 |
+| エージェント一覧（名前のみ） | Agents Reference（ドメイン別）: [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — 32 エージェントの入出力と NEXT 条件 |
 | — | [Rules Reference](./Rules-Reference.md): 9 つの行動ルールのスコープとカスタマイズ方法 |
 | — | [Contributing](./Contributing.md): エージェント・ルールの追加方法、Wiki メンテナンス |
 
@@ -35,7 +35,7 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 | [Getting Started](./Getting-Started.md) | Claude Code セットアップ、初回実行、利用シナリオ、コマンドリファレンス | 新規ユーザー |
 | Architecture（3 ページ） | [Domain Model](./Architecture-Domain-Model.md), [Protocols](./Architecture-Protocols.md), [Operational Rules](./Architecture-Operational-Rules.md) — 3 ドメインモデル、ハンドオフファイル、`AGENT_RESULT` プロトコル、ランタイム挙動 | エージェント開発者 |
 | [Triage System](./Triage-System.md) | 4 ティアプラン選択ロジック、ドメイン別エージェントマトリクス、必須エージェント | 全ユーザー |
-| Agents Reference（5 ページ） | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — 31 エージェント全件 | エージェント開発者 |
+| Agents Reference（5 ページ） | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md) — 32 エージェント全件 | エージェント開発者 |
 | [Rules Reference](./Rules-Reference.md) | 9 つの行動ルール: スコープ・自動ロード・相互関係 | エージェント開発者 |
 | [Contributing](./Contributing.md) | エージェント・ルールの追加、バイリンガル同期ワークフロー | エージェント開発者 |
 


### PR DESCRIPTION
## Summary
- Add new cross-cutting agent `doc-reviewer` for SPEC/ARCHITECTURE/UI_SPEC/design-note consistency review
- Integrate doc-reviewer auto-insertion + rollback flow into orchestrator-rules.md
- Clarify reviewer ↔ doc-reviewer boundary (vertical vs. horizontal consistency)
- Add design-notes (analyst + architect outputs) for full traceability

## Related Issue
Linked Issue: #91 (PR 1 of 2 — flow agent wiring follows in PR 2; do not auto-close)

## Linked Plans
- docs/design-notes/doc-reviewer-agent-introduction.md
- docs/design-notes/doc-reviewer-architecture.md

## Test plan
- [ ] doc-reviewer.md frontmatter parses (Tools/Model fields valid)
- [ ] orchestrator-rules.md rollback limit value (3) unchanged from before
- [ ] reviewer.md mission paragraph addition does not regress existing behavior
- [ ] Manual review of cross-doc references (links between design-notes)