### PR TITLE
docs: add Aphelion hooks rule + reference + rules-12-to-13 (PR 1b/4) (#107)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -3,7 +3,7 @@
 Claude Code 向け AI コーディングエージェント定義集です。40 の専門エージェントがプロジェクトの全工程を自動化します。
 
 [![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.com-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.com/)
-![agents](https://img.shields.io/badge/agents-40-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-12-green) ![license](https://img.shields.io/badge/license-MIT-blue)
+![agents](https://img.shields.io/badge/agents-40-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-13-green) ![license](https://img.shields.io/badge/license-MIT-blue)
 
 **[English README](README.md)**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A collection of AI coding agent definitions for Claude Code that automates the entire project lifecycle with 40 specialized agents.
 
 [![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.com-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.com/)
-![agents](https://img.shields.io/badge/agents-40-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-12-green) ![license](https://img.shields.io/badge/license-MIT-blue)
+![agents](https://img.shields.io/badge/agents-40-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-13-green) ![license](https://img.shields.io/badge/license-MIT-blue)
 
 **[日本語版 README はこちら](README.ja.md)**
 

--- a/TASK.md
+++ b/TASK.md
@@ -16,7 +16,7 @@ Status: In progress
 - [x] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
 - [x] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
 - [x] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
-- [ ] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md
+- [x] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md
 - [ ] TASK-009: `site/astro.config.mjs` PAGES 配列に Hooks-Reference エントリ追加 | Target file: site/astro.config.mjs
 - [ ] TASK-010: `README.md` / `README.ja.md` rules badge 12→13 | Target file: README.md, README.ja.md
 

--- a/TASK.md
+++ b/TASK.md
@@ -13,7 +13,7 @@ Status: In progress
 - [x] TASK-002: `src/.claude/rules/aphelion-overview.md` に Hook layer 段落追加 | Target file: src/.claude/rules/aphelion-overview.md
 - [x] TASK-003: `docs/wiki/en/Rules-Reference.md` ルール追加 + 12→13 bump | Target file: docs/wiki/en/Rules-Reference.md
 - [x] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
-- [ ] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
+- [x] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
 - [ ] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
 - [ ] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
 - [ ] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md

--- a/TASK.md
+++ b/TASK.md
@@ -11,7 +11,7 @@ Status: In progress
 ### Phase 1b
 - [x] TASK-001: `src/.claude/rules/hooks-policy.md` 新規作成 | Target file: src/.claude/rules/hooks-policy.md
 - [x] TASK-002: `src/.claude/rules/aphelion-overview.md` に Hook layer 段落追加 | Target file: src/.claude/rules/aphelion-overview.md
-- [ ] TASK-003: `docs/wiki/en/Rules-Reference.md` ルール追加 + 12→13 bump | Target file: docs/wiki/en/Rules-Reference.md
+- [x] TASK-003: `docs/wiki/en/Rules-Reference.md` ルール追加 + 12→13 bump | Target file: docs/wiki/en/Rules-Reference.md
 - [ ] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
 - [ ] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
 - [ ] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md

--- a/TASK.md
+++ b/TASK.md
@@ -18,7 +18,7 @@ Status: In progress
 - [x] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
 - [x] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md
 - [x] TASK-009: `site/astro.config.mjs` PAGES 配列に Hooks-Reference エントリ追加 | Target file: site/astro.config.mjs
-- [ ] TASK-010: `README.md` / `README.ja.md` rules badge 12→13 | Target file: README.md, README.ja.md
+- [x] TASK-010: `README.md` / `README.ja.md` rules badge 12→13 | Target file: README.md, README.ja.md
 
 ## Recent Commits
 (Record git log --oneline -3 after each task completion.)

--- a/TASK.md
+++ b/TASK.md
@@ -1,3 +1,27 @@
 # TASK.md
 
-（フェーズ未割当。次回 `developer` 起動時に ARCHITECTURE.md を参照して再生成されます）
+> Source: ARCHITECTURE.md (aphelion-hooks-architecture.md §12.2, 2026-04-30)
+
+## Phase: PR 1b/4 — Hooks rule + wiki + rules-count bump (#107)
+Last updated: 2026-05-01T00:10:00+09:00
+Status: In progress
+
+## Task List
+
+### Phase 1b
+- [x] TASK-001: `src/.claude/rules/hooks-policy.md` 新規作成 | Target file: src/.claude/rules/hooks-policy.md
+- [ ] TASK-002: `src/.claude/rules/aphelion-overview.md` に Hook layer 段落追加 | Target file: src/.claude/rules/aphelion-overview.md
+- [ ] TASK-003: `docs/wiki/en/Rules-Reference.md` ルール追加 + 12→13 bump | Target file: docs/wiki/en/Rules-Reference.md
+- [ ] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
+- [ ] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
+- [ ] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
+- [ ] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
+- [ ] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md
+- [ ] TASK-009: `site/astro.config.mjs` PAGES 配列に Hooks-Reference エントリ追加 | Target file: site/astro.config.mjs
+- [ ] TASK-010: `README.md` / `README.ja.md` rules badge 12→13 | Target file: README.md, README.ja.md
+
+## Recent Commits
+(Record git log --oneline -3 after each task completion.)
+
+## Session Interruption Notes
+(Record the situation here when a session is interrupted.)

--- a/TASK.md
+++ b/TASK.md
@@ -15,7 +15,7 @@ Status: In progress
 - [x] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
 - [x] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
 - [x] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
-- [ ] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
+- [x] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
 - [ ] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md
 - [ ] TASK-009: `site/astro.config.mjs` PAGES 配列に Hooks-Reference エントリ追加 | Target file: site/astro.config.mjs
 - [ ] TASK-010: `README.md` / `README.ja.md` rules badge 12→13 | Target file: README.md, README.ja.md

--- a/TASK.md
+++ b/TASK.md
@@ -17,7 +17,7 @@ Status: In progress
 - [x] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
 - [x] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
 - [x] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md
-- [ ] TASK-009: `site/astro.config.mjs` PAGES 配列に Hooks-Reference エントリ追加 | Target file: site/astro.config.mjs
+- [x] TASK-009: `site/astro.config.mjs` PAGES 配列に Hooks-Reference エントリ追加 | Target file: site/astro.config.mjs
 - [ ] TASK-010: `README.md` / `README.ja.md` rules badge 12→13 | Target file: README.md, README.ja.md
 
 ## Recent Commits

--- a/TASK.md
+++ b/TASK.md
@@ -12,7 +12,7 @@ Status: In progress
 - [x] TASK-001: `src/.claude/rules/hooks-policy.md` 新規作成 | Target file: src/.claude/rules/hooks-policy.md
 - [x] TASK-002: `src/.claude/rules/aphelion-overview.md` に Hook layer 段落追加 | Target file: src/.claude/rules/aphelion-overview.md
 - [x] TASK-003: `docs/wiki/en/Rules-Reference.md` ルール追加 + 12→13 bump | Target file: docs/wiki/en/Rules-Reference.md
-- [ ] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
+- [x] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
 - [ ] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
 - [ ] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
 - [ ] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md

--- a/TASK.md
+++ b/TASK.md
@@ -1,27 +1,3 @@
 # TASK.md
 
-> Source: ARCHITECTURE.md (aphelion-hooks-architecture.md §12.2, 2026-04-30)
-
-## Phase: PR 1b/4 — Hooks rule + wiki + rules-count bump (#107)
-Last updated: 2026-05-01T00:10:00+09:00
-Status: In progress
-
-## Task List
-
-### Phase 1b
-- [x] TASK-001: `src/.claude/rules/hooks-policy.md` 新規作成 | Target file: src/.claude/rules/hooks-policy.md
-- [x] TASK-002: `src/.claude/rules/aphelion-overview.md` に Hook layer 段落追加 | Target file: src/.claude/rules/aphelion-overview.md
-- [x] TASK-003: `docs/wiki/en/Rules-Reference.md` ルール追加 + 12→13 bump | Target file: docs/wiki/en/Rules-Reference.md
-- [x] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
-- [x] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
-- [x] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
-- [x] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
-- [x] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md
-- [x] TASK-009: `site/astro.config.mjs` PAGES 配列に Hooks-Reference エントリ追加 | Target file: site/astro.config.mjs
-- [x] TASK-010: `README.md` / `README.ja.md` rules badge 12→13 | Target file: README.md, README.ja.md
-
-## Recent Commits
-(Record git log --oneline -3 after each task completion.)
-
-## Session Interruption Notes
-(Record the situation here when a session is interrupted.)
+（フェーズ未割当。次回 `developer` 起動時に ARCHITECTURE.md を参照して再生成されます）

--- a/TASK.md
+++ b/TASK.md
@@ -10,7 +10,7 @@ Status: In progress
 
 ### Phase 1b
 - [x] TASK-001: `src/.claude/rules/hooks-policy.md` 新規作成 | Target file: src/.claude/rules/hooks-policy.md
-- [ ] TASK-002: `src/.claude/rules/aphelion-overview.md` に Hook layer 段落追加 | Target file: src/.claude/rules/aphelion-overview.md
+- [x] TASK-002: `src/.claude/rules/aphelion-overview.md` に Hook layer 段落追加 | Target file: src/.claude/rules/aphelion-overview.md
 - [ ] TASK-003: `docs/wiki/en/Rules-Reference.md` ルール追加 + 12→13 bump | Target file: docs/wiki/en/Rules-Reference.md
 - [ ] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
 - [ ] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md

--- a/TASK.md
+++ b/TASK.md
@@ -14,7 +14,7 @@ Status: In progress
 - [x] TASK-003: `docs/wiki/en/Rules-Reference.md` ルール追加 + 12→13 bump | Target file: docs/wiki/en/Rules-Reference.md
 - [x] TASK-004: `docs/wiki/ja/Rules-Reference.md` 同期 (EN canonical date 更新) | Target file: docs/wiki/ja/Rules-Reference.md
 - [x] TASK-005: `docs/wiki/en/Hooks-Reference.md` 新規作成 | Target file: docs/wiki/en/Hooks-Reference.md
-- [ ] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
+- [x] TASK-006: `docs/wiki/ja/Hooks-Reference.md` 新規作成 (Bilingual Sync) | Target file: docs/wiki/ja/Hooks-Reference.md
 - [ ] TASK-007: `docs/wiki/en/Home.md` Related Pages に Hooks-Reference 追加 + 12→13 | Target file: docs/wiki/en/Home.md
 - [ ] TASK-008: `docs/wiki/ja/Home.md` 同期 + 12→13 | Target file: docs/wiki/ja/Home.md
 - [ ] TASK-009: `site/astro.config.mjs` PAGES 配列に Hooks-Reference エントリ追加 | Target file: site/astro.config.mjs

--- a/docs/wiki/en/Home.md
+++ b/docs/wiki/en/Home.md
@@ -3,6 +3,7 @@
 > **Language**: [English](../en/Home.md) | [日本語](../ja/Home.md)
 > **Last updated**: 2026-05-01
 > **Update history**:
+>   - 2026-05-01: Add Hooks-Reference link, bump rule count 12 → 13 (#107)
 >   - 2026-05-01: Bump agent count 39 → 40 for visual-designer (#109)
 >   - 2026-04-30: Bump rule count 9 → 12 (#103)
 >   - 2026-04-30: Add Agents-Doc.md to Agents Reference (5→6 pages), Doc Flow to glossary (#54)
@@ -25,7 +26,8 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 | Quick Start commands | [Getting Started](./Getting-Started.md): Claude Code setup, first-run walkthrough, scenarios, troubleshooting |
 | Triage plan table (summary) | [Triage System](./Triage-System.md): selection logic, conditions, and agent matrices |
 | Agent list (names only) | Agents Reference (split by domain): [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md), [Doc](./Agents-Doc.md) — all 40 agents with inputs, outputs, NEXT conditions |
-| — | [Rules Reference](./Rules-Reference.md): 12 behavior rules with scope and customization notes |
+| — | [Rules Reference](./Rules-Reference.md): 13 behavior rules with scope and customization notes |
+| — | [Hooks Reference](./Hooks-Reference.md): Claude Code hooks distributed by Aphelion (MVP 3 hooks) |
 | — | [Contributing](./Contributing.md): how to add agents, rules, and maintain the wiki |
 
 ---
@@ -40,7 +42,8 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 | Architecture (3 pages) | [Domain Model](./Architecture-Domain-Model.md), [Protocols](./Architecture-Protocols.md), [Operational Rules](./Architecture-Operational-Rules.md) — 3-domain model, handoff files, AGENT_RESULT protocol, runtime rules | Agent developers |
 | [Triage System](./Triage-System.md) | 4-tier plan selection logic, per-domain agent matrices, mandatory agents | All users |
 | Agents Reference (6 pages) | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md), [Doc](./Agents-Doc.md) — all 40 agents | Agent developers |
-| [Rules Reference](./Rules-Reference.md) | All 12 behavior rules: scope, auto-load, interactions | Agent developers |
+| [Rules Reference](./Rules-Reference.md) | All 13 behavior rules: scope, auto-load, interactions | Agent developers |
+| [Hooks Reference](./Hooks-Reference.md) | Aphelion hooks: usage, bypass, disable, customisation | All users |
 | [Contributing](./Contributing.md) | Adding agents, rules; bilingual sync workflow | Agent developers |
 
 ---
@@ -102,6 +105,7 @@ Aphelion's README covers the quick start and an overview. This wiki provides the
 
 - [Getting Started](./Getting-Started.md)
 - [Architecture: Domain Model](./Architecture-Domain-Model.md)
+- [Hooks Reference](./Hooks-Reference.md)
 - [Contributing](./Contributing.md)
 
 ## Canonical Sources

--- a/docs/wiki/en/Hooks-Reference.md
+++ b/docs/wiki/en/Hooks-Reference.md
@@ -1,0 +1,298 @@
+# Hooks Reference
+
+> **Language**: [English](../en/Hooks-Reference.md) | [日本語](../ja/Hooks-Reference.md)
+> **Last updated**: 2026-05-01
+> **Update history**:
+>   - 2026-05-01: initial release — MVP 3 hooks (#107)
+> **Audience**: Aphelion users (developers operating hooks in user projects)
+
+This page is the user-facing reference for the Claude Code hooks that Aphelion distributes.
+Hooks act as the fourth defense layer — proactive content scanning — on top of the existing
+deny rules, sandbox isolation, and post-failure diagnosis.
+
+For the full policy (auto-load rule for agents), see
+[hooks-policy.md](../../.claude/rules/hooks-policy.md).
+
+## Table of Contents
+
+- [Hook A — aphelion-secrets-precommit](#hook-a--aphelion-secrets-precommit)
+- [Hook B — aphelion-sensitive-file-guard](#hook-b--aphelion-sensitive-file-guard)
+- [Hook E — aphelion-deps-postinstall](#hook-e--aphelion-deps-postinstall)
+- [How hooks are distributed](#how-hooks-are-distributed)
+- [Disabling a hook](#disabling-a-hook)
+- [Adding your own hook](#adding-your-own-hook)
+- [Troubleshooting](#troubleshooting)
+- [Related Pages](#related-pages)
+- [Canonical Sources](#canonical-sources)
+
+---
+
+## Hook A — aphelion-secrets-precommit
+
+**Script**: `.claude/hooks/aphelion-secrets-precommit.sh`
+**Event**: `PreToolUse`
+**Matcher**: `Bash`
+**Activates on**: `Bash(git commit*)`
+**Blocks**: Yes (exit 2)
+
+### What it does
+
+Before Claude Code executes `git commit`, this hook scans the staged diff
+(`git diff --cached -U0`) for known secret patterns. Only added lines are inspected;
+removed lines are ignored. The hook uses eight ERE regexes (IDs P1–P8) defined in
+`.claude/hooks/lib/secret-patterns.sh`:
+
+| ID | Pattern |
+|----|---------|
+| P1 | AWS Access Key (`AKIA[0-9A-Z]{16}`) |
+| P2 | GitHub PAT / OAuth token (`gh[pousr]_...`) |
+| P3 | OpenAI API key (`sk-...`) |
+| P4 | Anthropic API key (`sk-ant-...`) |
+| P5 | Slack token (`xox[baprs]-...`) |
+| P6 | Stripe live secret (`sk_live_...`) |
+| P7 | RSA / EC / DSA / OpenSSH private key header |
+| P8 | Generic credential assignment (`api_key =`, `password =`, `token = "..."` etc.) |
+
+If a match is found, the hook:
+1. Prints the matched **pattern ID** to stderr (the actual value is intentionally withheld to avoid leaking via logs).
+2. Exits 2, which causes Claude Code to block the `git commit` call.
+
+If no match is found, the hook exits 0 and the commit proceeds normally.
+
+### Bypass
+
+Append `[skip-secrets-check]` anywhere in the commit message:
+
+```bash
+git commit -m "feat: add sample config [skip-secrets-check]"
+```
+
+Use this when the hook triggers on a known-safe placeholder value (e.g., `MY_API_KEY_HERE`).
+Before bypassing, use `/secrets-scan` to confirm the value is not a real secret.
+
+### When to use bypass
+
+- The value is a placeholder (`TODO_REPLACE`, `<YOUR_TOKEN>`, `example_key`).
+- The value is in documentation or test fixtures (but ideally those paths should be
+  in an `ALLOW_PATH_PATTERNS` directory such as `tests/` or `docs/`).
+
+---
+
+## Hook B — aphelion-sensitive-file-guard
+
+**Script**: `.claude/hooks/aphelion-sensitive-file-guard.sh`
+**Event**: `PreToolUse`
+**Matcher**: `Write|Edit`
+**Activates on**: See below
+**Blocks**: Yes (exit 2)
+
+### What it does
+
+Before Claude Code writes to or edits a file, this hook checks whether the target path
+matches a conventionally sensitive filename. If matched, the write is blocked.
+
+**Activated on these filename patterns** (from `settings.json`):
+```
+Write(.env*)  Write(**/*.pem)  Write(**/*.key)  Write(**/credentials.*)
+Write(**/*.secret)  Write(**/id_rsa)  Write(**/id_ed25519)  Write(**/id_ecdsa)
+Edit(.env*)   Edit(**/*.pem)   Edit(**/*.key)   Edit(**/credentials.*)
+```
+
+**Path decision order** (higher priority wins):
+
+| Priority | Condition | Result |
+|----------|-----------|--------|
+| 1 (highest) | Path contains `/tests?/`, `/__fixtures__/`, `/fixtures/`, `/examples/`, `/docs/` | Allow |
+| 2 | Filename ends with `.example`, `.template`, `.sample`, `.dist` | Allow |
+| 3 | Filename matches a `BLOCK_GLOB` | Block |
+| 4 (lowest) | Anything else | Allow |
+
+**Examples**:
+
+| Path | Decision | Reason |
+|------|----------|--------|
+| `/project/.env` | Block | `.env` glob match |
+| `/project/.env.example` | Allow | `.example` suffix |
+| `/project/tests/fixtures/.env` | Allow | `tests/` path pattern |
+| `/project/certs/server.pem` | Block | `*.pem` glob match |
+| `/project/docs/sample.pem` | Allow | `docs/` path pattern |
+
+### Bypass
+
+There is **no bypass marker** for hook B. This is intentional: writing to files like `.env`
+or `*.pem` directly in the project tree is almost always a mistake. If you genuinely need to
+create such a file, edit `.claude/settings.json` and remove the
+`aphelion-sensitive-file-guard` entry from the `PreToolUse` section.
+
+The entry will not be restored by `npx aphelion-agents update` (settings.json is protected
+after the first init).
+
+---
+
+## Hook E — aphelion-deps-postinstall
+
+**Script**: `.claude/hooks/aphelion-deps-postinstall.sh`
+**Event**: `PostToolUse`
+**Matcher**: `Bash`
+**Activates on**: `npm install*`, `npm i *`, `npm ci*`, `uv add*`, `uv pip install*`, `pip install*`, `cargo add*`, `go get *`
+**Blocks**: No (always exits 0)
+
+### What it does
+
+After a dependency installation command completes, this hook emits an advisory message on
+stderr recommending a vulnerability scan. It detects the tech stack from the command prefix
+and suggests the appropriate tool:
+
+| Command prefix | Stack | Recommended scan |
+|---------------|-------|-----------------|
+| `npm*` | Node.js | `npm audit` |
+| `uv*` | Python | `uv run pip-audit` |
+| `pip*` | Python | `pip-audit` |
+| `cargo*` | Rust | `cargo audit` |
+| `go*` | Go | `govulncheck ./...` |
+
+**Example output**:
+```
+[aphelion-hook:deps-postinstall] Node.js dependency change detected.
+  Recommended next step: run /vuln-scan to check for known vulnerabilities.
+  (Manual equivalent: npm audit)
+  Skipping recommended after lockfile-only updates or when offline.
+```
+
+### Bypass
+
+No bypass is needed — hook E is advisory only and never blocks execution.
+You can safely ignore the message during lockfile-only updates or in offline environments.
+
+---
+
+## How hooks are distributed
+
+Aphelion distributes hooks via `npx aphelion-agents init` and `npx aphelion-agents update`.
+
+### init (first-time setup)
+
+```bash
+npx github:kirin0198/aphelion-agents init
+```
+
+- Copies `src/.claude/settings.json` (hook registration template) to your project's
+  `.claude/settings.json` — only if the file does not already exist.
+- Copies all files in `src/.claude/hooks/` to `.claude/hooks/` (recursive overlay).
+- Sets execute permissions (`chmod 0755`) on all `*.sh` files so Claude Code can run them.
+
+### update
+
+```bash
+npx aphelion-agents update
+```
+
+- **`settings.json`** — Protected: if `.claude/settings.json` already exists, it is
+  preserved and a warning is printed. Your custom hooks and disabled entries are kept.
+- **`hooks/`** — Overlay: always re-copied from canonical. Ensures bug fixes and new
+  secret patterns reach your project automatically.
+- Restores execute permissions if lost (e.g., after a Windows git clone).
+
+---
+
+## Disabling a hook
+
+To permanently disable a specific hook, edit `.claude/settings.json` and delete or
+comment out the relevant entry.
+
+**Example — disable hook A (secrets-precommit)**:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      // Delete or comment out the aphelion-secrets-precommit entry here
+      {
+        "matcher": "Write|Edit",
+        "if": "...",
+        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/aphelion-sensitive-file-guard.sh"
+      }
+    ],
+    "PostToolUse": [ ... ]
+  }
+}
+```
+
+The change will not be overwritten by `npx aphelion-agents update` because
+`settings.json` is protected after the first init.
+
+---
+
+## Adding your own hook
+
+To add a custom hook without losing it on `update`:
+
+1. Place your script at `.claude/hooks/local/your-hook.sh` (outside the overlay target).
+2. Add execute permissions: `chmod +x .claude/hooks/local/your-hook.sh`.
+3. Register it in `.claude/settings.json` under the relevant event section:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git push*)",
+        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/local/your-hook.sh",
+        "description": "Your custom hook"
+      }
+    ]
+  }
+}
+```
+
+Scripts in `.claude/hooks/local/` are not touched by `aphelion-agents update`.
+
+---
+
+## Troubleshooting
+
+**Hook does not seem to fire**
+
+1. Check that the hook script is executable:
+   ```bash
+   ls -la .claude/hooks/*.sh
+   ```
+   If the execute bit is missing, run `npx aphelion-agents update` to restore it.
+
+2. Verify that the hook entry exists in `.claude/settings.json` under the correct event.
+
+3. Confirm that Claude Code is reading `.claude/settings.json` (the file must be at the
+   project root level, not inside a subdirectory).
+
+**Hook A fires on every commit (false positive)**
+
+Run `/secrets-scan` to inspect the staged content with LLM-aware placeholder detection.
+If the value is confirmed safe, append `[skip-secrets-check]` to the commit message.
+
+If the same pattern keeps triggering false positives on your project, open an issue at
+[github.com/kirin0198/aphelion-agents](https://github.com/kirin0198/aphelion-agents)
+with the pattern ID (e.g., P8) and a safe example of the false-positive content.
+
+**WSL / Windows note**
+
+Aphelion hooks require `bash` and `grep -E`. On WSL2 (recommended) and macOS / Linux,
+these are available by default. Windows native (PowerShell without WSL) is **not currently
+supported** — a PowerShell-compatible hook set is planned for Phase 2.
+
+If you use Aphelion on WSL2, ensure your project is stored inside the WSL filesystem
+(`/home/…`) rather than a Windows mount (`/mnt/c/…`) to avoid performance issues with
+`git diff --cached` in hook A.
+
+---
+
+## Related Pages
+
+- [Rules Reference](./Rules-Reference.md) — hooks-policy entry with agent-developer scope
+- [Getting Started](./Getting-Started.md) — overall Aphelion setup guide
+
+## Canonical Sources
+
+- [src/.claude/hooks/](../../src/.claude/hooks/) — Canonical hook scripts
+- [src/.claude/settings.json](../../src/.claude/settings.json) — Hook registration template
+- [src/.claude/rules/hooks-policy.md](../../src/.claude/rules/hooks-policy.md) — Auto-loaded policy rule

--- a/docs/wiki/en/Rules-Reference.md
+++ b/docs/wiki/en/Rules-Reference.md
@@ -1,8 +1,9 @@
 # Rules Reference
 
 > **Language**: [English](../en/Rules-Reference.md) | [日本語](../ja/Rules-Reference.md)
-> **Last updated**: 2026-04-30
+> **Last updated**: 2026-05-01
 > **Update history**:
+>   - 2026-05-01: add hooks-policy entry, sync rule count 12 → 13 (#107)
 >   - 2026-04-30: add missing localization-dictionary entry, sync rule count to 12 (#105)
 >   - 2026-04-30: language-rules — add "Repo-root README sync convention" sub-section (#82)
 >   - 2026-04-29: language-rules — add "Hand-authored canonical narrative" section (#75)
@@ -10,7 +11,7 @@
 >   - 2026-04-25: added denial-categories rule, #31
 > **Audience**: Agent developers
 
-This page is a compact reference for all 12 behavioral rules in `.claude/rules/`. Each entry summarizes scope, auto-load behavior, interactions with other rules and agents, and the key constraint the rule enforces.
+This page is a compact reference for all 13 behavioral rules in `.claude/rules/`. Each entry summarizes scope, auto-load behavior, interactions with other rules and agents, and the key constraint the rule enforces.
 
 For full details, follow the **Canonical** link to the source file.
 
@@ -22,6 +23,7 @@ For full details, follow the **Canonical** link to the source file.
 - [document-versioning](#document-versioning)
 - [file-operation-principles](#file-operation-principles)
 - [git-rules](#git-rules)
+- [hooks-policy](#hooks-policy)
 - [language-rules](#language-rules)
 - [library-and-security-policy](#library-and-security-policy)
 - [localization-dictionary](#localization-dictionary)
@@ -93,6 +95,26 @@ For full details, follow the **Canonical** link to the source file.
   - `developer` owns branch creation, push, and PR submission per `## Branch & PR Strategy` and emits `BRANCH` / `PR_URL` in `AGENT_RESULT`.
   - `analyst` does **not** create branches or PRs; it only authors design notes and GitHub issues.
 - **Summary**: Defines (1) commit granularity, staging policy (`git add -A` is prohibited; use explicit file paths; never commit `.env`, `credentials.*`, `*.secret`), and commit message format (8 prefix types: feat, fix, refactor, test, docs, chore, ci, ops); (2) Co-Authored-By trailer policy; (3) `## Repository` — `Remote type` declaration in `project-rules.md` (`github` / `gitlab` / `gitea` / `local-only` / `none`); (4) `## Startup Probe` — once-per-session probe resolving `REPO_STATE`; (5) `## Branch & PR Strategy` — branch naming (`fix/` / `feat/` / `refactor/`), branch lifecycle (create → commit → push → PR with `Closes #N`), and `AGENT_RESULT` additions (`BRANCH`, `PR_URL`); (6) `## Behavior by Remote Type` — per-`REPO_STATE` matrix for branch / commit / push / PR ops.
+
+---
+
+## hooks-policy
+
+- **Canonical**: [.claude/rules/hooks-policy.md](../../.claude/rules/hooks-policy.md)
+- **Scope**: All agents that recommend or perform `git commit`, file write (`Write`/`Edit`), or dependency install commands; agents interacting with hook bypass markers.
+- **Auto-load behavior**: Auto-loaded by Claude Code on every session start
+- **Interactions**:
+  - Companion to `sandbox-policy.md` and `denial-categories.md`. Hooks form the **fourth** defense layer (proactive content scan) on top of `settings.local.json` deny (Layer 1), `sandbox-runner` (Layer 2), and `denial-categories` post-mortem (Layer 3).
+  - Hook A fires before `git commit`, integrating with the `library-and-security-policy.md` secret-detection mandate.
+  - Hook E fires after dependency installs, triggering the `/vuln-scan` workflow defined in `library-and-security-policy.md`.
+  - `developer` should inform users about the `[skip-secrets-check]` bypass when hook A fires on a known-safe placeholder.
+- **Hook inventory (MVP)**:
+  - **A** `aphelion-secrets-precommit.sh` — `PreToolUse Bash(git commit*)` — scans staged diff for 8 secret patterns (P1–P8); exits 2 on match. Bypass: append `[skip-secrets-check]` to commit message.
+  - **B** `aphelion-sensitive-file-guard.sh` — `PreToolUse Write|Edit` — blocks writes to conventional secret-file names (`.env*`, `*.pem`, `*.key`, etc.); allows `tests/`, `fixtures/`, and `.example`/`.template`/`.sample`/`.dist` suffixes. No bypass marker — edit `settings.json` to disable.
+  - **E** `aphelion-deps-postinstall.sh` — `PostToolUse Bash(npm install*|uv add*|pip install*|cargo add*|go get*)` — non-blocking advisory; recommends `/vuln-scan` after dependency changes.
+- **Failure safety**: All hooks wrap their body in `trap ERR → exit 0` so an internal script error never blocks user work (fail-open).
+- **Distribution**: `src/.claude/hooks/` (canonical) deployed via `npx aphelion-agents init/update`. `settings.json` is protected after init (user customisations preserved); `hooks/` scripts are overlay-copied on every update.
+- **Summary**: Establishes that Aphelion's three MVP hooks act as a proactive content-scanning layer. Agents must know the bypass rules (hook A: `[skip-secrets-check]`; hook B: no bypass, `settings.json` edit required; hook E: no bypass needed). All hooks are fail-open by design. The canonical pattern library (`secret-patterns.sh`, IDs P1–P8) is the single source of truth shared by hook A and the `/secrets-scan` slash command.
 
 ---
 
@@ -178,6 +200,7 @@ For full details, follow the **Canonical** link to the source file.
 
 ## Canonical Sources
 
-- [.claude/rules/](../../.claude/rules/) — All 12 rule files (authoritative source)
+- [.claude/rules/](../../.claude/rules/) — All 13 rule files (authoritative source)
 - [.claude/rules/aphelion-overview.md](../../.claude/rules/aphelion-overview.md) — Workflow overview (now part of the rules collection)
 - [.claude/orchestrator-rules.md](../../.claude/orchestrator-rules.md) — Orchestrator behavior that depends on agent-communication-protocol
+- [Hooks Reference](./Hooks-Reference.md) — User-facing guide for the hook set

--- a/docs/wiki/ja/Home.md
+++ b/docs/wiki/ja/Home.md
@@ -3,6 +3,7 @@
 > **Language**: [English](../en/Home.md) | [日本語](../ja/Home.md)
 > **Last updated**: 2026-05-01
 > **Update history**:
+>   - 2026-05-01: Hooks-Reference リンク追加、ルール数 12 → 13 に更新 (#107)
 >   - 2026-05-01: visual-designer 追加に伴いエージェント数を 39 → 40 に更新 (#109)
 >   - 2026-04-30: ルール数 9 → 12 に修正 (#103)
 >   - 2026-04-30: Agents-Doc.md を Agents Reference に追加（5 → 6 ページ）、Doc Flow を用語集に追加 (#54)
@@ -26,7 +27,8 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 | クイックスタートコマンド | [Getting Started](./Getting-Started.md): Claude Code セットアップ、初回実行ウォークスルー、シナリオ、トラブルシューティング |
 | トリアージプラン表（概要） | [Triage System](./Triage-System.md): 選択ロジック、条件、エージェントマトリクス |
 | エージェント一覧（名前のみ） | Agents Reference（ドメイン別）: [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md), [Doc](./Agents-Doc.md) — 40 エージェントの入出力と NEXT 条件 |
-| — | [Rules Reference](./Rules-Reference.md): 12 つの行動ルールのスコープとカスタマイズ方法 |
+| — | [Rules Reference](./Rules-Reference.md): 13 つの行動ルールのスコープとカスタマイズ方法 |
+| — | [Hooks Reference](./Hooks-Reference.md): Aphelion が配布する Claude Code フック（MVP 3 フック） |
 | — | [Contributing](./Contributing.md): エージェント・ルールの追加方法、Wiki メンテナンス |
 
 ---
@@ -41,7 +43,8 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 | Architecture（3 ページ） | [Domain Model](./Architecture-Domain-Model.md), [Protocols](./Architecture-Protocols.md), [Operational Rules](./Architecture-Operational-Rules.md) — 3 ドメインモデル、ハンドオフファイル、`AGENT_RESULT` プロトコル、ランタイム挙動 | エージェント開発者 |
 | [Triage System](./Triage-System.md) | 4 ティアプラン選択ロジック、ドメイン別エージェントマトリクス、必須エージェント | 全ユーザー |
 | Agents Reference（6 ページ） | [Orchestrators & Cross-Cutting](./Agents-Orchestrators.md), [Discovery](./Agents-Discovery.md), [Delivery](./Agents-Delivery.md), [Operations](./Agents-Operations.md), [Maintenance](./Agents-Maintenance.md), [Doc](./Agents-Doc.md) — 40 エージェント全件 | エージェント開発者 |
-| [Rules Reference](./Rules-Reference.md) | 12 つの行動ルール: スコープ・自動ロード・相互関係 | エージェント開発者 |
+| [Rules Reference](./Rules-Reference.md) | 13 つの行動ルール: スコープ・自動ロード・相互関係 | エージェント開発者 |
+| [Hooks Reference](./Hooks-Reference.md) | Aphelion フック: 使用方法・bypass・無効化・カスタマイズ | 全ユーザー |
 | [Contributing](./Contributing.md) | エージェント・ルールの追加、バイリンガル同期ワークフロー | エージェント開発者 |
 
 ---
@@ -103,6 +106,7 @@ Aphelion のリポジトリの README はクイックスタートと概要をカ
 
 - [Getting Started](./Getting-Started.md)
 - [Architecture: Domain Model](./Architecture-Domain-Model.md)
+- [Hooks Reference](./Hooks-Reference.md)
 - [Contributing](./Contributing.md)
 
 ## 正規ソース

--- a/docs/wiki/ja/Hooks-Reference.md
+++ b/docs/wiki/ja/Hooks-Reference.md
@@ -1,0 +1,294 @@
+# Hooks Reference
+
+> **Language**: [English](../en/Hooks-Reference.md) | [日本語](../ja/Hooks-Reference.md)
+> **Last updated**: 2026-05-01
+> **Update history**:
+>   - 2026-05-01: initial release — MVP 3 hooks (#107)
+> **EN canonical**: 2026-05-01 of wiki/en/Hooks-Reference.md
+> **Audience**: Aphelion ユーザー（ユーザープロジェクトでフックを運用する開発者）
+
+このページは Aphelion が配布する Claude Code フックのユーザー向けリファレンスです。
+フックは第 4 の防御層として、既存の deny ルール・サンドボックス分離・事後診断の上に
+積極的なコンテンツスキャンを追加します。
+
+エージェント向けの完全なポリシー（自動ロードルール）は
+[hooks-policy.md](../../.claude/rules/hooks-policy.md) を参照してください。
+
+## 目次
+
+- [Hook A — aphelion-secrets-precommit](#hook-a--aphelion-secrets-precommit)
+- [Hook B — aphelion-sensitive-file-guard](#hook-b--aphelion-sensitive-file-guard)
+- [Hook E — aphelion-deps-postinstall](#hook-e--aphelion-deps-postinstall)
+- [フックの配布方法](#フックの配布方法)
+- [フックを無効化する](#フックを無効化する)
+- [独自フックを追加する](#独自フックを追加する)
+- [トラブルシューティング](#トラブルシューティング)
+- [関連ページ](#関連ページ)
+- [正規ソース](#正規ソース)
+
+---
+
+## Hook A — aphelion-secrets-precommit
+
+**スクリプト**: `.claude/hooks/aphelion-secrets-precommit.sh`
+**イベント**: `PreToolUse`
+**Matcher**: `Bash`
+**発動条件**: `Bash(git commit*)`
+**ブロック**: あり（exit 2）
+
+### 動作内容
+
+Claude Code が `git commit` を実行する前に、このフックがステージ済みの差分
+（`git diff --cached -U0`）を既知のシークレットパターンで検査します。
+検査対象は追加行（`+` で始まる行）のみで、削除行は無視されます。
+`.claude/hooks/lib/secret-patterns.sh` に定義された 8 つの ERE 正規表現（ID: P1〜P8）を使用します。
+
+| ID | パターン |
+|----|---------|
+| P1 | AWS アクセスキー (`AKIA[0-9A-Z]{16}`) |
+| P2 | GitHub PAT / OAuth トークン (`gh[pousr]_...`) |
+| P3 | OpenAI API キー (`sk-...`) |
+| P4 | Anthropic API キー (`sk-ant-...`) |
+| P5 | Slack トークン (`xox[baprs]-...`) |
+| P6 | Stripe ライブシークレット (`sk_live_...`) |
+| P7 | RSA / EC / DSA / OpenSSH 秘密鍵ヘッダー |
+| P8 | 汎用的な認証情報代入（`api_key =`・`password =`・`token = "..."` など） |
+
+マッチが見つかった場合、フックは：
+1. マッチしたパターンの **ID のみ** を stderr に出力します（実際の値はログへの漏洩を防ぐため意図的に非表示）。
+2. exit 2 で終了し、Claude Code が `git commit` 呼び出しをブロックします。
+
+マッチがなければ exit 0 で終了し、コミットは通常通り進みます。
+
+### bypass（回避）
+
+コミットメッセージのどこかに `[skip-secrets-check]` を追記します：
+
+```bash
+git commit -m "feat: add sample config [skip-secrets-check]"
+```
+
+フックが安全なプレースホルダー値（例: `MY_API_KEY_HERE`）で発動した場合に使用します。
+bypass する前に `/secrets-scan` で値が本物のシークレットでないことを確認してください。
+
+### bypass を使うべき場合
+
+- 値がプレースホルダーである（`TODO_REPLACE`・`<YOUR_TOKEN>`・`example_key` 等）。
+- 値がドキュメントやテストフィクスチャ内にある（ただし理想的には `tests/` や `docs/` など
+  `ALLOW_PATH_PATTERNS` に該当するパスに配置してください）。
+
+---
+
+## Hook B — aphelion-sensitive-file-guard
+
+**スクリプト**: `.claude/hooks/aphelion-sensitive-file-guard.sh`
+**イベント**: `PreToolUse`
+**Matcher**: `Write|Edit`
+**発動条件**: 下記を参照
+**ブロック**: あり（exit 2）
+
+### 動作内容
+
+Claude Code がファイルを書き込む前に、対象パスが慣習的に機密ファイルに使用されるファイル名に
+マッチするかを確認します。マッチした場合、書き込みをブロックします。
+
+**発動するファイル名パターン**（`settings.json` から）：
+```
+Write(.env*)  Write(**/*.pem)  Write(**/*.key)  Write(**/credentials.*)
+Write(**/*.secret)  Write(**/id_rsa)  Write(**/id_ed25519)  Write(**/id_ecdsa)
+Edit(.env*)   Edit(**/*.pem)   Edit(**/*.key)   Edit(**/credentials.*)
+```
+
+**パス判定の優先順位**（上位が優先）：
+
+| 優先度 | 条件 | 結果 |
+|--------|------|------|
+| 1（最高） | パスが `/tests?/`・`/__fixtures__/`・`/fixtures/`・`/examples/`・`/docs/` を含む | 許可 |
+| 2 | ファイル名が `.example`・`.template`・`.sample`・`.dist` で終わる | 許可 |
+| 3 | ファイル名が `BLOCK_GLOB` にマッチ | ブロック |
+| 4（最低） | その他 | 許可 |
+
+**判定例**：
+
+| パス | 判定 | 理由 |
+|------|------|------|
+| `/project/.env` | ブロック | `.env` glob マッチ |
+| `/project/.env.example` | 許可 | `.example` サフィックス |
+| `/project/tests/fixtures/.env` | 許可 | `tests/` パスパターン |
+| `/project/certs/server.pem` | ブロック | `*.pem` glob マッチ |
+| `/project/docs/sample.pem` | 許可 | `docs/` パスパターン |
+
+### bypass（回避）
+
+Hook B には **bypass マーカーはありません**。これは意図的な設計です：
+`.env` や `*.pem` などのファイルをプロジェクトツリー内に直接書き込むことはほぼ常にミスです。
+どうしても必要な場合は、`.claude/settings.json` を編集して `PreToolUse` セクションから
+`aphelion-sensitive-file-guard` エントリを削除してください。
+
+`npx aphelion-agents update` でこのエントリが復元されることはありません（settings.json は
+init 後は保護されます）。
+
+---
+
+## Hook E — aphelion-deps-postinstall
+
+**スクリプト**: `.claude/hooks/aphelion-deps-postinstall.sh`
+**イベント**: `PostToolUse`
+**Matcher**: `Bash`
+**発動条件**: `npm install*`・`npm i *`・`npm ci*`・`uv add*`・`uv pip install*`・`pip install*`・`cargo add*`・`go get *`
+**ブロック**: なし（常に exit 0）
+
+### 動作内容
+
+依存関係インストールコマンドの完了後、このフックが stderr に脆弱性スキャンを推奨する
+勧告メッセージを出力します。コマンドプレフィックスからtechスタックを検出し、
+適切なツールを提案します：
+
+| コマンドプレフィックス | スタック | 推奨スキャン |
+|----------------------|--------|------------|
+| `npm*` | Node.js | `npm audit` |
+| `uv*` | Python | `uv run pip-audit` |
+| `pip*` | Python | `pip-audit` |
+| `cargo*` | Rust | `cargo audit` |
+| `go*` | Go | `govulncheck ./...` |
+
+**出力例**：
+```
+[aphelion-hook:deps-postinstall] Node.js dependency change detected.
+  Recommended next step: run /vuln-scan to check for known vulnerabilities.
+  (Manual equivalent: npm audit)
+  Skipping recommended after lockfile-only updates or when offline.
+```
+
+### bypass（回避）
+
+bypass は不要です — Hook E は勧告のみで、実行をブロックしません。
+lockfile のみの更新やオフライン環境ではメッセージを無視して構いません。
+
+---
+
+## フックの配布方法
+
+Aphelion はフックを `npx aphelion-agents init` および `npx aphelion-agents update` で配布します。
+
+### init（初回セットアップ）
+
+```bash
+npx github:kirin0198/aphelion-agents init
+```
+
+- `src/.claude/settings.json`（フック登録テンプレート）をプロジェクトの `.claude/settings.json` にコピーします（ファイルが存在しない場合のみ）。
+- `src/.claude/hooks/` の全ファイルを `.claude/hooks/` に再帰的にオーバーレイコピーします。
+- Claude Code が実行できるよう、全 `*.sh` ファイルに実行権限（`chmod 0755`）を付与します。
+
+### update
+
+```bash
+npx aphelion-agents update
+```
+
+- **`settings.json`** — 保護あり: `.claude/settings.json` が既に存在する場合は保持され、警告が表示されます。カスタムフックや無効化したエントリは保持されます。
+- **`hooks/`** — オーバーレイ: 常に正規ソースから再コピー。バグ修正や新しいシークレットパターンが自動的にプロジェクトに反映されます。
+- 実行権限が失われた場合（例: Windows の git clone 後）に自動で復元します。
+
+---
+
+## フックを無効化する
+
+特定のフックを永続的に無効化するには、`.claude/settings.json` を編集して
+該当エントリを削除してください。
+
+**例 — Hook A（secrets-precommit）を無効化**：
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      // aphelion-secrets-precommit エントリを削除または省略
+      {
+        "matcher": "Write|Edit",
+        "if": "...",
+        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/aphelion-sensitive-file-guard.sh"
+      }
+    ],
+    "PostToolUse": [ ... ]
+  }
+}
+```
+
+変更は `npx aphelion-agents update` で上書きされません（settings.json は init 後に保護されます）。
+
+---
+
+## 独自フックを追加する
+
+`update` で失われない独自フックを追加するには：
+
+1. スクリプトを `.claude/hooks/local/your-hook.sh` に配置します（オーバーレイの対象外）。
+2. 実行権限を付与します: `chmod +x .claude/hooks/local/your-hook.sh`。
+3. `.claude/settings.json` の該当イベントセクションに登録します：
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git push*)",
+        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/local/your-hook.sh",
+        "description": "カスタムフック"
+      }
+    ]
+  }
+}
+```
+
+`.claude/hooks/local/` 内のスクリプトは `aphelion-agents update` では変更されません。
+
+---
+
+## トラブルシューティング
+
+**フックが発動しない**
+
+1. フックスクリプトに実行権限があるか確認します：
+   ```bash
+   ls -la .claude/hooks/*.sh
+   ```
+   実行ビットがない場合は `npx aphelion-agents update` を実行して復元してください。
+
+2. `.claude/settings.json` の正しいイベント下にフックエントリが存在するか確認します。
+
+3. Claude Code が `.claude/settings.json` を読み込んでいるか確認します（ファイルはサブディレクトリではなくプロジェクトルートに配置する必要があります）。
+
+**Hook A が毎回のコミットで誤検知する**
+
+`/secrets-scan` でステージ済みコンテンツを LLM による文脈検出で確認します。
+値が安全なプレースホルダーだと確認できたら、コミットメッセージに `[skip-secrets-check]` を追記します。
+
+同じパターンが繰り返し誤検知する場合は
+[github.com/kirin0198/aphelion-agents](https://github.com/kirin0198/aphelion-agents)
+にイシューを開き、パターン ID（例: P8）と誤検知の安全なサンプルコンテンツを記載してください。
+
+**WSL / Windows に関する注意**
+
+Aphelion のフックは `bash` と `grep -E` を必要とします。WSL2（推奨）・macOS・Linux ではデフォルトで利用可能です。
+Windows ネイティブ（WSL なしの PowerShell）は**現在サポートされていません** — Phase 2 で PowerShell 互換の
+フックセットを予定しています。
+
+WSL2 で Aphelion を使用する場合は、プロジェクトを Windows マウント（`/mnt/c/…`）ではなく
+WSL ファイルシステム（`/home/…`）内に配置することで、Hook A の `git diff --cached` の
+パフォーマンス問題を回避できます。
+
+---
+
+## 関連ページ
+
+- [Rules Reference](./Rules-Reference.md) — エージェント開発者向けの hooks-policy エントリ
+- [Getting Started](./Getting-Started.md) — Aphelion 全体のセットアップガイド
+
+## 正規ソース
+
+- [src/.claude/hooks/](../../src/.claude/hooks/) — 正規フックスクリプト
+- [src/.claude/settings.json](../../src/.claude/settings.json) — フック登録テンプレート
+- [src/.claude/rules/hooks-policy.md](../../src/.claude/rules/hooks-policy.md) — 自動ロードポリシールール

--- a/docs/wiki/ja/Rules-Reference.md
+++ b/docs/wiki/ja/Rules-Reference.md
@@ -1,17 +1,18 @@
 # Rules Reference
 
 > **Language**: [English](../en/Rules-Reference.md) | [日本語](../ja/Rules-Reference.md)
-> **Last updated**: 2026-04-30
+> **Last updated**: 2026-05-01
 > **Update history**:
+>   - 2026-05-01: hooks-policy エントリ追加、ルール数 12 → 13 に更新 (#107)
 >   - 2026-04-30: add missing localization-dictionary entry, sync rule count to 12 (#105)
 >   - 2026-04-30: language-rules — "Repo-root README sync convention" sub-section を追加 (#82)
 >   - 2026-04-29: language-rules — "Hand-authored canonical narrative" セクションを追加 (#75)
 >   - 2026-04-26: Sync with #62, #66, #72, #74 (issue #77)
 >   - 2026-04-25: denial-categories ルール追加, #31
-> **EN canonical**: 2026-04-30 of wiki/en/Rules-Reference.md
+> **EN canonical**: 2026-05-01 of wiki/en/Rules-Reference.md
 > **Audience**: エージェント開発者
 
-このページは`.claude/rules/`にある 12 の行動ルールのコンパクトなリファレンスです。各エントリはスコープ、自動ロードの動作、他ルール・エージェントとのインタラクション、ルールが強制する主要な制約をまとめています。
+このページは`.claude/rules/`にある 13 の行動ルールのコンパクトなリファレンスです。各エントリはスコープ、自動ロードの動作、他ルール・エージェントとのインタラクション、ルールが強制する主要な制約をまとめています。
 
 詳細については、**正規**リンクからソースファイルを参照してください。
 
@@ -23,6 +24,7 @@
 - [document-versioning](#document-versioning)
 - [file-operation-principles](#file-operation-principles)
 - [git-rules](#git-rules)
+- [hooks-policy](#hooks-policy)
 - [language-rules](#language-rules)
 - [library-and-security-policy](#library-and-security-policy)
 - [localization-dictionary](#localization-dictionary)
@@ -94,6 +96,26 @@
   - `developer` は `## Branch & PR Strategy` に従ってブランチ作成・プッシュ・PR 作成を担い、`AGENT_RESULT` に `BRANCH` / `PR_URL` を出力します。
   - `analyst` はブランチや PR を作成しません；設計ノートと GitHub イシューの作成のみを担います。
 - **概要**: (1) コミットの粒度、ステージングポリシー（`git add -A` は禁止；明示的なファイルパスを使用；`.env`、`credentials.*`、`*.secret` はコミットしない）、コミットメッセージフォーマット（8 つのプレフィックスタイプ: feat、fix、refactor、test、docs、chore、ci、ops）；(2) Co-Authored-By トレーラーポリシー；(3) `## Repository` — `project-rules.md` 内の `Remote type` 宣言（`github` / `gitlab` / `gitea` / `local-only` / `none`）；(4) `## Startup Probe` — `REPO_STATE` を解決するセッションごとのプローブ；(5) `## Branch & PR Strategy` — ブランチ命名（`fix/` / `feat/` / `refactor/`）、ブランチライフサイクル（作成 → コミット → プッシュ → `Closes #N` 付き PR）、`AGENT_RESULT` への追加項目（`BRANCH`、`PR_URL`）；(6) `## Behavior by Remote Type` — ブランチ / コミット / プッシュ / PR 操作のための `REPO_STATE` 別マトリックスを定義します。
+
+---
+
+## hooks-policy
+
+- **正規**: [.claude/rules/hooks-policy.md](../../.claude/rules/hooks-policy.md)
+- **スコープ**: `git commit`・ファイル書き込み（`Write`/`Edit`）・依存関係インストールを推奨または実施する全エージェント；フック bypass マーカーと連携するエージェント
+- **自動ロードの動作**: Claude Code が全セッション起動時に自動ロード
+- **インタラクション**:
+  - `sandbox-policy.md` および `denial-categories.md` のコンパニオンルール。フックは**第 4 層**（積極的なコンテンツスキャン）として、`settings.local.json` deny（第 1 層）・`sandbox-runner`（第 2 層）・`denial-categories` 事後診断（第 3 層）の上に位置します。
+  - フック A は `git commit` の前に実行され、`library-and-security-policy.md` のシークレット検出要件と統合します。
+  - フック E は依存関係インストール後に実行され、`library-and-security-policy.md` で定義された `/vuln-scan` ワークフローをトリガーします。
+  - `developer` はフック A が安全なプレースホルダーで発動した場合、`[skip-secrets-check]` bypass をユーザーに案内してください。
+- **フック一覧（MVP）**:
+  - **A** `aphelion-secrets-precommit.sh` — `PreToolUse Bash(git commit*)` — ステージ差分を 8 つのシークレットパターン（P1〜P8）でスキャン；マッチ時は exit 2。bypass: コミットメッセージに `[skip-secrets-check]` を追加。
+  - **B** `aphelion-sensitive-file-guard.sh` — `PreToolUse Write|Edit` — 慣習的なシークレットファイル名（`.env*`・`*.pem`・`*.key` 等）への書き込みをブロック。`tests/`・`fixtures/` ディレクトリや `.example`/`.template`/`.sample`/`.dist` サフィックスは許可。bypass マーカーなし — 無効化には `settings.json` 編集が必要。
+  - **E** `aphelion-deps-postinstall.sh` — `PostToolUse Bash(npm install*|uv add*|pip install*|cargo add*|go get*)` — 非ブロッキングの勧告のみ；依存関係変更後に `/vuln-scan` を推奨。
+- **フェイルセーフ**: 全フックは `trap ERR → exit 0` でラップされており、スクリプト内部エラーがユーザーの作業を止めることはありません（フェイルオープン設計）。
+- **配布**: `src/.claude/hooks/`（正規）から `npx aphelion-agents init/update` で配布。`settings.json` は init 後は保護される（ユーザーのカスタマイズを保持）；`hooks/` スクリプトは毎回 update で上書きコピーされます。
+- **概要**: Aphelion の MVP 3 フックが積極的なコンテンツスキャン層として機能することを定めます。エージェントは bypass ルール（フック A: `[skip-secrets-check]`；フック B: bypass なし・`settings.json` 編集が必要；フック E: bypass 不要）を知っておく必要があります。全フックはフェイルオープン設計です。正規パターンライブラリ（`secret-patterns.sh`・ID P1〜P8）はフック A と `/secrets-scan` slash command が共有する単一の信頼ソースです。
 
 ---
 
@@ -179,6 +201,7 @@
 
 ## 正規ソース
 
-- [.claude/rules/](../../.claude/rules/) — 12のルールファイル全体（権威あるソース）
+- [.claude/rules/](../../.claude/rules/) — 13 のルールファイル全体（権威あるソース）
 - [.claude/rules/aphelion-overview.md](../../.claude/rules/aphelion-overview.md) — ワークフロー概要（rules コレクションの一部に統合）
 - [.claude/orchestrator-rules.md](../../.claude/orchestrator-rules.md) — `agent-communication-protocol` に依存する Flow Orchestrator の動作
+- [Hooks Reference](./Hooks-Reference.md) — フックセットのユーザー向けガイド

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -36,6 +36,7 @@ const PAGES = [
 		],
 	},
 	{ slug: 'rules-reference',  labelEn: 'Rules Reference',   labelJa: 'Rules Reference'    },
+	{ slug: 'hooks-reference',  labelEn: 'Hooks Reference',   labelJa: 'Hooks Reference'    },
 	{ slug: 'contributing',     labelEn: 'Contributing',      labelJa: 'Contributing'       },
 ];
 

--- a/src/.claude/rules/aphelion-overview.md
+++ b/src/.claude/rules/aphelion-overview.md
@@ -7,6 +7,7 @@
 >   - 2026-04-30: doc-reviewer (cross-cutting agent) を追加 (#91)
 >   - 2026-04-30: doc-flow (5th flow, customer deliverable generation) を追加 (#54)
 >   - 2026-05-01: Delivery 12 → 13 agents (visual-designer 追加) (#109)
+>   - 2026-05-01: Hook layer section 追加 (MVP 3 hooks, rules count 12→13) (#107)
 
 This file provides a high-level overview of the Aphelion workflow.
 Behavioral rules are defined in `.claude/rules/` (auto-loaded).
@@ -86,6 +87,17 @@ Orchestrator-specific rules are in `.claude/orchestrator-rules.md` (read on-dema
 | `api-reference-author` | Read, Write, Glob, Grep | API reference (customer) | via doc-flow / standalone |
 | `user-manual-author` | Read, Write, Glob, Grep | End-user manual | via doc-flow / standalone |
 | `handover-author` | Read, Write, Glob, Grep | Handover package | via doc-flow / standalone |
+
+### Hook layer
+
+Aphelion ships a small set of Claude Code hooks under `.claude/hooks/` to provide a
+fourth defense layer (proactive content scan) on top of `settings.local.json` deny
+rules, `sandbox-runner` isolation, and `denial-categories` post-mortem classification.
+The MVP hook set focuses on user-project safety: secrets pre-commit guard, sensitive
+file write block, and dependency-install vuln-scan reminder.
+
+See `hooks-policy.md` (rule, auto-loaded) and `docs/wiki/en/Hooks-Reference.md`
+(user-facing) for details.
 
 ---
 

--- a/src/.claude/rules/hooks-policy.md
+++ b/src/.claude/rules/hooks-policy.md
@@ -1,0 +1,213 @@
+# Hooks Policy
+
+> **Last updated**: 2026-05-01
+> **Auto-loaded**: Yes — placed in `.claude/rules/`, loaded by Claude Code on every session start
+> Update history:
+>   - 2026-05-01: initial release — MVP 3 hooks (A / B / E) (#107)
+
+This rule documents Aphelion's Claude Code hooks: their role, distribution, bypass rules,
+and interaction with other policy layers. All agents should be aware of this policy when
+recommending `git commit`, file write, or dependency install operations.
+
+---
+
+## 1. Overview
+
+Aphelion ships a set of Claude Code hooks that act as the **fourth defense layer** — proactive
+content scanning — on top of the existing three layers:
+
+| Layer | Mechanism | When it acts |
+|-------|-----------|-------------|
+| 1 | `settings.local.json` deny rules | Static pattern match; blocks before tool execution |
+| 2 | `sandbox-runner` agent | Isolation of `required`-tier Bash commands (Standard+ plans) |
+| 3 | `denial-categories.md` | Post-failure diagnosis and recovery guidance |
+| **4** | **Hooks (this file)** | **Proactive content scan; inspects command content before commit / write** |
+
+The deny layer (Layer 1) blocks by command shape (e.g., `git push --force`). It does **not**
+inspect the *contents* of a commit. Hooks fill this gap: they read `git diff --cached` output
+or file paths to detect sensitive data before it reaches the repository or disk.
+
+Hooks are distributed via `src/.claude/hooks/` (canonical) and deployed to
+`.claude/hooks/` in user projects via `npx aphelion-agents init / update`.
+
+---
+
+## 2. Available Hooks (MVP)
+
+Three hooks form the initial release. All scripts reside at
+`src/.claude/hooks/` (canonical) → deployed to `.claude/hooks/`.
+
+| ID | Script | Event | Matcher | if condition | Block? | Bypass |
+|----|--------|-------|---------|-------------|--------|--------|
+| A | `aphelion-secrets-precommit.sh` | `PreToolUse` | `Bash` | `Bash(git commit*)` | Yes (exit 2) | `[skip-secrets-check]` in commit message |
+| B | `aphelion-sensitive-file-guard.sh` | `PreToolUse` | `Write\|Edit` | See §2.2 | Yes (exit 2) | None (edit `settings.json` to disable) |
+| E | `aphelion-deps-postinstall.sh` | `PostToolUse` | `Bash` | See §2.3 | No (exit 0 + stderr) | N/A (advisory only) |
+
+A shared pattern library lives at `.claude/hooks/lib/secret-patterns.sh`.
+It defines `APHELION_SECRET_PATTERNS` (8 ERE regexes, IDs P1–P8) used by hook A.
+
+### 2.1 Hook A — aphelion-secrets-precommit
+
+**Purpose**: Scan the staged diff for known secret patterns before `git commit` is executed.
+
+**Operation**:
+1. Parses `tool_input.command` from stdin JSON to detect `[skip-secrets-check]` bypass marker.
+2. Runs `git diff --cached -U0` to obtain only added lines (`^+` prefix, excluding `+++` headers).
+3. Tests each added line against the 8 patterns in `secret-patterns.sh` using `grep -iE`.
+4. On match: emits a stderr message reporting the pattern ID (not the matched value), then exits 2 to block the commit.
+5. On no match: exits 0.
+
+**Exit semantics**:
+- `0` — No secrets detected; commit proceeds.
+- `1` — Script internal error (caught by `trap ERR`); falls through to `exit 0` (fail-open).
+- `2` — Secret pattern matched; commit is blocked.
+
+**stderr format** (on block):
+```
+[aphelion-hook:secrets-precommit] BLOCKED: staged diff matches secret pattern {ID}.
+- The actual matching value is intentionally NOT printed (avoid leaking via logs).
+- Re-scan with /secrets-scan to inspect with LLM-aware placeholder detection.
+- If the match is a placeholder / sample, append [skip-secrets-check] to the
+  commit message and re-run.
+```
+
+### 2.2 Hook B — aphelion-sensitive-file-guard
+
+**Purpose**: Block writes to files whose names match conventional secret-file patterns.
+
+**if condition** (from `settings.json`):
+```
+Write(.env*)|Write(**/*.pem)|Write(**/*.key)|Write(**/credentials.*)|Write(**/*.secret)|Write(**/id_rsa)|Write(**/id_ed25519)|Write(**/id_ecdsa)|Edit(.env*)|Edit(**/*.pem)|Edit(**/*.key)|Edit(**/credentials.*)
+```
+
+**Path decision order** (higher priority overrides lower):
+1. `ALLOW_PATH_PATTERNS` match (path contains `/tests?/`, `/__fixtures__/`, `/fixtures/`, `/examples/`, `/docs/`) → allow
+2. `ALLOW_SUFFIXES` match (basename ends with `.example`, `.template`, `.sample`, `.dist`) → allow
+3. `BLOCK_GLOBS` match (`.env`, `.env.*`, `*.pem`, `*.key`, `credentials.*`, `*.secret`, `id_rsa`, `id_ed25519`, `id_ecdsa`) → block
+4. Anything else → allow
+
+**Exit semantics**:
+- `0` — Path is allowed; write proceeds.
+- `1` — Script internal error (trap ERR); falls through to exit 0 (fail-open).
+- `2` — Path is blocked.
+
+**stderr format** (on block):
+```
+[aphelion-hook:sensitive-file-guard] BLOCKED: write to sensitive file
+  path: {absolute path}
+  matched glob: {glob}
+  rationale: this filename is conventionally used for secrets ...
+  bypass: there is no commit-message-style bypass for this hook.
+    To proceed, edit .claude/settings.json and remove the
+    aphelion-sensitive-file-guard PreToolUse entry, or rename the target file
+    to one of: *.example, *.template, *.sample, *.dist.
+```
+
+### 2.3 Hook E — aphelion-deps-postinstall
+
+**Purpose**: Emit a non-blocking advisory message after dependency installation commands,
+prompting the developer to run a vulnerability scan.
+
+**if condition** (from `settings.json`):
+```
+Bash(npm install*)|Bash(npm i *)|Bash(npm ci*)|Bash(uv add*)|Bash(uv pip install*)|Bash(pip install*)|Bash(cargo add*)|Bash(go get *)
+```
+
+**Operation**: Detects the tech stack from the command prefix (npm / uv / pip / cargo / go)
+and emits a stderr message recommending the matching vulnerability scan command.
+
+**Exit semantics**: Always `0` (`PostToolUse` hooks cannot block tool execution).
+
+**stderr format**:
+```
+[aphelion-hook:deps-postinstall] {Stack} dependency change detected.
+  Recommended next step: run /vuln-scan to check for known vulnerabilities.
+  (Manual equivalent: {scan command})
+  Skipping recommended after lockfile-only updates or when offline.
+```
+
+---
+
+## 3. Bypass Mechanisms
+
+| Hook | Bypass Method | Notes |
+|------|--------------|-------|
+| A (secrets-precommit) | Append `[skip-secrets-check]` to the commit message | Conventional Commits style; applies regardless of `-m` or `-F` |
+| B (sensitive-file-guard) | No bypass marker — edit `.claude/settings.json` to remove the hook entry | Intentional: a bypass marker would undermine multi-layer defense |
+| E (deps-postinstall) | No bypass needed — advisory only; always exits 0 | — |
+
+When hook A blocks due to a false positive (e.g., a placeholder value that looks like a real
+secret), use `/secrets-scan` to confirm it is safe, then append `[skip-secrets-check]` and retry.
+
+---
+
+## 4. Distribution Policy
+
+### 4.1 Canonical location
+
+```
+src/.claude/hooks/
+├── lib/
+│   └── secret-patterns.sh      # Shared pattern library (P1–P8)
+├── aphelion-secrets-precommit.sh
+├── aphelion-sensitive-file-guard.sh
+└── aphelion-deps-postinstall.sh
+
+src/.claude/settings.json       # Hook registration template
+```
+
+All hook scripts and the settings template are in `src/.claude/` and are distributed
+by the same overlay-copy mechanism as `src/.claude/rules/`.
+
+### 4.2 init / update semantics
+
+`npx aphelion-agents init` (first-time setup):
+- Copies `src/.claude/settings.json` to `.claude/settings.json` (new file only; never overwrites).
+- Copies all files in `src/.claude/hooks/` to `.claude/hooks/` (recursive overlay).
+- Sets execute bit (`chmod 0755`) on all `*.sh` files via `chmodHooks()`.
+
+`npx aphelion-agents update`:
+- **`settings.json`** — Protected: if `.claude/settings.json` already exists, it is preserved and a warning is printed. User customisations (added hooks, disabled entries) are not overwritten.
+- **`hooks/`** — Overlay: always re-copied from canonical. Ensures bug fixes and new patterns reach all deployed hook scripts automatically.
+- Re-runs `chmodHooks()` to restore execute bits if lost (e.g., after a Windows git clone).
+
+### 4.3 User customisation
+
+To add a custom hook without losing it on `update`:
+- Place the script at `.claude/hooks/local/your-hook.sh` (outside the overlay target).
+- Register it in `.claude/settings.json` under the relevant event section.
+
+To disable an Aphelion hook:
+- Edit `.claude/settings.json` and delete or comment out the relevant `PreToolUse` or `PostToolUse` entry.
+- The entry will not be restored by `update` (settings.json is protected after init).
+
+---
+
+## 5. Failure Modes
+
+| Scenario | Behaviour | Recovery |
+|----------|-----------|---------|
+| Hook script exits with uncaught error | `trap ERR` catches it and exits 0 (fail-open). Work is not blocked by hook bugs. | Review `[aphelion-hook:…] internal error` message in stderr. Report to Aphelion issue tracker. |
+| Hook script times out (Claude Code default: 60 s) | Claude Code emits a warning; hook is skipped. | Contact Aphelion issue tracker if timeout is recurrent. |
+| `git` binary not found | Hook A outputs an early-exit warning and exits 0. Commit proceeds. | Ensure `git` is on PATH inside the project environment. |
+| Execute bit missing on hook script | Claude Code cannot exec the script; hook fails with `permission denied`. Run `aphelion-agents update` to restore bits. | Re-run `npx aphelion-agents update`. |
+| Regex false positive (hook A) | Commit is blocked with pattern ID. | Use `/secrets-scan` to confirm it is a placeholder, then append `[skip-secrets-check]`. |
+
+---
+
+## 6. Interactions with Other Policies
+
+| Policy | Relationship |
+|--------|-------------|
+| `sandbox-policy.md` | Hooks act before sandbox delegation. A hook blocking `git commit` (exit 2) prevents the command from reaching the `sandbox-runner` delegation step. |
+| `denial-categories.md` | If a hook's block is misread as a denial by Claude Code's auto-mode, diagnose with `denial-categories.md` — the cause is `sandbox_policy` (hook block), not `os_permission`. |
+| `library-and-security-policy.md` | Hook E (deps-postinstall) is the runtime signal that triggers the vulnerability scanning recommended in `library-and-security-policy.md`. The `/vuln-scan` command performs the full scan. |
+
+---
+
+## 7. Auto-load Notes
+
+- File location: `src/.claude/rules/hooks-policy.md` (canonical; deployed to `.claude/rules/hooks-policy.md` in user projects)
+- This file is in `.claude/rules/` and is auto-loaded by Claude Code on every session start, applying to all agents.
+- The hooks themselves (`*.sh`) are **not** rule files; they are executed by Claude Code's hook runtime, not loaded as context.
+- Canonical pattern library: `src/.claude/hooks/lib/secret-patterns.sh` — single source of truth for P1–P8 regexes. The `/secrets-scan` slash command will reference this library after PR 1d refactor.


### PR DESCRIPTION
## Summary

- Add `src/.claude/rules/hooks-policy.md` as the 13th auto-loaded rule: MVP 3 hooks (A: secrets-precommit, B: sensitive-file-guard, E: deps-postinstall), their exit semantics, bypass mechanisms, distribution policy, and interaction table with sandbox-policy / denial-categories / library-and-security-policy
- Add `docs/wiki/{en,ja}/Hooks-Reference.md` (user-facing reference): hook descriptions, bypass guide, distribution, disable, custom hooks, troubleshooting, and bilingual parity (10/10 `^##` headings matched)
- Bump rules count 12 → 13 across `Rules-Reference.md` (en/ja), `Home.md` (en/ja), `README.md`, `README.ja.md`, and `site/astro.config.mjs` PAGES array
- Add "Hook layer" paragraph to `aphelion-overview.md` (auto-loaded rule)

## Related Issue

Linked Issue: #107

## PR Series Context

- PR 1a (#111): `src/.claude/hooks/` scripts + `src/.claude/settings.json` + `bin/` — **merged**
- **PR 1b (this PR)**: docs + rules count bump — adds hooks-policy.md as rule #13
- PR 1c: dogfooding — `.claude/settings.json` for this repo + Phase 2 hooks
- PR 1d: `secrets-scan.md` refactor + hooks-3 badge + CHANGELOG — will contain `Closes #107`

## Linked Plan

docs/design-notes/archived/aphelion-hooks-architecture.md (§12.2)

## Bilingual Sync Policy

- `docs/wiki/en/Hooks-Reference.md` and `docs/wiki/ja/Hooks-Reference.md` created in the same PR (Bilingual Sync Policy compliant)
- Skeleton headings and metadata blocks are English-fixed in both language files
- Narrative sections are in English (en) and Japanese (ja) respectively
- EN canonical date markers set to 2026-05-01 in all JA wiki files updated

## Test plan

- [x] `bash scripts/check-readme-wiki-sync.sh` — exits 0 (all 3 checks pass)
- [x] `site/astro.config.mjs` syntax check — `node --check` passes
- [x] `^## ` heading parity: en/ja Hooks-Reference.md both have 10 headings at matching positions
- [x] Rules-Reference lead text updated to "all 13 behavioral rules" in both en and ja
- [x] README.md and README.ja.md rules badge both show rules-13
- [ ] `cd site && npm run build` (optional — Astro build in CI)