### PR TITLE
chore: dogfood Aphelion hooks in this repo (PR 1c/4) (#107)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,72 @@
+{
+  "_comment": "This repo's own dogfooding hook registration (PR 1c/4, #107). NOT the user-facing template (src/.claude/settings.json). References hooks from src/.claude/hooks/ (canonical source in this repo).",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/src/.claude/hooks/aphelion-secrets-precommit.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/src/.claude/hooks/aphelion-sensitive-file-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/src/.claude/hooks/aphelion-md-sync.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/src/.claude/hooks/aphelion-deps-postinstall.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/src/.claude/hooks/aphelion-md-sync.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/src/.claude/hooks/aphelion-agent-count-check.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/src/.claude/hooks/aphelion-task-md-lifecycle.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 /.claude/settings.local.json
 !src/.claude/settings.local.json
 
+# Dogfooding: this repo's own hook registration is a shared asset (PR 1c/4, #107).
+# settings.json (not settings.local.json) must remain committed.
+# Explicit negation protects against user-level gitignore patterns like `**/.claude/settings.json`.
+!/.claude/settings.json
+
 # Node
 node_modules/
 

--- a/TASK.md
+++ b/TASK.md
@@ -1,3 +1,26 @@
 # TASK.md
 
-（フェーズ未割当。次回 `developer` 起動時に ARCHITECTURE.md を参照して再生成されます）
+> Source: docs/design-notes/archived/aphelion-hooks-architecture.md (2026-04-30) §12.3 / §13.3
+
+## Phase: PR 1c — Aphelion hooks dogfooding
+Last updated: 2026-05-01T00:00:00
+Status: In progress
+
+## Task List
+
+### Phase 1c
+- [x] TASK-001: Create branch feat/aphelion-hooks-mvp-1c | Target: git branch
+- [x] TASK-002: Add .gitignore entry to ensure .claude/settings.json is commit target | Target: .gitignore
+- [ ] TASK-003: Create aphelion-md-sync.sh dogfooding hook | Target: src/.claude/hooks/aphelion-md-sync.sh
+- [ ] TASK-004: Create aphelion-agent-count-check.sh (discretionary) | Target: src/.claude/hooks/aphelion-agent-count-check.sh
+- [ ] TASK-005: Create aphelion-task-md-lifecycle.sh (discretionary) | Target: src/.claude/hooks/aphelion-task-md-lifecycle.sh
+- [ ] TASK-006: Create this repo's .claude/settings.json with 3 user hooks + 3 dogfooding hooks | Target: .claude/settings.json
+- [ ] TASK-007: Shellcheck all hooks | Target: src/.claude/hooks/*.sh
+- [ ] TASK-008: Run dogfooding pass (10 commits through hook A) and record false-positive rate | Target: measurement
+- [ ] TASK-009: Create PR 1c/4 | Target: GitHub PR
+
+## Recent Commits
+(Updated per task completion)
+
+## Session Interruption Notes
+(Empty — new session)

--- a/TASK.md
+++ b/TASK.md
@@ -14,7 +14,7 @@ Status: In progress
 - [x] TASK-003: Create aphelion-md-sync.sh dogfooding hook | Target: src/.claude/hooks/aphelion-md-sync.sh
 - [x] TASK-004: Create aphelion-agent-count-check.sh (discretionary, implemented) | Target: src/.claude/hooks/aphelion-agent-count-check.sh
 - [x] TASK-005: Create aphelion-task-md-lifecycle.sh (discretionary, implemented) | Target: src/.claude/hooks/aphelion-task-md-lifecycle.sh
-- [ ] TASK-006: Create this repo's .claude/settings.json with 3 user hooks + 3 dogfooding hooks | Target: .claude/settings.json
+- [x] TASK-006: Create this repo's .claude/settings.json with 3 user hooks + 3 dogfooding hooks | Target: .claude/settings.json
 - [ ] TASK-007: Shellcheck all hooks | Target: src/.claude/hooks/*.sh
 - [ ] TASK-008: Run dogfooding pass (10 commits through hook A) and record false-positive rate | Target: measurement
 - [ ] TASK-009: Create PR 1c/4 | Target: GitHub PR

--- a/TASK.md
+++ b/TASK.md
@@ -15,8 +15,8 @@ Status: In progress
 - [x] TASK-004: Create aphelion-agent-count-check.sh (discretionary, implemented) | Target: src/.claude/hooks/aphelion-agent-count-check.sh
 - [x] TASK-005: Create aphelion-task-md-lifecycle.sh (discretionary, implemented) | Target: src/.claude/hooks/aphelion-task-md-lifecycle.sh
 - [x] TASK-006: Create this repo's .claude/settings.json with 3 user hooks + 3 dogfooding hooks | Target: .claude/settings.json
-- [ ] TASK-007: Shellcheck all hooks | Target: src/.claude/hooks/*.sh
-- [ ] TASK-008: Run dogfooding pass (10 commits through hook A) and record false-positive rate | Target: measurement
+- [x] TASK-007: Shellcheck all hooks | Target: src/.claude/hooks/*.sh
+- [x] TASK-008: Run dogfooding pass (10 commits through hook A) and record false-positive rate | Target: measurement
 - [ ] TASK-009: Create PR 1c/4 | Target: GitHub PR
 
 ## Recent Commits

--- a/TASK.md
+++ b/TASK.md
@@ -11,9 +11,9 @@ Status: In progress
 ### Phase 1c
 - [x] TASK-001: Create branch feat/aphelion-hooks-mvp-1c | Target: git branch
 - [x] TASK-002: Add .gitignore entry to ensure .claude/settings.json is commit target | Target: .gitignore
-- [ ] TASK-003: Create aphelion-md-sync.sh dogfooding hook | Target: src/.claude/hooks/aphelion-md-sync.sh
-- [ ] TASK-004: Create aphelion-agent-count-check.sh (discretionary) | Target: src/.claude/hooks/aphelion-agent-count-check.sh
-- [ ] TASK-005: Create aphelion-task-md-lifecycle.sh (discretionary) | Target: src/.claude/hooks/aphelion-task-md-lifecycle.sh
+- [x] TASK-003: Create aphelion-md-sync.sh dogfooding hook | Target: src/.claude/hooks/aphelion-md-sync.sh
+- [x] TASK-004: Create aphelion-agent-count-check.sh (discretionary, implemented) | Target: src/.claude/hooks/aphelion-agent-count-check.sh
+- [x] TASK-005: Create aphelion-task-md-lifecycle.sh (discretionary, implemented) | Target: src/.claude/hooks/aphelion-task-md-lifecycle.sh
 - [ ] TASK-006: Create this repo's .claude/settings.json with 3 user hooks + 3 dogfooding hooks | Target: .claude/settings.json
 - [ ] TASK-007: Shellcheck all hooks | Target: src/.claude/hooks/*.sh
 - [ ] TASK-008: Run dogfooding pass (10 commits through hook A) and record false-positive rate | Target: measurement

--- a/TASK.md
+++ b/TASK.md
@@ -1,26 +1,3 @@
 # TASK.md
 
-> Source: docs/design-notes/archived/aphelion-hooks-architecture.md (2026-04-30) §12.3 / §13.3
-
-## Phase: PR 1c — Aphelion hooks dogfooding
-Last updated: 2026-05-01T00:00:00
-Status: In progress
-
-## Task List
-
-### Phase 1c
-- [x] TASK-001: Create branch feat/aphelion-hooks-mvp-1c | Target: git branch
-- [x] TASK-002: Add .gitignore entry to ensure .claude/settings.json is commit target | Target: .gitignore
-- [x] TASK-003: Create aphelion-md-sync.sh dogfooding hook | Target: src/.claude/hooks/aphelion-md-sync.sh
-- [x] TASK-004: Create aphelion-agent-count-check.sh (discretionary, implemented) | Target: src/.claude/hooks/aphelion-agent-count-check.sh
-- [x] TASK-005: Create aphelion-task-md-lifecycle.sh (discretionary, implemented) | Target: src/.claude/hooks/aphelion-task-md-lifecycle.sh
-- [x] TASK-006: Create this repo's .claude/settings.json with 3 user hooks + 3 dogfooding hooks | Target: .claude/settings.json
-- [x] TASK-007: Shellcheck all hooks | Target: src/.claude/hooks/*.sh
-- [x] TASK-008: Run dogfooding pass (10 commits through hook A) and record false-positive rate | Target: measurement
-- [ ] TASK-009: Create PR 1c/4 | Target: GitHub PR
-
-## Recent Commits
-(Updated per task completion)
-
-## Session Interruption Notes
-(Empty — new session)
+（フェーズ未割当。次回 `developer` 起動時に ARCHITECTURE.md を参照して再生成されます）

--- a/src/.claude/hooks/aphelion-agent-count-check.sh
+++ b/src/.claude/hooks/aphelion-agent-count-check.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# aphelion-agent-count-check.sh
+# Aphelion dogfooding hook — agent count consistency guard (this repo only)
+# Event:   PostToolUse on Write|Edit (.claude/agents/*.md, README*.md, docs/wiki/*/Home.md)
+#
+# Purpose: When an agent file or README/Home.md is written, check that the agent count
+#          reported in README.md / README.ja.md / wiki/en/Home.md / wiki/ja/Home.md
+#          matches the actual number of .claude/agents/*.md files. Non-blocking advisory.
+#
+# Dogfooding rationale (OQ-C decision): The check-readme-wiki-sync.sh script already
+# covers this as Check 1. This hook adds real-time feedback during editing (PostToolUse),
+# before the developer reaches git commit. The dual coverage provides earlier signal with
+# negligible overhead (pure grep + wc, < 50ms). Implemented.
+#
+# Canonical path: src/.claude/hooks/aphelion-agent-count-check.sh
+# Referenced by: .claude/settings.json (this repo's dogfooding settings, NOT src/.claude/settings.json)
+#
+# Dogfooding note: This hook is inert in user projects (copied via bin/ overlay but
+# not registered in src/.claude/settings.json). See aphelion-md-sync.sh for pattern.
+
+set -euo pipefail
+
+HOOK_NAME="agent-count-check"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Fail-open: any uncaught error exits with 0 so hook bugs never block user work.
+# shellcheck disable=SC2064
+trap 'echo "[aphelion-hook:'"${HOOK_NAME}"'] internal error at line $LINENO; passing through" >&2; exit 0' ERR
+
+# Read stdin (Claude Code hook payload JSON)
+RAW_PAYLOAD="$(cat)"
+
+# PostToolUse only (advisory; cannot block)
+# Extract the file path that was written/edited
+TARGET_PATH=$(printf '%s' "$RAW_PAYLOAD" \
+  | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]+"' \
+  | head -1 \
+  | sed -E 's/^"file_path"[[:space:]]*:[[:space:]]*"//; s/"$//')
+
+[ -z "$TARGET_PATH" ] && exit 0
+
+# Only check when agent definition files, README, or Home.md are touched
+RELEVANT=false
+if printf '%s' "$TARGET_PATH" | grep -qE '(\.claude/agents/|README|docs/wiki/.*/Home\.md)'; then
+  RELEVANT=true
+fi
+
+"$RELEVANT" || exit 0
+
+# Count actual agent files
+AGENTS_DIR="${PROJECT_DIR}/.claude/agents"
+if [ ! -d "$AGENTS_DIR" ]; then
+  exit 0
+fi
+
+ACTUAL=$(ls "$AGENTS_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
+
+# Extract reported counts from README.md
+README_EN_PATH="${PROJECT_DIR}/README.md"
+README_JA_PATH="${PROJECT_DIR}/README.ja.md"
+HOME_EN_PATH="${PROJECT_DIR}/docs/wiki/en/Home.md"
+HOME_JA_PATH="${PROJECT_DIR}/docs/wiki/ja/Home.md"
+
+MISMATCH=false
+MISMATCH_DETAILS=""
+
+if [ -f "$README_EN_PATH" ]; then
+  REPORTED=$(grep -hoE '[0-9]+ specialized agents|all [0-9]+ agents' "$README_EN_PATH" \
+    | grep -oE '[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
+  if [ -n "$REPORTED" ] && [ "$REPORTED" != "$ACTUAL" ]; then
+    MISMATCH=true
+    MISMATCH_DETAILS="${MISMATCH_DETAILS}  README.md reports '${REPORTED}', actual=${ACTUAL}\n"
+  fi
+fi
+
+if [ -f "$README_JA_PATH" ]; then
+  REPORTED=$(grep -hoE '[0-9]+ の専門エージェント|[0-9]+ エージェント' "$README_JA_PATH" \
+    | grep -oE '[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
+  if [ -n "$REPORTED" ] && [ "$REPORTED" != "$ACTUAL" ]; then
+    MISMATCH=true
+    MISMATCH_DETAILS="${MISMATCH_DETAILS}  README.ja.md reports '${REPORTED}', actual=${ACTUAL}\n"
+  fi
+fi
+
+if [ -f "$HOME_EN_PATH" ]; then
+  REPORTED=$(grep -oE 'all [0-9]+ agents' "$HOME_EN_PATH" \
+    | grep -oE '[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
+  if [ -n "$REPORTED" ] && [ "$REPORTED" != "$ACTUAL" ]; then
+    MISMATCH=true
+    MISMATCH_DETAILS="${MISMATCH_DETAILS}  wiki/en/Home.md reports '${REPORTED}', actual=${ACTUAL}\n"
+  fi
+fi
+
+if [ -f "$HOME_JA_PATH" ]; then
+  REPORTED=$(grep -oE '[0-9]+ エージェント' "$HOME_JA_PATH" \
+    | grep -oE '[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
+  if [ -n "$REPORTED" ] && [ "$REPORTED" != "$ACTUAL" ]; then
+    MISMATCH=true
+    MISMATCH_DETAILS="${MISMATCH_DETAILS}  wiki/ja/Home.md reports '${REPORTED}', actual=${ACTUAL}\n"
+  fi
+fi
+
+if "$MISMATCH"; then
+  echo "[aphelion-hook:${HOOK_NAME}] agent count mismatch detected (actual: ${ACTUAL}):" >&2
+  printf '%b' "$MISMATCH_DETAILS" >&2
+  echo "[aphelion-hook:${HOOK_NAME}] Update README.md/README.ja.md/Home.md to reflect actual count." >&2
+fi
+
+exit 0

--- a/src/.claude/hooks/aphelion-md-sync.sh
+++ b/src/.claude/hooks/aphelion-md-sync.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# aphelion-md-sync.sh
+# Aphelion dogfooding hook — MD sync guard (this repo only, NOT shipped via bin/init)
+# Event:   PostToolUse on Edit|Write (docs/wiki/* or README*)
+#          PreToolUse  on Bash(git commit*)
+#
+# Purpose: Remind developer to run check-readme-wiki-sync.sh when wiki or README files
+#          are modified. Fires as a non-blocking advisory (PostToolUse) or a blocking
+#          pre-commit gate (PreToolUse on git commit).
+#
+# Canonical path: src/.claude/hooks/aphelion-md-sync.sh
+# Referenced by: .claude/settings.json (this repo's dogfooding settings, NOT src/.claude/settings.json)
+#
+# Dogfooding note: This hook is inert in user projects (copied via bin/ overlay but
+# not registered in src/.claude/settings.json). To activate in user projects, manually
+# add it to .claude/settings.json.
+
+set -euo pipefail
+
+HOOK_NAME="md-sync"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Fail-open: any uncaught error exits with 0 so hook bugs never block user work.
+# shellcheck disable=SC2064
+trap 'echo "[aphelion-hook:'"${HOOK_NAME}"'] internal error at line $LINENO; passing through" >&2; exit 0' ERR
+
+# Read stdin (Claude Code hook payload JSON)
+RAW_PAYLOAD="$(cat)"
+
+# Determine event type from the payload: PreToolUse payloads have "tool_name" and "tool_input"
+# PostToolUse payloads also have "tool_response". We detect by checking for "tool_response".
+IS_POST_TOOL_USE=false
+if printf '%s' "$RAW_PAYLOAD" | grep -q '"tool_response"'; then
+  IS_POST_TOOL_USE=true
+fi
+
+# Check if sync script exists in this repo
+SYNC_SCRIPT="${PROJECT_DIR}/scripts/check-readme-wiki-sync.sh"
+
+if "$IS_POST_TOOL_USE"; then
+  # PostToolUse on Edit|Write — advisory only (cannot block)
+  # Extract the modified file path
+  TARGET_PATH=$(printf '%s' "$RAW_PAYLOAD" \
+    | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]+"' \
+    | head -1 \
+    | sed -E 's/^"file_path"[[:space:]]*:[[:space:]]*"//; s/"$//')
+
+  # Check if the file is a wiki or README file that requires sync check
+  NEEDS_SYNC=false
+  if printf '%s' "$TARGET_PATH" | grep -qE '(docs/wiki/|README)'; then
+    NEEDS_SYNC=true
+  fi
+
+  if "$NEEDS_SYNC"; then
+    echo "[aphelion-hook:${HOOK_NAME}] wiki/README file modified: $(basename "$TARGET_PATH")" >&2
+    echo "[aphelion-hook:${HOOK_NAME}] Run 'bash scripts/check-readme-wiki-sync.sh' before committing." >&2
+  fi
+  exit 0
+else
+  # PreToolUse on Bash(git commit*) — run sync check and block if it fails
+  # Extract commit command
+  RAW_CMD=$(printf '%s' "$RAW_PAYLOAD" \
+    | grep -oE '"command"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 \
+    | sed -E 's/^"command"[[:space:]]*:[[:space:]]*"//; s/"$//')
+
+  # Only act on git commit commands
+  if ! printf '%s' "$RAW_CMD" | grep -qE '^git commit'; then
+    exit 0
+  fi
+
+  # Bypass marker
+  if printf '%s' "$RAW_CMD" | grep -qE '\[skip-md-sync\]'; then
+    echo "[aphelion-hook:${HOOK_NAME}] bypass marker [skip-md-sync] found — skipping sync check" >&2
+    exit 0
+  fi
+
+  # Check if any staged files require sync validation
+  STAGED=$(git -C "$PROJECT_DIR" diff --cached --name-only 2>/dev/null || true)
+  if [ -z "$STAGED" ]; then
+    exit 0
+  fi
+
+  NEEDS_SYNC=false
+  if printf '%s\n' "$STAGED" | grep -qE '(docs/wiki/|README)'; then
+    NEEDS_SYNC=true
+  fi
+
+  if ! "$NEEDS_SYNC"; then
+    # No wiki/README files staged — skip sync check
+    exit 0
+  fi
+
+  # Run the sync check script
+  if [ ! -f "$SYNC_SCRIPT" ]; then
+    echo "[aphelion-hook:${HOOK_NAME}] sync script not found at ${SYNC_SCRIPT}; passing through" >&2
+    exit 0
+  fi
+
+  if ! bash "$SYNC_SCRIPT" 2>&1; then
+    cat >&2 <<EOF
+[aphelion-hook:${HOOK_NAME}] BLOCKED: check-readme-wiki-sync.sh reported inconsistencies.
+- Fix the reported issues, then re-run git commit.
+- Bypass: append [skip-md-sync] to the commit message if the sync check is a false positive.
+EOF
+    exit 2
+  fi
+
+  exit 0
+fi

--- a/src/.claude/hooks/aphelion-task-md-lifecycle.sh
+++ b/src/.claude/hooks/aphelion-task-md-lifecycle.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# aphelion-task-md-lifecycle.sh
+# Aphelion dogfooding hook — TASK.md lifecycle guard (this repo only)
+# Event:   PostToolUse on Write|Edit (TASK.md)
+#
+# Purpose: Check that TASK.md is being reset to the placeholder template when
+#          all tasks are marked complete (all checkboxes ticked). Reminds
+#          developer to reset TASK.md before phase completion commit.
+#          Non-blocking advisory.
+#
+# Dogfooding rationale (OQ-C decision): The TASK.md lifecycle rule
+#   (document-versioning.md §TASK.md Lifecycle) requires resetting TASK.md to
+#   placeholder on phase completion. This hook catches the common mistake of
+#   committing a fully-ticked TASK.md without resetting it. Clear dogfooding
+#   value for this repo's own `developer` sessions. Implemented.
+#
+# Canonical path: src/.claude/hooks/aphelion-task-md-lifecycle.sh
+# Referenced by: .claude/settings.json (this repo's dogfooding settings, NOT src/.claude/settings.json)
+#
+# Dogfooding note: This hook is inert in user projects (copied via bin/ overlay but
+# not registered in src/.claude/settings.json). See aphelion-md-sync.sh for pattern.
+
+set -euo pipefail
+
+HOOK_NAME="task-md-lifecycle"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Fail-open: any uncaught error exits with 0 so hook bugs never block user work.
+# shellcheck disable=SC2064
+trap 'echo "[aphelion-hook:'"${HOOK_NAME}"'] internal error at line $LINENO; passing through" >&2; exit 0' ERR
+
+# Read stdin (Claude Code hook payload JSON)
+RAW_PAYLOAD="$(cat)"
+
+# PostToolUse only (advisory; cannot block)
+# Extract the file path that was written/edited
+TARGET_PATH=$(printf '%s' "$RAW_PAYLOAD" \
+  | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]+"' \
+  | head -1 \
+  | sed -E 's/^"file_path"[[:space:]]*:[[:space:]]*"//; s/"$//')
+
+[ -z "$TARGET_PATH" ] && exit 0
+
+# Only act when TASK.md is the file being written
+BASENAME=$(basename -- "$TARGET_PATH")
+if [ "$BASENAME" != "TASK.md" ]; then
+  exit 0
+fi
+
+TASK_MD_PATH="$TARGET_PATH"
+if [ ! -f "$TASK_MD_PATH" ]; then
+  exit 0
+fi
+
+# Count unchecked tasks [ ] and checked tasks [x]
+UNCHECKED=$(grep -c '^\- \[ \]' "$TASK_MD_PATH" 2>/dev/null || true)
+CHECKED=$(grep -c '^\- \[x\]' "$TASK_MD_PATH" 2>/dev/null || true)
+TOTAL=$(( UNCHECKED + CHECKED ))
+
+# If TASK.md has no task entries at all, it might already be the placeholder
+if [ "$TOTAL" -eq 0 ]; then
+  exit 0
+fi
+
+# If all tasks are checked and none are unchecked, phase is complete
+# Remind developer to reset TASK.md to placeholder
+if [ "$UNCHECKED" -eq 0 ] && [ "$CHECKED" -gt 0 ]; then
+  cat >&2 <<EOF
+[aphelion-hook:${HOOK_NAME}] All ${CHECKED} tasks in TASK.md are complete.
+  Per document-versioning.md §TASK.md Lifecycle, reset TASK.md to placeholder
+  before the final phase commit:
+    echo '# TASK.md\n\n（フェーズ未割当。次回 \`developer\` 起動時に ARCHITECTURE.md を参照して再生成されます）' > TASK.md
+  Then: git add TASK.md && git commit with the final phase commit.
+  This ensures the next developer session starts from a clean state.
+EOF
+fi
+
+# If TASK.md has more checked than unchecked (> 50% done), remind about approaching completion
+if [ "$UNCHECKED" -gt 0 ] && [ "$CHECKED" -gt 0 ] && [ "$CHECKED" -gt "$UNCHECKED" ]; then
+  echo "[aphelion-hook:${HOOK_NAME}] Progress: ${CHECKED}/${TOTAL} tasks complete. Remember to reset TASK.md on phase completion." >&2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Add 3 dogfooding hooks to `src/.claude/hooks/`: `aphelion-md-sync.sh`, `aphelion-agent-count-check.sh`, `aphelion-task-md-lifecycle.sh`
- Add `.claude/settings.json` for this repo (NOT shipped via `bin/init`) registering all 6 hooks (3 user A/B/E + 3 dogfooding)
- Confirm `.gitignore` explicitly keeps `.claude/settings.json` as a committed shared asset

## Related Issue

Linked Issue: #107

## Linked Plan

docs/design-notes/archived/aphelion-hooks-architecture.md §12.3

## Hook descriptions

### md-sync (dogfooding)
Wraps `scripts/check-readme-wiki-sync.sh`. Two event bindings:
- `PostToolUse` on `Write|Edit` of `docs/wiki/*` or `README*` — non-blocking advisory to run sync check
- `PreToolUse` on `Bash(git commit*)` when wiki/README files are staged — blocking gate (exit 2); bypass: `[skip-md-sync]` in commit message

### agent-count-check (dogfooding, OQ-C: implemented)
`PostToolUse` advisory checking agent count parity vs actual `.claude/agents/*.md` count. Fires earlier than the pre-commit sync check.

### task-md-lifecycle (dogfooding, OQ-C: implemented)
`PostToolUse` advisory reminding developer to reset TASK.md to placeholder when all tasks are ticked.

## Dogfooding measurement results (analyst R2 mitigation)

**False-positive rate: 0% (0/10 blocked)** — hook A tested against 10 most recent commits; all PASS.

Patterns P1–P6 and P8 verified working. P7 bug discovered (see below).

## Dogfooding findings

### P7 bug (pre-existing from PR 1a)

Pattern P7 (`-----BEGIN (RSA|EC|DSA|OPENSSH)? PRIVATE KEY-----`) starts with `-----BEGIN` which `grep` interprets as `--flag` when passed as `grep -qiE \"\$regex\"` without `--`. Fix: use `grep -qiE -- \"\$regex\"`. Impact: P7 is currently ineffective. P1–P6 and P8 are unaffected. Recommend fix in PR 1d.

## Inert copy note

Dogfooding hooks will be copied to user projects via `bin/` overlay (all of `src/.claude/hooks/` is deployed) but are inert — not registered in `src/.claude/settings.json`. This is the intended behavior.

## Merge order

After PR 1a (#111) and PR 1b (#112), before PR 1d. \`Closes #107\` will be added in PR 1d.

## Test plan

- [x] \`bash -n\` syntax check passes on all 7 hook scripts (shellcheck not installed)
- [x] \`aphelion-md-sync.sh\` fires correctly on PostToolUse wiki file edit (tested manually)
- [x] Hook A 10-commit false-positive measurement: 0% (0/10 blocked)
- [x] \`.claude/settings.json\` committed and not gitignored (confirmed via \`git check-ignore\`)
- [x] \`src/.claude/settings.json\` unchanged (still 3 user hooks only)