### PR TITLE
feat: add docs/design-notes/proposals/ directory (PR-3 of #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`docs/design-notes/proposals/`** directory: New opt-in staging area for
+  pre-issue ideas and exploration notes. Files here are intentionally not tied
+  to a GitHub issue and are excluded from all archive automation
+  (`archive-closed-plans.yml` and `archive-orphan-plans.yml`). Includes
+  `proposals/README.md` with header conventions, promotion lifecycle (draft →
+  promote to active planning doc → reject/pending), and cross-references to
+  the active and archived README files. (#118, PR-3 of 3)
+
 - **`document-locations.md` rule** (rule #14): Centralized path-resolution rule for
   Aphelion-generated planning / design / handoff documents. Default output location
   moved from repository root to `docs/<NAME>.md`; existing projects continue to work

--- a/TASK.md
+++ b/TASK.md
@@ -1,28 +1,21 @@
 # TASK.md
 
-> Source: docs/design-notes/archived/aphelion-output-docs-default-location-design.md (2026-05-11)
+> Source: docs/design-notes/design-notes-archive-safety-net-and-proposals-design.md (2026-05-11)
 
-## Phase: PR-C — wiki / README / CHANGELOG / templates
-Last updated: 2026-05-12
+## Phase: PR-3 — proposals/ directory creation (Issue #118)
+Last updated: 2026-05-13T00:00:00Z
 Status: Completed
 
 ## Task List
 
-### Phase C (PR-C: wiki / README / CHANGELOG / templates)
-
-- [x] TASK-C01: Update en/ja Rules-Reference.md (add document-locations rule, count 13→14) | Target: docs/wiki/en/Rules-Reference.md, docs/wiki/ja/Rules-Reference.md
-- [x] TASK-C02: Update en/ja Home.md (rule count 13→14) | Target: docs/wiki/en/Home.md, docs/wiki/ja/Home.md
-- [x] TASK-C03: Check Contributing.md for SPEC.md/ARCHITECTURE.md path examples (update if needed) | Target: docs/wiki/en/Contributing.md, docs/wiki/ja/Contributing.md — No changes needed (no SPEC.md/ARCHITECTURE.md path examples found)
-- [x] TASK-C04: Check README.md / README.ja.md for docs/ default location mentions (update badges if needed) | Target: README.md, README.ja.md — Updated rules badge 13 → 14
-- [x] TASK-C05: Add Issue #117 entry to CHANGELOG.md | Target: CHANGELOG.md
-- [x] TASK-C06: Annotate handover.en.md + handover.ja.md Source artifacts table (WR-002 follow-up) | Target: .claude/templates/doc-flow/handover.en.md, .claude/templates/doc-flow/handover.ja.md
+### Phase 3 (PR-3)
+- [x] TASK-001: Create docs/design-notes/proposals/.gitkeep | Target file: docs/design-notes/proposals/.gitkeep
+- [x] TASK-002: Create docs/design-notes/proposals/README.md | Target file: docs/design-notes/proposals/README.md
+- [x] TASK-003: Update CHANGELOG.md with Unreleased entry for proposals/ | Target file: CHANGELOG.md
+- [x] TASK-004: Bump package.json version to 0.3.6 | Target file: package.json
 
 ## Recent Commits
-- docs: add document-locations rule to wiki Rules-Reference (PR-C of #117)
-- docs: update Home.md rule count 13 → 14 for document-locations (PR-C of #117)
-- docs: update rules badge 13 → 14 in README.md / README.ja.md (PR-C of #117)
-- docs: add Issue #117 entry to CHANGELOG (PR-C of #117)
-- docs: annotate handover template Source artifacts with document-locations note (PR-C of #117 / WR-002 follow-up)
+(Record git log --oneline -3 after each task completion.)
 
 ## Session Interruption Notes
-PR-A and PR-B fully completed. Starting PR-C wiki/docs updates on feature/issue-117-pr-c-wiki-readme-changelog branch.
+All 4 tasks completed in a single session. PR-3 is the final PR closing Issue #118.

--- a/docs/design-notes/proposals/README.md
+++ b/docs/design-notes/proposals/README.md
@@ -1,0 +1,46 @@
+# Proposals
+
+Pre-issue ideas and exploration notes. Files here are intentionally
+**not** tied to a GitHub issue. They exist to give contributors a place
+to draft a problem statement before deciding whether it merits a real
+planning doc + issue.
+
+## Header convention
+
+Proposals do NOT use the same header as planning docs. Use the following
+instead (the `> GitHub Issue:` line is deliberately absent):
+
+```markdown
+> Status: proposal
+> Author: <name or handle>
+> Created: <YYYY-MM-DD>
+> Last updated: <YYYY-MM-DD>
+```
+
+## Lifecycle
+
+1. **Draft** — write `proposals/<slug>.md` with whatever level of detail
+   you have. No PR template, no review gate.
+2. **Promote** — once the proposal is ready to act on, an analyst:
+   - opens a GitHub issue,
+   - moves the file to `docs/design-notes/<slug>.md` (or rewrites it
+     from scratch using the analyst design-note template),
+   - replaces the `> Status: proposal` header block with the standard
+     `> GitHub Issue: [#N](...)` block.
+3. **Reject / pending** — leave the file in place. If the project has
+   accumulated rejected proposals, consider moving them to
+   `proposals/archived/` (deferred; see §5).
+
+## Out of scope for automation
+
+- `proposals/*.md` are **excluded** from `archive-closed-plans.yml`
+  (they have no issue number to match) and from
+  `archive-orphan-plans.yml` (the cron only walks
+  `docs/design-notes/*.md` one level deep).
+- Aphelion agents (`doc-reviewer`, `handover-author`, ...) do NOT read
+  files under `proposals/`. They are human-facing scratch space.
+
+## Cross-references
+
+- [`../README.md`](../README.md) — active planning docs
+- [`../archived/README.md`](../archived/README.md) — closed planning docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aphelion-agents",
-  "version": "0.3.4",
+  "version": "0.3.6",
   "description": "AI coding agent definitions for Claude Code.",
   "license": "MIT",
   "author": "kirin0198",


### PR DESCRIPTION
## Summary

- Add `docs/design-notes/proposals/` as an opt-in staging area for pre-issue ideas and exploration notes
- `proposals/README.md` documents header convention, promotion lifecycle, automation exclusions, and cross-references
- `docs/design-notes/proposals/.gitkeep` keeps the empty directory tracked by git
- CHANGELOG.md updated with Unreleased entry; package.json bumped 0.3.4 → 0.3.6

## Related Issue

Closes #118

## Linked Plan

docs/design-notes/design-notes-archive-safety-net-and-proposals.md

> Note: the `archive-closed-plans.yml` reactive workflow will auto-move both
> `design-notes-archive-safety-net-and-proposals.md` and
> `design-notes-archive-safety-net-and-proposals-design.md` to `archived/`
> when this PR is opened (Issue #118 will close on merge).

## Sibling PRs (same issue)

- PR-1: #125 — `feat/archive-orphan-plans` — cron safety-net workflow (`archive-orphan-plans.yml`)
- PR-2: #126 — `docs/design-notes-readme-and-agents` — `docs/design-notes/README.md` + agent + wiki updates

PR-2's `docs/design-notes/README.md` already contains `[proposals/README.md](./proposals/README.md)`;
this PR fulfills that forward reference.

## Test plan

- [x] `ls docs/design-notes/proposals/` shows only `.gitkeep` + `README.md`
- [x] `git diff --stat` shows exactly 4 user-facing files changed (+ TASK.md)
- [x] `proposals/README.md` is a coherent guide (header convention, lifecycle, automation exclusions)
- [x] `package.json` version is `0.3.6`
- [ ] After merge: verify `archive-closed-plans.yml` auto-archives the two planning docs from Issue #118