### PR TITLE
docs: add shields.io badges to README (#101)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -3,6 +3,7 @@
 Claude Code 向け AI コーディングエージェント定義集です。39 の専門エージェントがプロジェクトの全工程を自動化します。
 
 [![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.com-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.com/)
+![agents](https://img.shields.io/badge/agents-39-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-12-green) ![license](https://img.shields.io/badge/license-MIT-blue)
 
 **[English README](README.md)**
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A collection of AI coding agent definitions for Claude Code that automates the entire project lifecycle with 39 specialized agents.
 
 [![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.com-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.com/)
+![agents](https://img.shields.io/badge/agents-39-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-12-green) ![license](https://img.shields.io/badge/license-MIT-blue)
 
 **[日本語版 README はこちら](README.ja.md)**
 


### PR DESCRIPTION
## Summary
- Add 4 shields.io static badges (agents / commands / rules / license) directly after the existing Wiki badge in both README.md and README.ja.md
- Hooks badge intentionally omitted — Aphelion does not use Claude Code hooks (analyst decision, design-note §3 / §5)

## Related Issue
Closes #101

## Linked Plan
docs/design-notes/readme-shields-badges.md

## Implementation values (counted live from main)
- agents: 39 (.claude/agents/*.md)
- commands: 14 (.claude/commands/*.md)
- rules: 12 (src/.claude/rules/*.md — canonical source distributed via npx)
- license: MIT

## Test plan
- [ ] scripts/check-readme-wiki-sync.sh passes (Check 1/2/3)
- [ ] README.md and README.ja.md have identical badge line at the same relative position
- [ ] Visual check: badges render correctly on GitHub PR view