### PR TITLE
docs: fix outdated agent / domain / page references in wiki landing and surroundings (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **doc-reviewer** cross-cutting agent for SPEC ↔ ARCHITECTURE ↔ design-note consistency review.
+  Auto-inserted by orchestrators per `orchestrator-rules.md` triggers. (#91, PR #92 / #93 / #95)
+- **doc-flow** 5th orchestrator with 6 author agents (`hld-author`, `lld-author`,
+  `api-reference-author`, `ops-manual-author`, `user-manual-author`, `handover-author`)
+  for customer-deliverable generation (HLD / LLD / API reference / ops manual / user manual /
+  handover). Invoked via `/doc-flow`. (#54, PR #96 / #97 / #98)
+- 12 markdown templates under `.claude/templates/doc-flow/` (6 doc types × en/ja). (#54)
+- `docs/wiki/{en,ja}/Agents-Doc.md` — 6th Agents Reference wiki page covering the 6
+  Doc domain author agents (5 → 6 pages). (#54)
+- shields.io badges in README.md / README.ja.md (`agents-39` / `commands-14` / `rules-12` /
+  `license-MIT`) plus a Cloudflare Pages "Wiki" badge linking to https://aphelion-agents.com/.
+  (#101, PR #102)
+
+### Changed
+
+- Agent count bumped 31 → 32 (`doc-reviewer`, #91) → 39 (`doc-flow` + 6 authors, #54).
+  Reflected in README.md / README.ja.md body, `aphelion-overview.md`, and
+  `docs/wiki/{en,ja}/Home.md`. (#54 / #91)
+- Aphelion expanded from 4-domain to 5-domain workflow (added Doc domain). (#54)
+- Agents Reference split from 5 pages to 6 pages (`agents-doc` added to wiki and sidebar). (#54)
+- `docs/wiki/{en,ja}/Home.md` rule count corrected 9 → 12 to match actual files in
+  `src/.claude/rules/` (catch-up after `denial-categories` #31 and
+  `localization-dictionary` addition). (#103)
+- `site/src/content/docs/{en,ja}/index.mdx` (Cloudflare Pages landing) refreshed for
+  39 agents / 5 flows / Doc domain card / doc-reviewer mention. (#103)
+- `site/astro.config.mjs` PAGES array: `Agents Reference` group now lists `agents-doc`
+  so the Doc domain page appears in the sidebar. (#103)
+
+### Added (continued)
+
 - `.github/workflows/check-readme-wiki-sync.yml` — advisory CI check for README ↔ Wiki
   drift; runs on every PR (`pull_request: [opened, edited, synchronize]`). Read-only
   check; does not block merge. Promotion to a required status check is a deliberate

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,7 +67,7 @@ cd /path/to/your-project && claude
 - [Getting Started](docs/wiki/ja/Getting-Started.md) — 初回実行ウォークスルー、利用シナリオ、トラブルシューティング
 - [Architecture: Domain Model](docs/wiki/ja/Architecture-Domain-Model.md) — 3領域モデルとハンドオフファイル
 - [Triage System](docs/wiki/ja/Triage-System.md) — プランティアとエージェント選択
-- [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 32 エージェント
+- [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 39 エージェント
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ All commands: run `/aphelion-help` after init, or see [Getting Started](docs/wik
 - [Getting Started](docs/wiki/en/Getting-Started.md) — first-run walkthrough, scenarios, troubleshooting
 - [Architecture: Domain Model](docs/wiki/en/Architecture-Domain-Model.md) — 3-domain model & handoff files
 - [Triage System](docs/wiki/en/Triage-System.md) — plan tiers & agent selection
-- [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 32 agents
+- [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 39 agents
 
 ---
 

--- a/docs/wiki/en/Home.md
+++ b/docs/wiki/en/Home.md
@@ -3,6 +3,7 @@
 > **Language**: [English](../en/Home.md) | [日本語](../ja/Home.md)
 > **Last updated**: 2026-04-30
 > **Update history**:
+>   - 2026-04-30: Bump rule count 9 → 12 (#103)
 >   - 2026-04-30: Add Agents-Doc.md to Agents Reference (5→6 pages), Doc Flow to glossary (#54)
 >   - 2026-04-25: link targets refreshed for Architecture / Agents-Reference page splits, #42
 > **Audience**: All users
@@ -23,7 +24,7 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 | Quick Start commands | [Getting Started](./Getting-Started.md): Claude Code setup, first-run walkthrough, scenarios, troubleshooting |
 | Triage plan table (summary) | [Triage System](./Triage-System.md): selection logic, conditions, and agent matrices |
 | Agent list (names only) | Agents Reference (split by domain): [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md), [Doc](./Agents-Doc.md) — all 39 agents with inputs, outputs, NEXT conditions |
-| — | [Rules Reference](./Rules-Reference.md): 9 behavior rules with scope and customization notes |
+| — | [Rules Reference](./Rules-Reference.md): 12 behavior rules with scope and customization notes |
 | — | [Contributing](./Contributing.md): how to add agents, rules, and maintain the wiki |
 
 ---
@@ -38,7 +39,7 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 | Architecture (3 pages) | [Domain Model](./Architecture-Domain-Model.md), [Protocols](./Architecture-Protocols.md), [Operational Rules](./Architecture-Operational-Rules.md) — 3-domain model, handoff files, AGENT_RESULT protocol, runtime rules | Agent developers |
 | [Triage System](./Triage-System.md) | 4-tier plan selection logic, per-domain agent matrices, mandatory agents | All users |
 | Agents Reference (6 pages) | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md), [Doc](./Agents-Doc.md) — all 39 agents | Agent developers |
-| [Rules Reference](./Rules-Reference.md) | All 9 behavior rules: scope, auto-load, interactions | Agent developers |
+| [Rules Reference](./Rules-Reference.md) | All 12 behavior rules: scope, auto-load, interactions | Agent developers |
 | [Contributing](./Contributing.md) | Adding agents, rules; bilingual sync workflow | Agent developers |
 
 ---

--- a/docs/wiki/ja/Home.md
+++ b/docs/wiki/ja/Home.md
@@ -3,6 +3,7 @@
 > **Language**: [English](../en/Home.md) | [日本語](../ja/Home.md)
 > **Last updated**: 2026-04-30
 > **Update history**:
+>   - 2026-04-30: ルール数 9 → 12 に修正 (#103)
 >   - 2026-04-30: Agents-Doc.md を Agents Reference に追加（5 → 6 ページ）、Doc Flow を用語集に追加 (#54)
 >   - 2026-04-25: terminology rebalance per #40
 > **EN canonical**: 2026-04-30 of wiki/en/Home.md
@@ -24,7 +25,7 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 | クイックスタートコマンド | [Getting Started](./Getting-Started.md): Claude Code セットアップ、初回実行ウォークスルー、シナリオ、トラブルシューティング |
 | トリアージプラン表（概要） | [Triage System](./Triage-System.md): 選択ロジック、条件、エージェントマトリクス |
 | エージェント一覧（名前のみ） | Agents Reference（ドメイン別）: [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md), [Doc](./Agents-Doc.md) — 39 エージェントの入出力と NEXT 条件 |
-| — | [Rules Reference](./Rules-Reference.md): 9 つの行動ルールのスコープとカスタマイズ方法 |
+| — | [Rules Reference](./Rules-Reference.md): 12 つの行動ルールのスコープとカスタマイズ方法 |
 | — | [Contributing](./Contributing.md): エージェント・ルールの追加方法、Wiki メンテナンス |
 
 ---
@@ -39,7 +40,7 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 | Architecture（3 ページ） | [Domain Model](./Architecture-Domain-Model.md), [Protocols](./Architecture-Protocols.md), [Operational Rules](./Architecture-Operational-Rules.md) — 3 ドメインモデル、ハンドオフファイル、`AGENT_RESULT` プロトコル、ランタイム挙動 | エージェント開発者 |
 | [Triage System](./Triage-System.md) | 4 ティアプラン選択ロジック、ドメイン別エージェントマトリクス、必須エージェント | 全ユーザー |
 | Agents Reference（6 ページ） | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md), [Doc](./Agents-Doc.md) — 39 エージェント全件 | エージェント開発者 |
-| [Rules Reference](./Rules-Reference.md) | 9 つの行動ルール: スコープ・自動ロード・相互関係 | エージェント開発者 |
+| [Rules Reference](./Rules-Reference.md) | 12 つの行動ルール: スコープ・自動ロード・相互関係 | エージェント開発者 |
 | [Contributing](./Contributing.md) | エージェント・ルールの追加、バイリンガル同期ワークフロー | エージェント開発者 |
 
 ---

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -32,6 +32,7 @@ const PAGES = [
 			{ slug: 'agents-delivery',      labelEn: 'Delivery Domain',               labelJa: 'Delivery Domain'               },
 			{ slug: 'agents-operations',    labelEn: 'Operations Domain',             labelJa: 'Operations Domain'             },
 			{ slug: 'agents-maintenance',   labelEn: 'Maintenance Domain',            labelJa: 'Maintenance Domain'            },
+			{ slug: 'agents-doc',           labelEn: 'Doc Domain',                    labelJa: 'Doc Domain'                    },
 		],
 	},
 	{ slug: 'rules-reference',  labelEn: 'Rules Reference',   labelJa: 'Rules Reference'    },

--- a/site/src/content/docs/en/index.mdx
+++ b/site/src/content/docs/en/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Aphelion
-description: AI coding agent workflow for Claude Code — Discovery, Delivery, Operations in three independent domains.
+description: AI coding agent workflow for Claude Code — Discovery, Delivery, Operations, Maintenance, and on-demand Doc generation across five independent domains.
 template: splash
 hero:
-  tagline: AI coding agents for the full project lifecycle — Discovery, Delivery, Operations.
+  tagline: AI coding agents for the full project lifecycle — Discovery, Delivery, Operations, Maintenance, and Doc.
   actions:
     - text: Get Started
       link: /en/getting-started/
@@ -21,11 +21,11 @@ hero:
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-## Meet the 29 Agents across 4 Flows
+## Meet the 39 Agents across 5 Flows
 
 <CardGrid>
 	<Card title="Flow Orchestrators" icon="rocket">
-		4 top-level orchestrators: discovery-flow, delivery-flow, operations-flow, maintenance-flow.
+		5 top-level orchestrators: discovery-flow, delivery-flow, operations-flow, maintenance-flow, doc-flow.
 		[→ Orchestrators & Cross-Cutting](/en/agents-orchestrators/)
 	</Card>
 	<Card title="Discovery Domain" icon="magnifier">
@@ -44,8 +44,12 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		2 agents (change-classifier, impact-analyzer) that triage and scope changes to existing projects.
 		[→ Maintenance Domain](/en/agents-maintenance/)
 	</Card>
+	<Card title="Doc Domain" icon="document">
+		7 agents (1 orchestrator + 6 authors: hld-author, lld-author, api-reference-author, ops-manual-author, user-manual-author, handover-author) generating customer-facing deliverables (HLD / LLD / API reference / operations manual / user manual / handover).
+		[→ Doc Domain](/en/agents-doc/)
+	</Card>
 	<Card title="Safety & Standalone" icon="approve-check">
-		sandbox-runner for isolated execution, plus analyst and codebase-analyzer for standalone use.
+		sandbox-runner for isolated execution, doc-reviewer for cross-cutting documentation consistency review, plus analyst and codebase-analyzer for standalone use.
 		[→ Orchestrators & Cross-Cutting](/en/agents-orchestrators/)
 	</Card>
 </CardGrid>
@@ -66,7 +70,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		[→ Triage System](/en/triage-system/)
 	</Card>
 	<Card title="Agents Reference" icon="open-book">
-		All 29 agents — split by domain (Orchestrators, Discovery, Delivery, Operations, Maintenance) with responsibilities, inputs, outputs, and NEXT conditions.
+		All 39 agents — split by domain (Orchestrators, Discovery, Delivery, Operations, Maintenance, Doc) with responsibilities, inputs, outputs, and NEXT conditions.
 		[→ Orchestrators & Cross-Cutting](/en/agents-orchestrators/)
 	</Card>
 	<Card title="Rules Reference" icon="setting">

--- a/site/src/content/docs/ja/index.mdx
+++ b/site/src/content/docs/ja/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Aphelion
-description: Claude Code 向け AI コーディングエージェントワークフロー — Discovery / Delivery / Operations の 3 ドメイン構成。
+description: Claude Code 向け AI コーディングエージェントワークフロー — Discovery / Delivery / Operations / Maintenance / Doc の 5 ドメイン構成。
 template: splash
 hero:
-  tagline: プロジェクトの全工程を支える AI コーディングエージェント — Discovery・Delivery・Operations。
+  tagline: プロジェクトの全工程を支える AI コーディングエージェント — Discovery・Delivery・Operations・Maintenance・Doc。
   actions:
     - text: Get Started
       link: /ja/getting-started/
@@ -21,11 +21,11 @@ hero:
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-## 29 エージェント × 4 フロー
+## 39 エージェント × 5 フロー
 
 <CardGrid>
 	<Card title="Flow Orchestrators" icon="rocket">
-		4 つの Flow Orchestrator: discovery-flow, delivery-flow, operations-flow, maintenance-flow。
+		5 つの Flow Orchestrator: discovery-flow, delivery-flow, operations-flow, maintenance-flow, doc-flow。
 		[→ Orchestrators & Cross-Cutting](/ja/agents-orchestrators/)
 	</Card>
 	<Card title="Discovery Domain" icon="magnifier">
@@ -44,8 +44,12 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		既存プロジェクトの変更をトリアージ・範囲確定する 2 エージェント (change-classifier, impact-analyzer)。
 		[→ Maintenance Domain](/ja/agents-maintenance/)
 	</Card>
+	<Card title="Doc Domain" icon="document">
+		7 エージェント（1 オーケストレーター + 6 オーサー: hld-author, lld-author, api-reference-author, ops-manual-author, user-manual-author, handover-author）が HLD / LLD / API リファレンス / 運用マニュアル / ユーザーマニュアル / 引継ぎ資料を生成。
+		[→ Doc Domain](/ja/agents-doc/)
+	</Card>
 	<Card title="Safety / Standalone" icon="approve-check">
-		隔離実行の sandbox-runner と、単独起動可能な analyst / codebase-analyzer。
+		隔離実行の sandbox-runner、横断的なドキュメント整合性レビューの doc-reviewer、単独起動可能な analyst / codebase-analyzer。
 		[→ Orchestrators & Cross-Cutting](/ja/agents-orchestrators/)
 	</Card>
 </CardGrid>
@@ -66,7 +70,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		[→ Triage System](/ja/triage-system/)
 	</Card>
 	<Card title="Agents Reference" icon="open-book">
-		29 エージェント全ての責務・入出力・NEXT 条件 — ドメイン別 5 ページに分割（Orchestrators・Discovery・Delivery・Operations・Maintenance）。
+		39 エージェント全ての責務・入出力・NEXT 条件 — ドメイン別 6 ページに分割（Orchestrators・Discovery・Delivery・Operations・Maintenance・Doc）。
 		[→ Orchestrators & Cross-Cutting](/ja/agents-orchestrators/)
 	</Card>
 	<Card title="Rules Reference" icon="setting">


### PR DESCRIPTION
## Summary

Audit-driven sync fixup discovered after the doc-flow (#54) / doc-reviewer (#91) / agents-39 badge (#101) work landed:

- **site/index.mdx (en + ja)**: 29 → 39 agents, 4 → 5 flows, add Doc Domain card, mention doc-reviewer in Safety & Standalone card
- **README pair L70**: stale "32 agents" link text → 39
- **wiki/Home.md (en + ja)**: "9 behavior rules" → 12; update history entries added
- **astro.config.mjs**: register `agents-doc` page in PAGES Agents Reference group (was missing → sidebar didn't expose it)
- **CHANGELOG [Unreleased]**: backfill doc-flow, doc-reviewer, Agents-Doc, agents-39 badge, agent count bump entries

## Related Issue

Closes #103

## Linked Plan

docs/design-notes/wiki-and-site-update-audit.md

## Test plan

- [x] `bash scripts/check-readme-wiki-sync.sh` passes locally
- [x] `cd site && npm run build` succeeds (31 pages built, `/en/agents-doc/` and `/ja/agents-doc/` generated)
- [ ] Cloudflare Pages build succeeds (astro build via PR preview)
- [ ] aphelion-agents.com landing now shows 39 agents / 5 flows / Doc Domain card
- [ ] Sidebar exposes Agents Doc Domain reference page

## Out of scope (tracked separately)

- Rules-Reference.md may still list 11 rule entries (separate audit)
- check-readme-wiki-sync.sh Check 1 only inspects L3, missed L70 drift (could be improved separately)