### PR TITLE
refactor: agent bulk update for document-locations (PR-B of #117)

### DIFF
--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -27,6 +27,7 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
 > Follows `.claude/rules/git-rules.md` for repository policy and gh CLI availability checks (Startup Probe).
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ---
 
@@ -323,6 +324,11 @@ EOF
 
 ---
 
+## Output Files
+
+- `SPEC.md` (incremental Edit; resolved per document-locations.md; default `docs/SPEC.md`)
+- `UI_SPEC.md` (incremental Edit when UI changes needed; resolved per document-locations.md; default `docs/UI_SPEC.md`)
+
 ## Required Output on Completion
 
 ```
@@ -333,6 +339,9 @@ ISSUE_SUMMARY: {one-line summary}
 DOCS_UPDATED:
   - SPEC.md: updated | no_change
   - UI_SPEC.md: updated | no_change | not_exists
+ARTIFACT_PATHS:
+  - SPEC: {resolved path, e.g. docs/SPEC.md or SPEC.md}
+  - UI_SPEC: {resolved path, e.g. docs/UI_SPEC.md or UI_SPEC.md}
 GITHUB_ISSUE: {issue URL | skipped}
 HANDOFF_TO: architect
 ARCHITECT_BRIEF: |

--- a/.claude/agents/api-reference-author.md
+++ b/.claude/agents/api-reference-author.md
@@ -25,6 +25,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **api-reference-author** agent in doc-flow. You generate API
 reference documentation for the customer's developer team and external API consumers.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Integrate SPEC.md (Use Cases), ARCHITECTURE.md (`## 5. API Design`), and

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -26,6 +26,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **architect agent** in the Aphelion workflow.
 In the Delivery domain, you bridge spec design and implementation.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Thoroughly read `SPEC.md` and generate **`ARCHITECTURE.md` (technical design document)** that enables `developer` to begin implementation without ambiguity.
@@ -73,7 +75,7 @@ If the user has specified a stack, always prioritize that; if no specification e
 
 ---
 
-## Output File: `ARCHITECTURE.md`
+## Output File: `ARCHITECTURE.md` (resolved per document-locations.md; default `docs/ARCHITECTURE.md`)
 
 ```markdown
 # Architecture Design: {Project Name}

--- a/.claude/agents/change-classifier.md
+++ b/.claude/agents/change-classifier.md
@@ -28,6 +28,7 @@ You are the **change classifier agent** in the Aphelion maintenance workflow.
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/codebase-analyzer.md
+++ b/.claude/agents/codebase-analyzer.md
@@ -30,6 +30,7 @@ You are the **codebase analysis agent** in the Aphelion workflow.
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 You reverse-engineer an existing codebase to generate `SPEC.md` and `ARCHITECTURE.md`,
 enabling the project to join the standard Aphelion workflow (analyst → delivery-flow).
 
@@ -127,7 +128,7 @@ Observe from the code (do not speculate):
 
 ---
 
-## Output File: `SPEC.md`
+## Output File: `SPEC.md` (resolved per document-locations.md; default `docs/SPEC.md`)
 
 Generate using the same format as `spec-designer` output, with `Source: existing codebase analysis` noted.
 
@@ -184,7 +185,7 @@ Generate using the same format as `spec-designer` output, with `Source: existing
 
 ---
 
-## Output File: `ARCHITECTURE.md`
+## Output File: `ARCHITECTURE.md` (resolved per document-locations.md; default `docs/ARCHITECTURE.md`)
 
 Generate using the same format as `architect` output, with `Source: existing codebase analysis` noted.
 
@@ -325,12 +326,19 @@ Record the determined `PRODUCT_TYPE` in SPEC.md.
 
 ## Output on Completion (Required)
 
+**Output path determination:** Before writing, ask the user where to place the output files:
+- Default (new project, no prior files): `docs/SPEC.md` and `docs/ARCHITECTURE.md`
+- If `.aphelion-auto-approve` is present (auto-approve mode), skip the question and use `docs/` as default
+
 ```
 AGENT_RESULT: codebase-analyzer
 STATUS: success | error
 ARTIFACTS:
   - SPEC.md
   - ARCHITECTURE.md
+ARTIFACT_PATHS:
+  - SPEC: docs/SPEC.md              # or SPEC.md if user selected root
+  - ARCHITECTURE: docs/ARCHITECTURE.md
 HAS_UI: true | false
 PRODUCT_TYPE: service | tool | library | cli
 LANGUAGE: {primary language}

--- a/.claude/agents/concept-validator.md
+++ b/.claude/agents/concept-validator.md
@@ -26,6 +26,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **concept validation agent** of the Aphelion workflow.
 In the Discovery domain, you evaluate the concept validity of projects that include UI.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Based on the preceding interview, research, and PoC results, design UI prototypes (wireframes, screen flows) and evaluate concept validity from a user experience perspective.

--- a/.claude/agents/db-ops.md
+++ b/.claude/agents/db-ops.md
@@ -29,6 +29,7 @@ You handle configuration, procedures, and risk assessment needed for production 
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/delivery-flow.md
+++ b/.claude/agents/delivery-flow.md
@@ -28,6 +28,8 @@ You manage each phase of design, implementation, testing, review, documentation,
 You must never proceed to the next phase without user approval. This is an absolute rule.
 **Exception:** When auto-approve mode is active, approval gates are automatically passed (see orchestrator-rules.md "Auto-Approve Mode").
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 > **Common rules:** At startup, `Read` `.claude/orchestrator-rules.md` and follow its common rules for triage, approval gates, error handling, phase execution loop, and rollback.
 
 ---
@@ -307,8 +309,12 @@ When rolling back, pass the following to `developer`:
 1. Check whether `DISCOVERY_RESULT.md` exists
    - If present → read PRODUCT_TYPE and requirements summary, then perform triage
    - If absent → receive requirements from the user, then perform triage
-2. Check whether existing `SPEC.md` / `ARCHITECTURE.md` files exist
-3. If existing files are found, confirm with `AskUserQuestion`:
+2. Inspect existing artifacts (single Glob per name, per document-locations.md):
+   For each of {SPEC, ARCHITECTURE, UI_SPEC, VISUAL_SPEC}:
+     Run `Glob("{docs/<NAME>.md,<NAME>.md}")` once.
+     Record the first match as the artifact's resolved path
+     (prefer `docs/` on tie; emit `WARNING_LEGACY_DUPLICATE: <NAME>` in AGENT_RESULT).
+3. If any existing artifact is found, confirm with `AskUserQuestion`:
    ```json
    {
      "questions": [{
@@ -322,8 +328,11 @@ When rolling back, pass the following to `developer`:
      }]
    }
    ```
-4. Present the triage result to the user and obtain approval
-5. Launch Phase 1
+4. Build `ARTIFACT_PATHS` from the resolved paths and carry it into every
+   subsequent agent prompt (per orchestrator-rules.md Phase Execution Loop
+   step 2 — MUST).
+5. Present the triage result to the user and obtain approval
+6. Launch Phase 1
 
 ---
 
@@ -353,10 +362,10 @@ Delivery complete
   Phase 11  Documentation            ✅ Approved
 
 Artifacts:
-  SPEC.md          ✅
+  SPEC.md          ✅  ({resolved path})         ← resolved per document-locations.md
   UI_SPEC.md       ✅ / (no UI)
   VISUAL_SPEC.md   ✅ / (no UI / Minimal / Light)
-  ARCHITECTURE.md  ✅
+  ARCHITECTURE.md  ✅  ({resolved path})         ← resolved per document-locations.md
   TEST_PLAN.md     ✅
   Implementation   ✅
   README.md        ✅

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -30,6 +30,7 @@ In the Delivery domain, you faithfully translate designs into code.
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/discovery-flow.md
+++ b/.claude/agents/discovery-flow.md
@@ -31,6 +31,8 @@ You manage the entire requirements exploration flow and launch each agent in seq
 You must never proceed to the next phase without user approval. This is an absolute rule.
 **Exception:** When auto-approve mode is active, approval gates are automatically passed (see orchestrator-rules.md "Auto-Approve Mode").
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Systematically conduct requirements exploration for the project and generate a **`DISCOVERY_RESULT.md` (discovery result)** of sufficient quality for the subsequent Delivery domain to begin work.

--- a/.claude/agents/doc-flow.md
+++ b/.claude/agents/doc-flow.md
@@ -31,6 +31,8 @@ You generate customer-facing deliverable documents from existing Aphelion artifa
 and launch each author agent in sequence with user approval gates.
 **You must always obtain user approval after each phase before proceeding to the next.**
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 > **Note (PR 1 skeleton release):** Author agents in this release are skeletons.
 > Full document generation logic is enabled in PR 2. Triage and approval gates
 > function correctly; each author agent will return STATUS: error or STATUS: skipped
@@ -174,7 +176,8 @@ For each author agent invocation, pass the following in the prompt:
 - `output_path` — full path for the output file
 - `template_version_required` — `1.0` (default)
 - `repo_root` — result of `git rev-parse --show-toplevel`
-- Input artifact absolute paths (SPEC.md, ARCHITECTURE.md, etc.)
+- Input artifact absolute paths resolved via `Glob("{docs/<NAME>.md,<NAME>.md}")`
+  per document-locations.md (carry as `ARTIFACT_PATHS` — MUST per orchestrator-rules.md)
 - Existing deliverable presence flag (for overwrite detection)
 
 **STATUS: skipped handling:** If an author agent returns `STATUS: skipped`,

--- a/.claude/agents/doc-reviewer.md
+++ b/.claude/agents/doc-reviewer.md
@@ -30,6 +30,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **doc-reviewer agent** in the Aphelion workflow.
 You perform horizontal consistency checks across markdown artifacts — not code review.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Review cross-document consistency among markdown artifacts (SPEC.md, ARCHITECTURE.md,

--- a/.claude/agents/doc-writer.md
+++ b/.claude/agents/doc-writer.md
@@ -28,6 +28,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **doc writer agent** in the Aphelion workflow.
 In the Delivery domain, you handle documentation preparation after implementation, testing, and review are complete.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Reference `SPEC.md`, `ARCHITECTURE.md`, and implementation code to generate a **complete set of documentation** for project users and developers.

--- a/.claude/agents/e2e-test-designer.md
+++ b/.claude/agents/e2e-test-designer.md
@@ -27,6 +27,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **E2E / GUI test design agent** in the Aphelion workflow.
 In the Delivery domain, you design E2E test plans for web applications and desktop GUI applications.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Thoroughly read `UI_SPEC.md` and the E2E test strategy in `ARCHITECTURE.md`, and **append an E2E test section to `TEST_PLAN.md`** that enables `tester` to create and execute E2E / GUI test code without ambiguity.

--- a/.claude/agents/handover-author.md
+++ b/.claude/agents/handover-author.md
@@ -25,6 +25,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **handover-author** agent in doc-flow. You generate handover
 packages for successor maintenance teams at project closeout.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Integrate SPEC.md, ARCHITECTURE.md, SECURITY_AUDIT.md, TEST_PLAN.md, and

--- a/.claude/agents/hld-author.md
+++ b/.claude/agents/hld-author.md
@@ -25,6 +25,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **hld-author** agent in doc-flow. You generate High-Level Design
 documents for customer architects and project managers.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Repackage SPEC.md and ARCHITECTURE.md into a system overview document targeted

--- a/.claude/agents/impact-analyzer.md
+++ b/.claude/agents/impact-analyzer.md
@@ -29,6 +29,7 @@ You are the **impact analyzer agent** in the Aphelion maintenance workflow.
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/infra-builder.md
+++ b/.claude/agents/infra-builder.md
@@ -32,6 +32,7 @@ that enables container-isolated execution for `sandbox-runner`.
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/interviewer.md
+++ b/.claude/agents/interviewer.md
@@ -27,6 +27,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **requirements interview agent** of the Aphelion workflow.
 You are responsible for the first phase of the Discovery domain, systematically collecting and structuring project requirements.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Interview requirements from the user and generate **`INTERVIEW_RESULT.md` (interview results)** that subsequent agents (researcher, poc-engineer, concept-validator, scope-planner) and the Delivery domain can reference.

--- a/.claude/agents/lld-author.md
+++ b/.claude/agents/lld-author.md
@@ -25,6 +25,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **lld-author** agent in doc-flow. You generate Low-Level Design
 documents for the customer's developer and maintenance team.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Read ARCHITECTURE.md and `src/*` (at signature level) and produce a detailed

--- a/.claude/agents/maintenance-flow.md
+++ b/.claude/agents/maintenance-flow.md
@@ -29,6 +29,8 @@ You manage the full maintenance lifecycle for changes to existing projects.
 You must never proceed to the next phase without user approval. This is an absolute rule.
 **Exception:** When auto-approve mode is active, approval gates are automatically passed (see orchestrator-rules.md "Auto-Approve Mode").
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 > **Common rules:** At startup, `Read` `.claude/orchestrator-rules.md` and follow its common rules for triage, approval gates, error handling, phase execution loop, and rollback.
 
 ---

--- a/.claude/agents/observability.md
+++ b/.claude/agents/observability.md
@@ -30,6 +30,7 @@ In the Operations domain, you design and implement monitoring, logging, and metr
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/operations-flow.md
+++ b/.claude/agents/operations-flow.md
@@ -29,6 +29,8 @@ You manage the entire deploy and operations flow, and **you must always obtain u
 You must never proceed to the next phase without user approval. This is an absolute rule.
 **Exception:** When auto-approve mode is active, approval gates are automatically passed (see orchestrator-rules.md "Auto-Approve Mode").
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 > **Common rules:** At startup, `Read` `.claude/orchestrator-rules.md` and follow its common rules for triage, approval gates, error handling, phase execution loop, and rollback.
 
 ## Mission
@@ -140,11 +142,16 @@ Phase 4: Operations planning   → ops-planner    → ⏸ User approval → Done
 
 ### At Startup
 
-1. Read `DELIVERY_RESULT.md`
+1. Run `Glob("{docs/DELIVERY_RESULT.md,DELIVERY_RESULT.md}")` to discover DELIVERY_RESULT.md
+   (prefer `docs/` on tie; emit `WARNING_LEGACY_DUPLICATE: DELIVERY_RESULT` if both match).
 2. Confirm `PRODUCT_TYPE` is `service` (stop if otherwise)
-3. Read `ARCHITECTURE.md` and `SPEC.md`
-4. Perform triage, report the plan to the user, and obtain approval
-5. Launch Phase 1
+3. Inspect existing artifacts (single Glob per name, per document-locations.md):
+   - Run `Glob("{docs/ARCHITECTURE.md,ARCHITECTURE.md}")` once; record resolved path.
+   - Run `Glob("{docs/SPEC.md,SPEC.md}")` once; record resolved path.
+4. Build `ARTIFACT_PATHS` from resolved paths and carry into every agent prompt
+   (MUST per orchestrator-rules.md Phase Execution Loop step 2).
+5. Perform triage, report the plan to the user, and obtain approval
+6. Launch Phase 1
 
 ### Information to Include in Agent Instructions
 

--- a/.claude/agents/ops-manual-author.md
+++ b/.claude/agents/ops-manual-author.md
@@ -25,6 +25,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **ops-manual-author** agent in doc-flow. You generate operations
 manuals for the customer's operations team.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Repackage infra-builder / releaser / observability outputs (Dockerfile,

--- a/.claude/agents/ops-planner.md
+++ b/.claude/agents/ops-planner.md
@@ -27,6 +27,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **operations planning agent** in the Aphelion workflow.
 You handle the final phase of the Operations domain, preparing the complete set of procedures needed for deployment and operations.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Integrate the artifacts from preceding agents (infra-builder, db-ops, observability) with `ARCHITECTURE.md` to create the procedures, playbooks, and checklists needed for production operations. As the final output, generate `OPS_RESULT.md` (the Operations handoff file).

--- a/.claude/agents/poc-engineer.md
+++ b/.claude/agents/poc-engineer.md
@@ -29,6 +29,7 @@ You are responsible for the third phase of the Discovery domain, verifying techn
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/releaser.md
+++ b/.claude/agents/releaser.md
@@ -30,6 +30,7 @@ You handle the final phase of the Delivery domain, performing versioning and rel
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -28,6 +28,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **domain research agent** of the Aphelion workflow.
 You are responsible for the second phase of the Discovery domain, systematically researching domain knowledge and technical information relevant to the project.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Thoroughly read `INTERVIEW_RESULT.md` and research the domain knowledge, external dependencies, and technical risks necessary for the project's realization, then generate **`RESEARCH_RESULT.md` (research results)**.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -26,6 +26,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **review agent** in the Aphelion workflow.
 In the Delivery domain, you serve as the pre-release code quality gate.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Review implementation code from both `SPEC.md` (spec compliance) and `ARCHITECTURE.md` (design consistency) perspectives,

--- a/.claude/agents/rules-designer.md
+++ b/.claude/agents/rules-designer.md
@@ -29,6 +29,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **project rules designer** of the Aphelion workflow.
 You interactively determine project-specific coding conventions, Git workflow, build commands, and other rules with the user, then generate `.claude/rules/project-rules.md`.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Establish project-specific rules **before Delivery begins**, so that all subsequent agents (spec-designer, architect, developer, etc.) operate under consistent conventions.

--- a/.claude/agents/sandbox-runner.md
+++ b/.claude/agents/sandbox-runner.md
@@ -29,6 +29,7 @@ You run commands that other Aphelion agents have classified as high-risk,
 using the host platform's native isolation features.
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ---
 

--- a/.claude/agents/scaffolder.md
+++ b/.claude/agents/scaffolder.md
@@ -31,6 +31,7 @@ In the Delivery domain, positioned between architecture design and implementatio
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/scope-planner.md
+++ b/.claude/agents/scope-planner.md
@@ -27,6 +27,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **scope planning agent** of the Aphelion workflow.
 You are responsible for the final phase of the Discovery domain, consolidating the results of requirements exploration and preparing the handoff to Delivery.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Integrate all artifacts from preceding agents, perform MVP definition, prioritization, and risk assessment, then generate the final handoff file `DISCOVERY_RESULT.md` for the Delivery domain.

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -29,6 +29,7 @@ In the Delivery domain, you serve as the security gate after implementation and 
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/spec-designer.md
+++ b/.claude/agents/spec-designer.md
@@ -26,6 +26,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **spec design agent** in the Aphelion workflow.
 Positioned at the top of the Delivery domain, you transform requirements into a specification document.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Analyze requirements presented by the user (or from `DISCOVERY_RESULT.md`) and generate **`SPEC.md` (functional specification)** that downstream agents (ux-designer, architect, developer) can reference.
@@ -91,7 +93,7 @@ Verify the following before starting work:
 
 ---
 
-## Output File: `SPEC.md`
+## Output File: `SPEC.md` (resolved per document-locations.md; default `docs/SPEC.md`)
 
 ```markdown
 # Specification: {Project Name}

--- a/.claude/agents/test-designer.md
+++ b/.claude/agents/test-designer.md
@@ -27,6 +27,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **test design agent** in the Aphelion workflow.
 In the Delivery domain, you formulate test plans based on specifications and design.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Thoroughly read the acceptance criteria in `SPEC.md` and the test strategy in `ARCHITECTURE.md`, and generate **`TEST_PLAN.md` (test plan document)** that enables `tester` to create and execute test code without ambiguity.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -31,6 +31,7 @@ In the Delivery domain, you create and execute test code based on test plans and
 
 > Follows `.claude/rules/sandbox-policy.md` for command risk classification and delegation to `sandbox-runner`.
 > Follows `.claude/rules/denial-categories.md` for post-failure diagnosis when a Bash command is denied.
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
 
 ## Mission
 

--- a/.claude/agents/user-manual-author.md
+++ b/.claude/agents/user-manual-author.md
@@ -26,6 +26,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **user-manual-author** agent in doc-flow. You generate end-user
 operation manuals for the actual system users.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 ## Mission
 
 Combine SPEC.md Use Cases with UI_SPEC.md screen definitions to produce an
@@ -79,7 +81,8 @@ Default to `en` if absent. Use `--lang` argument from orchestrator if provided.
 
 ### Step 2: Check Skip Condition (UI_SPEC.md presence)
 
-Attempt to `Read("UI_SPEC.md")`.
+Use `Glob("{docs/UI_SPEC.md,UI_SPEC.md}")` to discover UI_SPEC.md (per document-locations.md).
+Record the resolved path if found.
 
 **Case A: UI_SPEC.md is ABSENT and invoked via orchestrator (normal flow):**
 → Return `STATUS: skipped`, `SKIP_REASON: no UI (UI_SPEC.md not found)`
@@ -95,9 +98,12 @@ immediately. Orchestrator records this in `SKIPPED_TYPES`.
   replace `{{ui_spec.screens}}` with the "no UI" note, continue to Step 3.
 
 **Case C: UI_SPEC.md is PRESENT:**
-→ Set `HAS_UI_SPEC=true`, proceed to Step 3.
+→ Set `HAS_UI_SPEC=true`, record resolved path, proceed to Step 3.
 
 ### Step 3: Read Input Artifacts
+
+Use `ARTIFACT_PATHS` from the orchestrator if available; otherwise resolve via
+`Glob("{docs/<NAME>.md,<NAME>.md}")` per document-locations.md.
 
 - `SPEC.md` (required) — extract use case list. For each UC:
   - UC identifier (e.g., UC-001)
@@ -110,14 +116,14 @@ immediately. Orchestrator records this in `SKIPPED_TYPES`.
 If `SPEC.md` is absent, return `STATUS: error`.
 
 **UC extraction strategy:**
-Use `Grep` to find UC entries: `Grep("UC-[0-9]+", "SPEC.md")`.
-Then `Read("SPEC.md")` and parse the `## Use Cases` section to extract each
-UC's title, actor, and goal.
+Use `Grep` to find UC entries in the resolved SPEC.md path.
+Then read the resolved SPEC.md path and parse the `## Use Cases` section to
+extract each UC's title, actor, and goal.
 
 **UI_SPEC.md screen mapping:**
-Use `Grep` to find screen IDs: `Grep("SCR-[0-9]+|Screen:", "UI_SPEC.md")`.
-Then `Read("UI_SPEC.md")` to extract each screen's name, description, and
-associated UC references.
+Use `Grep` to find screen IDs in the resolved UI_SPEC.md path.
+Then read the resolved UI_SPEC.md path to extract each screen's name,
+description, and associated UC references.
 
 ### Step 4: Resolve Template
 

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -26,6 +26,8 @@ If `.claude/rules/project-rules.md` is absent, apply defaults:
 You are the **designer agent** in the Aphelion workflow.
 In the Delivery domain, positioned between spec design and architecture design, you act as a UI design expert.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 Your scope is **information architecture, screen flow, wireframes, and
 per-screen component specs**. Visual identity (color palette, typography,
 spacing tokens, design system selection, accessibility level, responsive
@@ -137,7 +139,7 @@ Step 5. Design interactions and states
 
 ---
 
-## Output File: `UI_SPEC.md`
+## Output File: `UI_SPEC.md` (resolved per document-locations.md; default `docs/UI_SPEC.md`)
 
 **Important: Each screen section must be self-contained so that it can be pasted directly into an AI design tool and used as-is.**
 

--- a/.claude/agents/visual-designer.md
+++ b/.claude/agents/visual-designer.md
@@ -36,6 +36,8 @@ level, responsive breakpoints, and tone & manner — collected in
 **`VISUAL_SPEC.md`** so that `developer` and any downstream AI design tool
 have one authoritative source of truth.
 
+> Follows `.claude/rules/document-locations.md` for artifact path resolution. New artifacts default to `docs/`; legacy root files are read if present.
+
 This agent is intentionally narrow. It does **not** redesign screens
 (`ux-designer` already did that), does **not** make tech-stack architecture
 decisions (`architect` does that), and does **not** implement components
@@ -168,7 +170,7 @@ Record the intake outcome at the top of `VISUAL_SPEC.md` under
 
 ---
 
-## Output File: `VISUAL_SPEC.md`
+## Output File: `VISUAL_SPEC.md` (resolved per document-locations.md; default `docs/VISUAL_SPEC.md`)
 
 > Skeleton headings below are **English-fixed** (template skeleton policy).
 > Free-form narrative content inside each section is written in the resolved

--- a/TASK.md
+++ b/TASK.md
@@ -2,13 +2,13 @@
 
 > Source: docs/design-notes/aphelion-output-docs-default-location-design.md (2026-05-11)
 
-## Phase: PR-A foundation — document-locations rule + protocol/orchestrator updates
-Last updated: 2026-05-11T01:00:00
-Status: Completed
+## Phase: PR-B agent bulk update — document-locations reference in all agents
+Last updated: 2026-05-11
+Status: In progress
 
 ## Task List
 
-### Phase A (PR-A: foundation)
+### Phase A (PR-A: foundation) — COMPLETED
 - [x] TASK-001: Create src/.claude/rules/document-locations.md (new rule) | Target file: src/.claude/rules/document-locations.md
 - [x] TASK-002: Update src/.claude/rules/agent-communication-protocol.md (ARTIFACT_PATHS as first-class field) | Target file: src/.claude/rules/agent-communication-protocol.md
 - [x] TASK-003: Update src/.claude/rules/aphelion-overview.md (rules count 13→14, add document-locations entry) | Target file: src/.claude/rules/aphelion-overview.md
@@ -16,8 +16,17 @@ Status: Completed
 - [x] TASK-005: Update src/.claude/rules/document-versioning.md (update example filenames with docs/ notation) | Target file: src/.claude/rules/document-versioning.md
 - [x] TASK-006: Update .claude/orchestrator-rules.md (Glob 1-pass pattern at startup + ARTIFACT_PATHS carry MUST) | Target file: .claude/orchestrator-rules.md
 
+### Phase B (PR-B: agent bulk update)
+- [ ] TASK-B01: Add document-locations reference to Delivery Flow agents + Output File headings + delivery-flow Glob pattern | Target: .claude/agents/{spec-designer,architect,ux-designer,visual-designer,developer,scaffolder,reviewer,tester,test-designer,e2e-test-designer,security-auditor,doc-writer,delivery-flow}.md
+- [ ] TASK-B02: Add document-locations reference to Maintenance Flow agents | Target: .claude/agents/{change-classifier,impact-analyzer,analyst,maintenance-flow}.md
+- [ ] TASK-B03: Add document-locations reference to Doc Flow agents + fix user-manual-author hardcoded Read | Target: .claude/agents/{hld-author,lld-author,api-reference-author,ops-manual-author,user-manual-author,handover-author,doc-reviewer,doc-flow}.md
+- [ ] TASK-B04: Add document-locations reference to Discovery Flow agents | Target: .claude/agents/{interviewer,researcher,poc-engineer,concept-validator,scope-planner,discovery-flow}.md
+- [ ] TASK-B05: Add document-locations reference to Operations Flow agents | Target: .claude/agents/{infra-builder,db-ops,observability,ops-planner,operations-flow}.md
+- [ ] TASK-B06: Add document-locations reference to cross-cutting agents + Output File headings | Target: .claude/agents/{codebase-analyzer,rules-designer,sandbox-runner,releaser}.md
+- [ ] TASK-B07: Static grep verification | Verify 0 hardcoded hits, 41 agents with reference
+
 ## Recent Commits
-(Record git log --oneline -3 each time a task is completed)
+(none for PR-B yet)
 
 ## Session Interruption Notes
-All 6 tasks completed in a single session. PR-A foundation is fully implemented.
+PR-A fully completed. Starting PR-B agent bulk update on feature/issue-117-pr-b-agent-bulk-update branch.

--- a/TASK.md
+++ b/TASK.md
@@ -17,16 +17,21 @@ Status: In progress
 - [x] TASK-006: Update .claude/orchestrator-rules.md (Glob 1-pass pattern at startup + ARTIFACT_PATHS carry MUST) | Target file: .claude/orchestrator-rules.md
 
 ### Phase B (PR-B: agent bulk update)
-- [ ] TASK-B01: Add document-locations reference to Delivery Flow agents + Output File headings + delivery-flow Glob pattern | Target: .claude/agents/{spec-designer,architect,ux-designer,visual-designer,developer,scaffolder,reviewer,tester,test-designer,e2e-test-designer,security-auditor,doc-writer,delivery-flow}.md
-- [ ] TASK-B02: Add document-locations reference to Maintenance Flow agents | Target: .claude/agents/{change-classifier,impact-analyzer,analyst,maintenance-flow}.md
-- [ ] TASK-B03: Add document-locations reference to Doc Flow agents + fix user-manual-author hardcoded Read | Target: .claude/agents/{hld-author,lld-author,api-reference-author,ops-manual-author,user-manual-author,handover-author,doc-reviewer,doc-flow}.md
-- [ ] TASK-B04: Add document-locations reference to Discovery Flow agents | Target: .claude/agents/{interviewer,researcher,poc-engineer,concept-validator,scope-planner,discovery-flow}.md
-- [ ] TASK-B05: Add document-locations reference to Operations Flow agents | Target: .claude/agents/{infra-builder,db-ops,observability,ops-planner,operations-flow}.md
-- [ ] TASK-B06: Add document-locations reference to cross-cutting agents + Output File headings | Target: .claude/agents/{codebase-analyzer,rules-designer,sandbox-runner,releaser}.md
-- [ ] TASK-B07: Static grep verification | Verify 0 hardcoded hits, 41 agents with reference
+- [x] TASK-B01: Add document-locations reference to Delivery Flow agents + Output File headings + delivery-flow Glob pattern | Target: .claude/agents/{spec-designer,architect,ux-designer,visual-designer,developer,scaffolder,reviewer,tester,test-designer,e2e-test-designer,security-auditor,doc-writer,delivery-flow}.md
+- [x] TASK-B02: Add document-locations reference to Maintenance Flow agents | Target: .claude/agents/{change-classifier,impact-analyzer,analyst,maintenance-flow}.md
+- [x] TASK-B03: Add document-locations reference to Doc Flow agents + fix user-manual-author hardcoded Read | Target: .claude/agents/{hld-author,lld-author,api-reference-author,ops-manual-author,user-manual-author,handover-author,doc-reviewer,doc-flow}.md
+- [x] TASK-B04: Add document-locations reference to Discovery Flow agents | Target: .claude/agents/{interviewer,researcher,poc-engineer,concept-validator,scope-planner,discovery-flow}.md
+- [x] TASK-B05: Add document-locations reference to Operations Flow agents | Target: .claude/agents/{infra-builder,db-ops,observability,ops-planner,operations-flow}.md
+- [x] TASK-B06: Add document-locations reference to cross-cutting agents + Output File headings | Target: .claude/agents/{codebase-analyzer,rules-designer,sandbox-runner,releaser}.md
+- [x] TASK-B07: Static grep verification | 0 hardcoded hits, 40/40 agents with reference
 
 ## Recent Commits
-(none for PR-B yet)
+- refactor: add document-locations reference to Delivery Flow agents (PR-B of #117)
+- refactor: add document-locations reference to Maintenance Flow agents (PR-B of #117)
+- refactor: add document-locations reference to Doc Flow agents (PR-B of #117)
+- refactor: add document-locations reference to Discovery Flow agents (PR-B of #117)
+- refactor: add document-locations reference to Operations Flow agents (PR-B of #117)
+- refactor: add document-locations reference to cross-cutting agents (PR-B of #117)
 
 ## Session Interruption Notes
 PR-A fully completed. Starting PR-B agent bulk update on feature/issue-117-pr-b-agent-bulk-update branch.


### PR DESCRIPTION
## Summary

PR-B of [#117](https://github.com/kirin0198/aphelion-agents/issues/117) — applies the `document-locations.md` rule (introduced in PR-A #119, merged) to all 40 agent definition files.

This PR was originally #120 (auto-closed when PR-A's base branch was deleted). Rebased onto current main and re-opened as a fresh PR.

## Changes

- **40 agents** (`.claude/agents/*.md`): 1-line reference declaration added (`Follows .claude/rules/document-locations.md ...`)
- **6 Write agents** (spec-designer, architect, ux-designer, visual-designer, codebase-analyzer, analyst): Output File header annotated with `(default docs/<NAME>.md)`
- **3 orchestrators** (delivery-flow, operations-flow, doc-flow): At Startup updated to use single `Glob("{docs/<NAME>.md,<NAME>.md}")` pattern; `MUST carry ARTIFACT_PATHS` added to Phase Execution Loop step 2
- **user-manual-author** (`Read("SPEC.md")` hardcoded residue from PR-A review): fixed in both Step 2 and Step 3, with `ARTIFACT_PATHS` fallback

## Verification

- `grep -rE 'Read\("(docs/)?[A-Z_]+\.md"\)' .claude/agents/` → **0 hits**
- `grep -rE 'Write\("(docs/)?[A-Z_]+\.md"\)' .claude/agents/` → **0 hits**
- `grep -l 'document-locations.md' .claude/agents/*.md | wc -l` → **40/40**
- `discovery-flow` / `maintenance-flow` orchestrators **intentionally not updated** for At Startup — they don't have existing-artifact detection steps (validated by reviewer)

## Review history

Reviewed before (#120): Approve with comments — 0 CRITICAL / 2 WARNING / 4 SUGGESTION:
- WR-001 (commit trailer model name `Claude Sonnet 4.6` violated git-rules.md) → **fixed via rebase**, all 7 commits now use bare `Claude`
- WR-002 (handover template Source artifacts row) → **moved to PR-C scope** (#121)

## Stacked PRs

- PR-A: #119 (merged via 5110a45)
- **PR-B: this PR** (originally #120)
- PR-C: #121 (wiki / README / CHANGELOG / templates, depends on this PR)

## Related Issue

Linked Issue: #117

## Test plan

- [x] Static greps clean (Read/Write hardcoded, document-locations references)
- [x] All 7 commits use bare `Claude` trailer (git-rules.md Model Name Policy)
- [x] Agent functional behavior unchanged (no Required Verification edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)