### PR TITLE
chore: archive 3 orphaned planning docs (#101 / #103 / #105)

### DIFF
--- a/docs/design-notes/archived/readme-shields-badges.md
+++ b/docs/design-notes/archived/readme-shields-badges.md
@@ -1,0 +1,191 @@
+> Last updated: 2026-04-30
+> GitHub Issue: [#101](https://github.com/kirin0198/aphelion-agents/issues/101)
+> Authored by: analyst (2026-04-30)
+> Next: developer (architect skip — single-purpose docs change)
+
+# README shields.io バッジ追加
+
+## 1. Problem statement
+
+`README.md` / `README.ja.md` には現在 Wiki への入口を示すバッジが 1 枚あるだけで、
+リポジトリの規模感 (agents / commands / rules の数) や license 種別が一目で
+分からない。GitHub のリポジトリトップに到達したユーザーが
+"このリポジトリは何で、どれくらいの規模で、何のライセンスか" を即座に把握できる
+ように shields.io 静的バッジを追加する。
+
+参考にした事例: <https://github.com/Donchitos/Claude-Code-Game-Studios/blob/main/README.md>
+
+## 2. Current state evidence
+
+実測値 (2026-04-30 時点):
+
+| 項目 | コマンド / 出典 | 実測値 | 備考 |
+|------|----------------|-------|------|
+| agents | `ls .claude/agents/*.md \| wc -l` | **39** | 既存 README 本文の "39 specialized agents" と一致 |
+| commands | `ls .claude/commands/*.md \| wc -l` | **14** | slash command 定義 |
+| rules | `ls .claude/rules/*.md \| wc -l` | 0 | リポジトリ内には存在しない |
+| rules (canonical) | `ls src/.claude/rules/*.md \| wc -l` | **12** | npx 配布で `~/.claude/rules/` にコピーされる canonical source |
+| hooks | `.claude/settings.json` / `src/.claude/settings.local.json` を grep | **0 (設定なし)** | Aphelion は hooks 機構を採用していない |
+| license | `head -1 LICENSE` → "MIT License" | **MIT** | |
+
+### 補足: rules バッジの canonical 対象判断
+
+リポジトリ内の `.claude/rules/` は (PR #54 系列の整理結果として) 空で、実体は
+`src/.claude/rules/` に集約されている。これは npx 配布時に `~/.claude/rules/`
+へコピーされる canonical source であり、ユーザーが Aphelion を使う場合は
+`src/.claude/rules/` の枚数が体感値と一致する。
+
+→ **rules バッジは `src/.claude/rules/` の 12 を採用する** (analyst 推奨)。
+README 本文には "src/" を書かずに `rules-12-green` とだけ表示し、ラベルは
+"rules" の単語のみとする。バッジが `src/` 配下を指すことは README 上では
+明示しない (バッジは粒度の粗いシグナルであり、詳細は README 本文や Wiki 側で
+説明する)。
+
+### 補足: hooks バッジの扱い判断
+
+Aphelion は Claude Code の `hooks` 機構を採用していない (rules.md /
+sandbox-policy.md / denial-categories.md 等のテキストルールベースで
+agent 動作を制御する設計)。`hooks-0-orange` を表示するのは
+"何かが欠けている" ように見えてミスリーディング。
+
+→ **hooks バッジは追加しない** (analyst 推奨)。最終的なバッジ枚数は **4 枚**
+(agents / commands / rules / license)。
+
+## 3. Constraints
+
+- **Repo-root README sync convention** (language-rules.md §3.1〜3.4):
+  `README.md` (canonical) と `README.ja.md` を同一 PR で更新する。
+  English-only マージは禁止 (typo / link 修正の minor fix exception を除く)。
+- **バッジラベル文字列は英語固定**: 両言語ファイルで完全に同一の markdown 行
+  を挿入する (heading parity = Check 3 を確実に満たすため)。
+- **`scripts/check-readme-wiki-sync.sh` の Check 1/2/3 を通過すること**:
+  - Check 1 (agent count parity): バッジは `^N specialized agents$` のような
+    本文記述ではないので影響なし
+  - Check 2 (slash command parity): バッジは slash command を含まないので
+    影響なし
+  - Check 3 (README pair heading position parity): `^## ` heading の数と
+    行位置を README 両方で同じに保つ。バッジは画像 markdown 行 (`![...]`)
+    で `## ` heading ではないため、両 README に **同じ行数** のバッジ block を
+    **同じ相対位置** に挿入する限り heading の絶対行位置が同じだけずれて
+    parity は維持される。
+- **shields.io 静的バッジ URL 構文の厳守**:
+  `https://img.shields.io/badge/<label>-<value>-<color>` 形式。
+  ラベル中のハイフンはダブルハイフン (`--`) でエスケープする必要がある
+  (今回はラベルが単語のみなので該当なし)。
+- 配置位置: 既存 Wiki バッジ (L5) の **直後** (改行のみで空行なし) に
+  挿入。ユーザー要求に従う。
+
+## 4. Success criteria
+
+- README.md / README.ja.md の Wiki バッジ直後に 4 枚のバッジが追加されている
+- en / ja で **完全に同じ markdown 行** が挿入されている
+- `bash scripts/check-readme-wiki-sync.sh` が pass する (ローカル + CI)
+- バッジ表示時の数値が実測値と一致する (agents=39 / commands=14 / rules=12 /
+  license=MIT)
+- design-note (本ファイル) の `> GitHub Issue:` 行が実 issue 番号で埋まる
+
+## 5. Approach
+
+### 5.1 配置と最終形 (developer がそのままコピペ可能な markdown)
+
+既存の README L5:
+
+```markdown
+[![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.com-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.com/)
+```
+
+の **直後** (空行を挟まず L6 に) 1 行で 4 枚のバッジを並べる:
+
+```markdown
+![agents](https://img.shields.io/badge/agents-39-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-12-green) ![license](https://img.shields.io/badge/license-MIT-blue)
+```
+
+(リンクは付けない静的バッジ。GitHub 側で自動的に折り返される。)
+
+挿入後の README.md / README.ja.md L1〜10 イメージ:
+
+```markdown
+# Aphelion — Frontier AI Agents
+
+A collection of AI coding agent definitions for Claude Code that automates the entire project lifecycle with 39 specialized agents.
+
+[![Wiki](https://img.shields.io/badge/Wiki-aphelion--agents.com-F38020?logo=cloudflarepages&logoColor=white&style=flat)](https://aphelion-agents.com/)
+![agents](https://img.shields.io/badge/agents-39-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-12-green) ![license](https://img.shields.io/badge/license-MIT-blue)
+
+**[日本語版 README はこちら](README.ja.md)**
+
+---
+
+## What's Aphelion
+```
+
+(README.ja.md は L7 の "[日本語版 README はこちら]" の代わりに
+"[English README](README.md)" となる点だけが既存差分。バッジ行は完全同一。)
+
+### 5.2 1 PR / 1 commit
+
+ユーザー要求の "small docs PR" に従い、両ファイルへのバッジ追加を **1 commit**
+にまとめる。commit prefix は `docs:` (git-rules.md の prefix table より)。
+
+ブランチ名 (developer 担当): `feat/readme-shields-badges` (Direct invocation /
+feature addition の default に従う)。
+
+## 6. Document changes
+
+| ファイル | 変更内容 |
+|----------|---------|
+| `README.md` | L5 (Wiki バッジ) の直後 (新 L6) に 4 バッジ行を挿入。後続行は +1 シフト。 |
+| `README.ja.md` | 同上 (L6 にバッジ行を挿入)。L5 の Wiki バッジ markdown と新 L6 のバッジ markdown は en と完全同一。 |
+| `docs/design-notes/readme-shields-badges.md` | (本ファイル) 新規作成。GitHub Issue 作成後に header の `> GitHub Issue:` を実番号に更新。 |
+
+SPEC.md / ARCHITECTURE.md / UI_SPEC.md / agent definition への変更はゼロ。
+
+## 7. Open questions / 確認事項
+
+AskUserQuestion は本セッションで利用不可と前提されているため、以下は
+analyst の推奨判断で確定する (ユーザーが PR レビュー時に修正依頼可能):
+
+- **Q1: rules バッジの canonical 対象**
+  → **§2 の判断に従い `src/.claude/rules/` (12 枚) を採用**。
+  バッジに "src/" は表示しない (粒度の粗いシグナル)。
+- **Q2: hooks バッジの扱い (0 件問題)**
+  → **§2 の判断に従いバッジ自体を追加しない**。最終枚数 4 枚。
+  ユーザーが "0 でも表示したい" 場合は PR 上で 1 行差分で復活可能。
+- **Q3: バッジへのリンク付与**
+  → **付与しない**。参考にした Donchitos/Claude-Code-Game-Studios の README も
+  静的バッジのみ。リンクを足すと改行が増えて Check 3 のリスクが上がる。
+- **Q4: README L5 と新 L6 の間に空行を入れるか**
+  → **入れない** (ユーザー要求 "改行のみ、空行なし" に従う)。バッジ群が
+  Wiki バッジと一塊になることで視覚的に "tags" として認識される。
+
+## 8. Handoff
+
+```
+HANDOFF_TO: developer
+ARCHITECT_SKIP_REASON: single-file docs editing chore (no design impact)
+BRANCH: feat/readme-shields-badges
+COMMITS: 1 (推奨)
+
+実測値:
+  agents: 39  (.claude/agents/*.md)
+  commands: 14 (.claude/commands/*.md)
+  rules: 12 (src/.claude/rules/*.md, canonical source)
+  hooks: N/A (バッジ追加しない)
+  license: MIT
+
+挿入位置:
+  README.md L5 の直後 (新 L6)
+  README.ja.md L5 の直後 (新 L6)
+
+挿入する markdown (両ファイル完全同一の 1 行):
+
+  ![agents](https://img.shields.io/badge/agents-39-blueviolet) ![commands](https://img.shields.io/badge/commands-14-blue) ![rules](https://img.shields.io/badge/rules-12-green) ![license](https://img.shields.io/badge/license-MIT-blue)
+
+検証コマンド (commit 前に必ず実行):
+  bash scripts/check-readme-wiki-sync.sh
+
+PR body には:
+  - Closes #{issue}
+  - Linked Plan: docs/design-notes/readme-shields-badges.md
+を含める (merge で auto-close + design-note auto-archive)。
+```

--- a/docs/design-notes/archived/rules-ref-and-sync-check-hardening.md
+++ b/docs/design-notes/archived/rules-ref-and-sync-check-hardening.md
@@ -1,0 +1,250 @@
+> Last updated: 2026-04-30
+> GitHub Issue: [#105](https://github.com/kirin0198/aphelion-agents/issues/105)
+> Authored by: analyst (2026-04-30)
+> Next: developer (architect skip — small docs + CI script change)
+
+# Rules-Reference page and check-readme-wiki-sync hardening (#103 follow-up)
+
+## 1. Problem statement
+
+#103 の PR #104 で out-of-scope として記録された 2 件の follow-up を本ノートで解消する。
+
+- **Follow-up A**: `docs/wiki/{en,ja}/Rules-Reference.md` の rule entries 数が canonical
+  (`src/.claude/rules/*.md` = 12 件) と整合していない可能性。Home.md は #103 で 9 → 12 に
+  bump 済みだが、Rules-Reference.md 本体の整合は未検証だった。
+- **Follow-up B**: `scripts/check-readme-wiki-sync.sh` Check 1 が **README.md / README.ja.md
+  の L3 に出現する agent count しか検証していない**。L70 の link 行 ("all 39 agents" /
+  "全 39 エージェント") で同様の数値 drift が起きても CI で検出できない構造的盲点が #103
+  で発覚した。
+
+## 2. Current state evidence
+
+### 2.1 Follow-up A: Rules-Reference.md の実測値
+
+canonical 側 (`src/.claude/rules/*.md`) は **12 件**:
+
+```
+agent-communication-protocol.md    aphelion-overview.md
+build-verification-commands.md     denial-categories.md
+document-versioning.md             file-operation-principles.md
+git-rules.md                       language-rules.md
+library-and-security-policy.md     localization-dictionary.md
+sandbox-policy.md                  user-questions.md
+```
+
+これに対し `docs/wiki/en/Rules-Reference.md` の `## ` 見出しによる rule entry は
+**11 件** ── `localization-dictionary` が欠落。
+
+```
+aphelion-overview                  agent-communication-protocol
+build-verification-commands        document-versioning
+file-operation-principles          git-rules
+language-rules                     library-and-security-policy
+sandbox-policy                     denial-categories
+user-questions
+                                   ← localization-dictionary 欠落
+```
+
+加えて、ページ内に同じ count drift が複数箇所で発生している:
+
+| 箇所 | 現状 | 期待値 | 備考 |
+|------|------|--------|------|
+| en L12 / ja L13 | "11 behavioral rules" / "11 の行動ルール" | 12 | 本文冒頭 |
+| en L169 / ja L170 | "All 10 rule files" / "10のルールファイル全体" | 12 | "Canonical Sources" 節 |
+| en L18-28 / ja L19-29 | ToC: 11 entries | 12 | `localization-dictionary` link 欠落 |
+| en L34-156 / ja L35-157 | 本体: 11 entries | 12 | `localization-dictionary` 節欠落 |
+
+ja 側に追加で 1 点表記揺れあり:
+
+- L103, L104 の "AGENT_RESTULT" は "AGENT_RESULT" の typo (本タスクの主目的ではないが、
+  rule entries 修正と同 PR で合わせて修正することを推奨)。
+
+### 2.2 Follow-up B: Check 1 の現行ロジックと盲点
+
+現行 (`scripts/check-readme-wiki-sync.sh` L26-42):
+
+```sh
+README_EN=$(grep -oE '[0-9]+ specialized agents' "$REPO_ROOT/README.md"     | grep -oE '[0-9]+' | head -1)
+README_JA=$(grep -oE '[0-9]+ の専門エージェント'  "$REPO_ROOT/README.ja.md"  | grep -oE '[0-9]+' | head -1)
+HOME_EN=$(grep -oE 'all [0-9]+ agents'           "$REPO_ROOT/docs/wiki/en/Home.md" | head -1 | grep -oE '[0-9]+')
+HOME_JA=$(grep -oE '[0-9]+ エージェント'          "$REPO_ROOT/docs/wiki/ja/Home.md" | grep -oE '[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
+```
+
+各ファイルの実際の出現箇所:
+
+| ファイル | L3 (canonical sentence) | L70 / その他 | 現行 Check 1 が見る箇所 |
+|----------|------------------------|---------------|--------------------------|
+| README.md | "with 39 specialized agents" | L70 "all 39 agents" | L3 のみ (L70 は regex 対象外) |
+| README.ja.md | "39 の専門エージェント" | L70 "全 39 エージェント" | L3 のみ (L70 は regex 対象外) |
+| docs/wiki/en/Home.md | L26 "all 39 agents" | L41 "all 39 agents" | `head -1` で L26 のみ |
+| docs/wiki/ja/Home.md | L27 "39 エージェント" | L42 "39 エージェント" | `sort -u` で両方検証 (OK) |
+
+**盲点 (drift しても CI が pass してしまう箇所)**:
+
+1. **README.md L70** ("all 39 agents") — 別 regex なので Check 1 の対象外
+2. **README.ja.md L70** ("全 39 エージェント") — 別 regex なので対象外
+3. **docs/wiki/en/Home.md L41** ("all 39 agents") — `head -1` で見落とし
+
+(ja Home.md は `sort -u` のおかげで既に複数行検証されており、ここに盲点はない)
+
+## 3. Constraints
+
+- bilingual sync (en + ja) を 1 PR に同梱 (wiki Bilingual Sync Policy)
+- `site/src/content/docs/{en,ja}/rules-reference.md` は `sync-wiki.mjs` で auto-overwrite
+  されるので **直接編集しない** (`docs/wiki/` 側の修正で連動)
+- 既存の Check 1 が pass する 4 ファイルはこれまで通り pass し続けること (regression なし)
+- false positive 増加を最小限に: commit message / archived/ 配下 / コードブロック内の
+  例示などは引き続きマッチ対象外であるべき
+- `archived/` 配下と `node_modules/` は触らない
+- script 改修は GNU grep の portable な範囲に留める (`grep -oE` / `grep -E` のみ)
+
+## 4. Success criteria
+
+- `docs/wiki/en/Rules-Reference.md` と `docs/wiki/ja/Rules-Reference.md` が **12 entries**
+  で揃い、本文冒頭の "N behavioral rules" / "N の行動ルール"、ToC、本体節、Canonical
+  Sources 節の数値表記がすべて 12 で整合する
+- `scripts/check-readme-wiki-sync.sh` Check 1 が以下 3 箇所の drift も検出する:
+  - README.md L70 link 行
+  - README.ja.md L70 link 行
+  - docs/wiki/en/Home.md L41 link 行
+- 既存の 4 値 (`README.md=39, README.ja.md=39, Home.md(en)=39, Home.md(ja)=39`) は
+  これまでどおり pass する
+- `bash scripts/check-readme-wiki-sync.sh` がローカルで pass し、`astro build` (任意)
+  も通る
+
+## 5. Approach
+
+### 5.1 Follow-up A の修復方針
+
+`docs/wiki/en/Rules-Reference.md`:
+
+1. L12 を "11 behavioral rules" → "12 behavioral rules" に変更
+2. ToC (L18-28) に `- [localization-dictionary](#localization-dictionary)` を追加
+   (アルファベット順を維持するため `library-and-security-policy` と `sandbox-policy`
+   の間に挿入)
+3. 本体に `## localization-dictionary` 節を新規追加 (`library-and-security-policy` 直後、
+   `sandbox-policy` の直前)。記載項目は他 entry と同じスケルトン:
+   - **Canonical**: `[.claude/rules/localization-dictionary.md](../../.claude/rules/localization-dictionary.md)`
+   - **Scope**: All agents that emit fixed UI strings (approval gates, AskUserQuestion
+     boilerplate, progress displays, "Phase N complete" headers)
+   - **Auto-load behavior**: Auto-loaded by Claude Code on every session start
+   - **Interactions**: Resolves at runtime against `project-rules.md` →
+     `## Localization` → `Output Language`. Cooperates with `language-rules.md` Hybrid
+     Localization Strategy: dictionary entries cover fixed UI strings, while free-form
+     narrative is generated directly by the agent in the resolved language.
+   - **Summary**: Provides the canonical en/ja translations for fixed UI strings
+     organized into three sections (Approval Gate, AskUserQuestion Fallback, Progress
+     Display). Template placeholders (`{N}`, `{M}`, `{agent}`) are substituted at render
+     time. The file also points to `docs/design-notes/archived/ja-terminology-rebalance.md`
+     for prose terminology used by Aphelion's own JA wiki/README (kept separate from
+     runtime UI strings).
+4. L169 を "All 10 rule files" → "All 12 rule files" に変更
+5. L4 の `> **Last updated**:` と `> **Update history**:` に今回の更新行を追加
+
+`docs/wiki/ja/Rules-Reference.md`: 上記の en と同等の修正に加えて:
+
+6. L103, L104 の "AGENT_RESTULT" → "AGENT_RESULT" 修正 (typo cleanup)
+7. L13, L170 の数値 (11 → 12, 10 → 12) を更新
+8. ToC と本体に `localization-dictionary` 節を追加 (en と同じ位置・同じ skeleton、
+   narrative は ja で記述)
+9. L4 と L11 の `> **EN canonical**:` 日付を更新
+
+### 5.2 Follow-up B の推奨案
+
+**推奨案: Plan A (パターン拡張 + ファイル全体検証)**
+
+3 案を比較:
+
+| 案 | 内容 | Pros | Cons |
+|----|------|------|------|
+| Plan A | 既存 4 regex を保ちつつ、各ファイルで `head -1` を外し全行抽出 + `sort -u` で deduplicate (Home ja の現行ロジックを横展開) | 最小変更、portable bash、false positive 増えない | regex を増やしてはいないので「L70 の link 文字列」だけのために新パターンは追加しない |
+| Plan B | README L3 / L70 を別パターンとして追加検証 (`all [0-9]+ agents` を README.md にも適用) | drift 箇所が明示的に列挙される | 同じ意味の行を 2 種類の regex で扱うことになり保守性低下 |
+| Plan C | language-rules.md / Contributing.md に「agent count を hard-code する箇所は L3 と link 行 (L70) の 2 箇所のみ」と invariant を文書化し、script は line-number-anchored に | 規約として明示できる | 行番号固定は脆弱。README 構造変更で即崩壊 |
+
+**推奨: Plan A** ── 理由:
+
+- README.md L70 の文字列は実は en Home.md と同じ `all [0-9]+ agents` パターンに
+  マッチするため、**README.md にも同じ regex を追加適用するのが最も自然**
+- README.ja.md L70 は `[0-9]+ エージェント` パターンにマッチするため、ja Home.md と
+  同じ regex を README.ja.md にも適用すれば良い
+- 新たな regex を導入する必要なし。既存 regex の **適用範囲拡大 + `head -1` 削除 +
+  `sort -u`** だけで盲点 3 箇所すべてをカバーできる
+- false positive 対策: commit message や archived/ 配下のファイルはそもそも grep
+  対象に含まれない (READMEs と Home.md のみ); コードブロック内の例示は L3 / L70 周辺の
+  文章にしか出現しないため実害なし
+
+**具体的な diff 案** (擬似コード):
+
+```sh
+# Before:
+README_EN=$(grep -oE '[0-9]+ specialized agents' "$REPO_ROOT/README.md" \
+  | grep -oE '[0-9]+' | head -1)
+
+# After: collect from BOTH "specialized agents" (L3) AND "all N agents" (L70)
+README_EN=$(grep -hoE '[0-9]+ specialized agents|all [0-9]+ agents' "$REPO_ROOT/README.md" \
+  | grep -oE '[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
+```
+
+`README.ja.md` も同様 (`[0-9]+ の専門エージェント|[0-9]+ エージェント` で OR 結合 +
+`sort -u`)。
+
+`Home.md (en)` は `head -1` を削除して `sort -u` を追加するだけ (既に regex は OK)。
+
+`Home.md (ja)` は変更なし (既に対応済み)。
+
+検証ロジック (L35-42 の for-loop) は文字列比較のままで OK。drift があれば
+`HOME_JA=12,9` のような複数値文字列が `ACTUAL=12` と不一致になり fail する。
+
+### 5.3 (任意) Plan A 適用に伴うドキュメント追記
+
+- `docs/wiki/en/Contributing.md` (or `language-rules.md` の repo-root README sync 節)
+  に「agent count は README L3 と L70 link 行の 2 箇所に出現する。両方とも同じ数値
+  でなければならない (Check 1 が enforce する)」と一行追記する案がある。これは
+  developer 判断で本 PR に同梱しても次回 follow-up でも可。
+
+## 6. Document changes
+
+| ファイル | 変更内容 |
+|----------|---------|
+| `docs/wiki/en/Rules-Reference.md` | 12 entries 化 (本文冒頭の 11→12, ToC entry 追加, `localization-dictionary` 節追加, "All 10 rule files" → "All 12 rule files", Last updated / Update history 更新) |
+| `docs/wiki/ja/Rules-Reference.md` | 同上 (ja narrative) + AGENT_RESTULT typo 修正 + EN canonical 日付更新 |
+| `scripts/check-readme-wiki-sync.sh` | Check 1 で 4 ファイル全行抽出 + `sort -u` (Plan A) |
+| (任意) `docs/wiki/en/Contributing.md` and `docs/wiki/ja/Contributing.md` | agent count invariant の文書化 |
+
+`SPEC.md` / `ARCHITECTURE.md`: 変更なし (本タスクは docs + ci-hardening のみ)。
+
+`site/src/content/docs/{en,ja}/rules-reference.md`: **触らない** (`sync-wiki.mjs` で
+auto-overwrite される)。
+
+## 7. Open questions
+
+- **Q1**: Rules-Reference.md の section 順は現状 "category 別 + alphabetical 部分混在"
+  になっている。`localization-dictionary` は `library-and-security-policy` と
+  `sandbox-policy` の間 (alphabetical 位置) に挿入することを推奨するが、developer は
+  既存 entry の並びを尊重しても良い (どちらでも canonical との整合は取れる)。
+- **Q2**: Plan A で `sort -u` を使うと、もし README.md 内で複数の正しい数値 (例えば
+  L3 が "39 specialized agents" で L70 が "all 39 agents") があった場合に両方とも同じ
+  "39" として deduplicate されるため、`HOME_JA` 同様 1 値として比較できる。drift があれば
+  `12,9` のような複数値文字列となり ACTUAL と一致しない。実装上の追加検討は不要。
+- **Q3**: ja Rules-Reference.md の "AGENT_RESTULT" typo 修正は本 PR 同梱で OK か、
+  別 commit / 別 PR にすべきか。本 follow-up と同 commit 内で `docs(wiki): fix
+  AGENT_RESTULT typo in ja Rules-Reference` 等の独立 commit にすることを推奨
+  (analyst 提案、developer 判断で確定)。
+
+## 8. Handoff
+
+- **HANDOFF_TO**: developer (architect skip)
+- **理由**: Follow-up A は単純な entry 追加と数値整合、Follow-up B は ~5 行の bash
+  patch のみ。設計判断は本ノート §5 で確定済みで、新規アーキテクチャ判断は不要。
+- **推奨 PR 構成**: 1 PR / 2-3 commit:
+  1. `docs(wiki): align Rules-Reference rule entries to 12` (en + ja 同 commit)
+  2. `ci: harden check-readme-wiki-sync to detect agent count drift in README L70`
+  3. (optional) `docs(wiki): fix AGENT_RESTULT typo in ja Rules-Reference`
+- **bilingual sync**: `docs/wiki/en/Rules-Reference.md` と `docs/wiki/ja/Rules-Reference.md`
+  は同 PR 必須
+- **検証**:
+  - `bash scripts/check-readme-wiki-sync.sh` がローカルで pass
+  - 可能なら `cd site && npm run build` (astro build) も pass
+  - rule entries が canonical 12 件と完全に一致 (`ls src/.claude/rules/*.md | wc -l` と
+    Rules-Reference.md の `## ` count から ToC + 関連ページ + 正規ソースの 3 セクション
+    を引いた値が 12 になる)

--- a/docs/design-notes/archived/wiki-and-site-update-audit.md
+++ b/docs/design-notes/archived/wiki-and-site-update-audit.md
@@ -1,0 +1,252 @@
+> Last updated: 2026-04-30
+> GitHub Issue: [#103](https://github.com/kirin0198/aphelion-agents/issues/103)
+> Authored by: analyst
+> Next: developer (architect skip — straightforward sync fixup)
+
+# Wiki and site/ update-drift audit
+
+## 1. Problem statement
+
+ユーザー報告: 「wiki のランディングページのエージェント数が更新されていない。他に更新漏れがないか確認して対応を開始してください。」
+
+直近の bump / 更新の流れ:
+
+- agent count: 31 → 32 (#91 doc-reviewer 追加, PR #92) → 39 (#54 doc-flow + 6 author 追加, PR #98)
+- domain count: 4 ドメイン → 5 ドメイン (Doc 追加, #54 / PR #98)
+- Agents Reference page 数: 5 ページ → 6 ページ (Agents-Doc.md 新設, #54 / PR #98)
+- README badge 追加 (agents-39 / commands-14 / rules-12 / license-MIT, PR #102)
+- 新 slash command: `/doc-flow` (#54)
+- 新 cross-cutting agent: `doc-reviewer` (#91)
+- 新 flow orchestrator: `doc-flow` (5th flow, #54)
+
+これらが複数の同期ポイントに渡っていた結果、`docs/wiki/{en,ja}/Home.md` 等の主要 canonical 文書は更新されたものの、**`site/` 配下の Astro Starlight ランディングページ**、**README 本文 (L70)**、**Home.md の rules 数**、**`astro.config.mjs` の sidebar 定義**、**CHANGELOG `[Unreleased]`** で取り残しが発生している。
+
+ユーザーが指摘した「wiki のランディングページ」は Cloudflare Pages 上の <https://aphelion-agents.com/> のトップ = `site/src/content/docs/{en,ja}/index.mdx` を指す。
+
+## 2. Current state evidence
+
+### 2.1 直近の bump 履歴 (確認済み)
+
+| PR / Issue | 内容 | canonical 反映 | 漏れ |
+|------------|------|----------------|------|
+| #91 / #92 | doc-reviewer 追加 (32 agents) | `.claude/agents/`, `aphelion-overview.md` 反映 | README.md L70 / README.ja.md L70 が "32" のまま |
+| #54 / #98 | doc-flow + Doc domain (39 agents / 5 flows / 6 pages) | wiki/Home.md, aphelion-overview.md 反映 | site/index.mdx 全体が 29/4/5 のまま. astro.config.mjs PAGES に Agents-Doc 不在. README L70 も 32 のまま (#91 引き継ぎ) |
+| #101 / #102 | README badge 追加 / 本文 39 化 | README.md L3, L6 / README.ja.md L3, L6 反映 | README.md L70 / README.ja.md L70 が 32 残存 |
+| 規模拡張に伴うルール 9 → 12 | rules 12 個実在 | `src/.claude/rules/` 12 ファイル, Rules-Reference.md 11 entries | wiki/Home.md (en/ja) L26-27, L41-42 で "9 behavior rules / 9 つの行動ルール" 残存 |
+| 上記すべて | Unreleased セクション | - | CHANGELOG.md `[Unreleased]` に doc-flow / doc-reviewer / Agents-Doc.md / agent count bump / badge entries が未記載 |
+
+### 2.2 site/ 配下構造と sync-wiki.mjs の挙動
+
+- `site/` は Astro Starlight プロジェクト (`site/package.json`)。`prebuild: node ../scripts/sync-wiki.mjs` により build 時に `docs/wiki/{en,ja}/*.md` を `site/src/content/docs/{en,ja}/*.md` へコピー + frontmatter 自動付与 + リンク Starlight 形式書き換え。
+- 同期対象 = wiki にある `*.md` のみ。**`index.mdx` は wiki に対応ファイルがなく、site/ 専用の手動メンテファイル**。
+- 結論:
+  - `site/src/content/docs/{en,ja}/index.mdx` → **手動更新必要** (本 audit のメイン対象)。
+  - `site/src/content/docs/{en,ja}/home.md`, `rules-reference.md`, `getting-started.md` 等の wiki 由来ファイル → コミット済みコピーが古くても build で自動上書きされるため、**直接の編集は不要** (wiki 側さえ正しければ Cloudflare Pages 再 build で正)。`docs/wiki/` を更新すれば自動連動する。
+- `astro.config.mjs` の `PAGES` 配列は手動メンテ。新規ページ追加時にここへ登録しないと **sidebar に新ページが表示されない**。`Agents-Doc.md` は wiki に存在するが PAGES 未登録 = 致命的漏れ。
+
+### 2.3 漏れ箇所一覧 (区分 a = 修正必須)
+
+| # | ファイル | 行 | 現状 (抜粋) | 期待 |
+|---|----------|----|-------------|------|
+| 1 | `site/src/content/docs/en/index.mdx` | L24 | `## Meet the 29 Agents across 4 Flows` | `## Meet the 39 Agents across 5 Flows` |
+| 2 | `site/src/content/docs/en/index.mdx` | L28 | `4 top-level orchestrators: discovery-flow, delivery-flow, operations-flow, maintenance-flow.` | `5 top-level orchestrators: discovery-flow, delivery-flow, operations-flow, maintenance-flow, doc-flow.` |
+| 3 | `site/src/content/docs/en/index.mdx` | L43-46 (Maintenance card 後) | Doc Domain card なし | Doc Domain card を追加 (7 agents: 1 orchestrator + 6 authors, link `/en/agents-doc/`) |
+| 4 | `site/src/content/docs/en/index.mdx` | L47-50 (Safety & Standalone) | `sandbox-runner for isolated execution, plus analyst and codebase-analyzer for standalone use.` | `sandbox-runner for isolated execution, doc-reviewer for cross-cutting consistency review, plus analyst and codebase-analyzer for standalone use.` |
+| 5 | `site/src/content/docs/en/index.mdx` | L68 | `All 29 agents — split by domain (Orchestrators, Discovery, Delivery, Operations, Maintenance)` | `All 39 agents — split by domain (Orchestrators, Discovery, Delivery, Operations, Maintenance, Doc)` |
+| 6 | `site/src/content/docs/en/index.mdx` | L1-3 (frontmatter) / L6 (hero tagline) | `Discovery, Delivery, Operations in three independent domains.` / 同様 | Doc / Maintenance を含む文言に更新 (narrative) |
+| 7 | `site/src/content/docs/ja/index.mdx` | L24 | `## 29 エージェント × 4 フロー` | `## 39 エージェント × 5 フロー` |
+| 8 | `site/src/content/docs/ja/index.mdx` | L28 | `4 つの Flow Orchestrator: discovery-flow, delivery-flow, operations-flow, maintenance-flow。` | `5 つの Flow Orchestrator: ... + doc-flow。` |
+| 9 | `site/src/content/docs/ja/index.mdx` | L43-46 | Doc Domain card なし | 追加 (7 エージェント, doc-flow + 6 author) |
+| 10 | `site/src/content/docs/ja/index.mdx` | L47-50 | Safety / Standalone に doc-reviewer なし | 追加 |
+| 11 | `site/src/content/docs/ja/index.mdx` | L69 | `29 エージェント全ての責務・入出力・NEXT 条件 — ドメイン別 5 ページに分割（Orchestrators・Discovery・Delivery・Operations・Maintenance）` | `39 エージェント全ての責務・入出力・NEXT 条件 — ドメイン別 6 ページに分割（Orchestrators・Discovery・Delivery・Operations・Maintenance・Doc）` |
+| 12 | `site/src/content/docs/ja/index.mdx` | L1-3 / L6 | `Discovery / Delivery / Operations の 3 ドメイン構成。` 等 | Doc / Maintenance 反映 (narrative) |
+| 13 | `README.md` | L70 | `- [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 32 agents` | `... — all 39 agents` |
+| 14 | `README.ja.md` | L70 | `- [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 32 エージェント` | `... — 全 39 エージェント` |
+| 15 | `docs/wiki/en/Home.md` | L26 | `\| — \| [Rules Reference](./Rules-Reference.md): 9 behavior rules with scope and customization notes \|` | `12 behavior rules` |
+| 16 | `docs/wiki/en/Home.md` | L41 | `\| [Rules Reference](./Rules-Reference.md) \| All 9 behavior rules: scope, auto-load, interactions \| Agent developers \|` | `All 12 behavior rules` |
+| 17 | `docs/wiki/ja/Home.md` | L27 | `\| — \| [Rules Reference](./Rules-Reference.md): 9 つの行動ルールのスコープとカスタマイズ方法 \|` | `12 つの行動ルール` |
+| 18 | `docs/wiki/ja/Home.md` | L42 | `\| [Rules Reference](./Rules-Reference.md) \| 9 つの行動ルール: スコープ・自動ロード・相互関係 \| エージェント開発者 \|` | `12 つの行動ルール` |
+| 19 | `site/astro.config.mjs` | L29-35 (`Agents Reference` group の `items`) | Maintenance leaf までで終わり | `{ slug: 'agents-doc', labelEn: 'Doc Domain', labelJa: 'Doc Domain' }` を Maintenance の後に追加 |
+| 20 | `CHANGELOG.md` `[Unreleased]` `### Added` | - | doc-flow (#54) / doc-reviewer (#91) / Agents-Doc.md / agents-39 badge (#101) / agent count 32→39 のエントリなし | Added エントリを追加 |
+
+### 2.4 problematic だが触らない箇所 (b/c 区分)
+
+- `site/src/content/docs/{en,ja}/home.md` (L25, L40 で "29 / 5 pages") — sync-wiki.mjs 上書き対象、`docs/wiki/{en,ja}/Home.md` が正なら次回 build で自動修正される。本 PR では触らない。
+- `site/src/content/docs/{en,ja}/rules-reference.md` (frontmatter / L3 / L7 / L10 で "11 rules") — 同上、wiki 側を直せば連動。本 PR では触らない (ただし wiki/Rules-Reference.md は別 PR の TODO; #82 で 12 個目 `denial-categories` 追加されたが Rules-Reference.md 本体は未確認)。これは別 audit 対象 → §7 Open question Q3 で記録。
+- `site/src/content/docs/{en,ja}/getting-started.md` — 同上、wiki 側は doc-flow を含む新 table が反映済みなので、build で自動更新される。
+- `archived/` 配下 — 履歴保存。
+- commit message / git log の数値出現 — 履歴の真実 (触らない)。
+- `docs/wiki/{en,ja}/Architecture-Domain-Model.md` L94/97 「主パイプラインから独立した第 4 のフロー」 — Maintenance 単独説明の文脈で正しい (Doc は第 5、別 paragraph)。
+
+## 3. Constraints
+
+- **Bilingual sync**: `language-rules.md` §3.2 (Repo-root README sync convention) により、README.md と README.ja.md は同 PR で同時更新必須。同様に wiki/{en,ja}/Home.md も Bilingual Sync Policy で同 PR 必須。site/ の index.mdx も両言語同時更新。
+- **`scripts/check-readme-wiki-sync.sh` Check 1/2/3 を破壊しない**:
+  - Check 1 (agent count parity): README.md L3 / README.ja.md L3 / wiki/{en,ja}/Home.md の "39" は変更しない。L70 のみ修正。
+  - Check 2 (slash command parity): `aphelion-help.md` と `wiki/en/Getting-Started.md` の command list は既に doc-flow 含む状態で一致。本 PR では触らない。
+  - Check 3 (README heading parity): L70 の修正は heading 行ではなく list item なので影響なし。
+- **astro build 確認**: `astro.config.mjs` 変更時は `cd site && npm run build` (または `node ../scripts/sync-wiki.mjs && npx astro build`) でエラーが出ないことを確認推奨。Cloudflare Pages CI でも検出可能なので、ローカル不可時はそちらに委ねる。
+- **canonical 範囲外の純 doc 修正のため `package.json` version bump 不要**: 本 PR は `.claude/agents/` / `src/.claude/rules/` / `.claude/commands/` / `.claude/orchestrator-rules.md` のいずれも変更しない (`docs/wiki/`, `site/`, `README*.md`, `CHANGELOG.md`, `astro.config.mjs` のみ)。Contributing.md の version-bump policy 該当外。
+
+## 4. Success criteria
+
+- [ ] §2.3 の漏れ箇所 (#1〜#20) が全て修正されている。
+- [ ] `bash scripts/check-readme-wiki-sync.sh` が exit 0 で pass。
+- [ ] `cd site && npm run build` が成功 (sidebar に Agents-Doc が登録され、ローカルで `/en/agents-doc/` が解決される)。リソース不足時は CI / Cloudflare Pages のビルド結果で代替。
+- [ ] index.mdx の en/ja 両言語を同 PR 内で同時更新。
+- [ ] `docs/wiki/en/Home.md` と `docs/wiki/ja/Home.md` の rules count を同 PR で同時更新。
+- [ ] CHANGELOG.md `[Unreleased]` に doc-flow / doc-reviewer / Agents-Doc / badge / agent count bump のエントリが追加されている。
+
+## 5. Approach
+
+PR 1 つで全漏れを同時修復する。`architect` をスキップ可能 (純粋な sync fixup で構造変更なし)。
+
+推奨 commit 分割:
+
+1. **`docs: refresh README agent count from 32 to 39 in body links (#91/#54 follow-up)`**
+   - README.md L70 / README.ja.md L70 を 39 に修正。
+2. **`docs(wiki): bump Home.md rule count from 9 to 12 (catch-up to denial-categories #31 + localization-dictionary)`**
+   - wiki/en/Home.md L26 / L41 と wiki/ja/Home.md L27 / L42 を 12 に修正。Last updated を 2026-04-30 に更新し、Update history に行追加。
+3. **`docs(site): refresh index.mdx landing pages for 39 agents / 5 flows / Doc domain (#54/#91 follow-up)`**
+   - site/src/content/docs/en/index.mdx を §2.3 #1-6 に従い更新。
+   - site/src/content/docs/ja/index.mdx を §2.3 #7-12 に従い更新 (bilingual)。
+4. **`chore(site): register Agents-Doc page in astro.config.mjs PAGES array (#54 follow-up)`**
+   - PAGES の `Agents Reference` group `items` に Doc leaf を Maintenance の後に追加。
+5. **`docs: backfill CHANGELOG Unreleased with doc-flow / doc-reviewer / Agents-Doc / agents-39 badge entries (#54/#91/#101)`**
+   - `[Unreleased]` の `### Added` / `### Changed` に該当エントリを追加。
+
+PR title 案: `docs: audit-fix outdated agent count / domain references across wiki landing and site/`
+
+## 6. Document changes
+
+### 6.1 site/src/content/docs/en/index.mdx (修正後の主要 diff 仕様)
+
+```mdx
+---
+title: Aphelion
+description: AI coding agent workflow for Claude Code — Discovery, Delivery, Operations, Maintenance, and on-demand Doc generation.
+template: splash
+hero:
+  tagline: AI coding agents for the full project lifecycle — Discovery, Delivery, Operations, Maintenance, and Doc.
+  ...
+
+## Meet the 39 Agents across 5 Flows
+
+<CardGrid>
+  <Card title="Flow Orchestrators" icon="rocket">
+    5 top-level orchestrators: discovery-flow, delivery-flow, operations-flow, maintenance-flow, doc-flow.
+    [→ Orchestrators & Cross-Cutting](/en/agents-orchestrators/)
+  </Card>
+  <Card title="Discovery Domain" icon="magnifier"> ... </Card>
+  <Card title="Delivery Domain" icon="puzzle"> ... </Card>
+  <Card title="Operations Domain" icon="laptop"> ... </Card>
+  <Card title="Maintenance Domain" icon="pencil"> ... </Card>
+  <Card title="Doc Domain" icon="document">
+    7 agents (1 orchestrator + 6 authors: hld-author, lld-author, api-reference-author, ops-manual-author, user-manual-author, handover-author) that generate customer-deliverable docs on demand.
+    [→ Doc Domain](/en/agents-doc/)
+  </Card>
+  <Card title="Safety & Standalone" icon="approve-check">
+    sandbox-runner for isolated execution, doc-reviewer for cross-cutting consistency review, plus analyst and codebase-analyzer for standalone use.
+    [→ Orchestrators & Cross-Cutting](/en/agents-orchestrators/)
+  </Card>
+</CardGrid>
+
+## Explore the Documentation
+...
+  <Card title="Agents Reference" icon="open-book">
+    All 39 agents — split by domain (Orchestrators, Discovery, Delivery, Operations, Maintenance, Doc) with responsibilities, inputs, outputs, and NEXT conditions.
+    ...
+  </Card>
+```
+
+ja 版は narrative を ja に翻訳しつつ同構造。
+
+### 6.2 site/astro.config.mjs (PAGES `Agents Reference` group)
+
+```js
+{
+  groupEn: 'Agents Reference',
+  groupJa: 'Agents Reference',
+  items: [
+    { slug: 'agents-orchestrators', labelEn: 'Orchestrators & Cross-Cutting', labelJa: 'Orchestrators & Cross-Cutting' },
+    { slug: 'agents-discovery',     labelEn: 'Discovery Domain',              labelJa: 'Discovery Domain'              },
+    { slug: 'agents-delivery',      labelEn: 'Delivery Domain',               labelJa: 'Delivery Domain'               },
+    { slug: 'agents-operations',    labelEn: 'Operations Domain',             labelJa: 'Operations Domain'             },
+    { slug: 'agents-maintenance',   labelEn: 'Maintenance Domain',            labelJa: 'Maintenance Domain'            },
+    { slug: 'agents-doc',           labelEn: 'Doc Domain',                    labelJa: 'Doc Domain'                    },
+  ],
+},
+```
+
+### 6.3 README.md / README.ja.md L70
+
+```diff
+-- [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 32 agents
+++ [Agents Reference](docs/wiki/en/Agents-Orchestrators.md) — all 39 agents
+```
+
+```diff
+-- [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 32 エージェント
+++ [Agents Reference](docs/wiki/ja/Agents-Orchestrators.md) — 全 39 エージェント
+```
+
+### 6.4 docs/wiki/en/Home.md / docs/wiki/ja/Home.md
+
+- en L26: `9 behavior rules` → `12 behavior rules`
+- en L41: `All 9 behavior rules` → `All 12 behavior rules`
+- ja L27: `9 つの行動ルール` → `12 つの行動ルール`
+- ja L42: `9 つの行動ルール` → `12 つの行動ルール`
+- 両ファイルとも `Last updated` を `2026-04-30` に更新し、`Update history` に
+  `> - 2026-04-30: bump rule count 9 → 12 (catch-up to denial-categories #31 / localization-dictionary)` を追加。
+
+### 6.5 CHANGELOG.md `[Unreleased]` 追加エントリ (時系列順)
+
+```markdown
+### Added
+
+- New 5th flow `/doc-flow` (doc-flow orchestrator) generating customer-deliverable
+  docs (HLD / LLD / API reference / ops manual / user manual / handover). Six new
+  author agents (`hld-author`, `lld-author`, `api-reference-author`,
+  `ops-manual-author`, `user-manual-author`, `handover-author`) and the new
+  `Agents-Doc.md` wiki page document the flow. (#54)
+- `doc-reviewer` cross-cutting agent for post-flow doc consistency review.
+  Auto-inserted by orchestrators per `orchestrator-rules.md` triggers. (#91)
+- `docs/wiki/{en,ja}/Agents-Doc.md` — 6th Agents Reference page covering Doc
+  domain agents (5 → 6 pages). (#54)
+- README badges (agents-39 / commands-14 / rules-12 / license-MIT) plus a
+  Cloudflare Pages "Wiki" badge linking to https://aphelion-agents.com/. (#101)
+
+### Changed
+
+- Agent count bumped 31 → 32 (#91 doc-reviewer) → 39 (#54 doc-flow + 6 authors).
+  Reflected in README.md / README.ja.md body, `aphelion-overview.md`, and
+  `docs/wiki/{en,ja}/Home.md`. (#54 / #91)
+- `docs/wiki/{en,ja}/Home.md` rule count corrected 9 → 12 to match the actual
+  files in `src/.claude/rules/` (catch-up after `denial-categories` #31 and
+  the addition of `localization-dictionary`). (this PR)
+- `site/src/content/docs/{en,ja}/index.mdx` (Cloudflare Pages landing pages)
+  refreshed for 39 agents / 5 flows / Doc domain card / doc-reviewer mention.
+  (this PR)
+- `site/astro.config.mjs` PAGES array: `Agents Reference` group now lists
+  `agents-doc` so the Doc domain page appears in the wiki sidebar. (this PR)
+```
+
+## 7. Open questions
+
+- **Q1 (analyst 推奨で確定)**: `package.json` version bump (0.3.4 → 0.3.5) は本 PR に**含めない**。本 PR は `.claude/**` 直下の canonical を一切触らないため、Contributing.md の version-bump policy に該当しない。npx 利用者への影響なし。
+- **Q2 (analyst 推奨で確定)**: `astro.config.mjs` の Doc leaf 挿入位置は `Maintenance` の直後 (`docs/wiki/Home.md` の列挙順と整合)。
+- **Q3 (別 audit へ)**: `docs/wiki/{en,ja}/Rules-Reference.md` 本体が 11 rules entries のままか 12 か未確認 (今回 site/rules-reference.md は frontmatter で "11 rules" と表示)。`localization-dictionary.md` のエントリが Rules-Reference.md にあるか別 PR で audit する。本 PR の scope 外。
+- **Q4 (developer に判断委ね)**: site/index.mdx の Doc Domain card に使う Starlight icon。CardGrid の他 card は `rocket / magnifier / puzzle / laptop / pencil / approve-check` を使用。Doc は `document` または `seti:notebook` 等が候補。Starlight v0.38 の利用可能 icon は `@astrojs/starlight/components` 仕様参照。失敗時はテキストのみ表示で実害なし。
+
+## 8. Handoff
+
+- **HANDOFF_TO**: developer (architect skip — 純粋な sync fixup, 構造変更なし)
+- **推奨ブランチ名**: `docs/wiki-and-site-update-audit` (developer の Branch Naming で `docs/` prefix 採用、または既定の `feat/` でも可)
+- **推奨 PR 構成**: 1 PR / 5 commits (§5 参照)
+- **検証コマンド**:
+  - `bash scripts/check-readme-wiki-sync.sh && echo PASS`
+  - `cd site && npm run build` (任意; Cloudflare Pages CI で代替可)
+- **PR body 必須**:
+  - `Closes #<issue-number>`
+  - `Linked Plan: docs/design-notes/wiki-and-site-update-audit.md`
+- **GitHub issue 作成後、本 design-note の `> GitHub Issue: TBD` を `> GitHub Issue: [#N](URL)` に更新する** (analyst 責務)。


### PR DESCRIPTION
## Summary

3 planning documents authored by `analyst` on 2026-04-30 were never committed before their corresponding work PRs merged and the issues closed. As a result, `.github/workflows/archive-closed-plans.yml` could not auto-move them. This PR lands them directly under `docs/design-notes/archived/` to preserve the planning history.

## Files archived

| File | Issue | Closed |
|---|---|---|
| `readme-shields-badges.md` | #101 | 2026-04-30 |
| `wiki-and-site-update-audit.md` | #103 | 2026-04-30 |
| `rules-ref-and-sync-check-hardening.md` | #105 | 2026-04-30 |

## Related Issue

Not closing any issue — referenced issues are already closed. This is a backfill of archive state that the auto-archive workflow missed.

This is the exact failure mode that #118 (archive safety net) is designed to detect and prevent.

## Test plan

- [x] Files moved to `docs/design-notes/archived/` only (no content changes)
- [x] No active `docs/design-notes/*.md` references these slugs as siblings
- [ ] CI green