### PR TITLE
chore: promote 4 proposals to active planning docs (#130 / #131 / #132 / #133)

### DIFF
--- a/docs/design-notes/agent-definition-simplification.md
+++ b/docs/design-notes/agent-definition-simplification.md
@@ -1,0 +1,202 @@
+> Last updated: 2026-05-15
+> GitHub Issue: [#131](https://github.com/kirin0198/aphelion-agents/issues/131)
+> Authored by: analyst (2026-05-15)
+> Promoted from: docs/design-notes/proposals/agent-definition-simplification-memo.md
+> Related: [token-reduction.md](./token-reduction.md) (#132) — §② と §B が aphelion-overview.md 上で衝突するため設計時に座標合わせ必須
+> Next: architect (mandatory — 全 39 エージェント + orchestrator パーサ契約に影響)
+
+# エージェント定義ファイルの重複削減 (~60% 削減目標)
+
+本書は user 起票の proposal を analyst が promotion したもの。
+proposal 段階で「設計確定・未着手」と評価されていたため、内容は元メモを保持し、
+ヘッダのみ標準フォーマットへ書き換えている。
+
+## #132 との座標合わせ
+
+| 本 issue (#131) | token-reduction (#132) | 衝突点 |
+|---|---|---|
+| §② Project-Specific Behavior → aphelion-overview.md (~390 行 **追加**) | §B aphelion-overview.md 軽量化 (**削減**) | 同一ファイルへの相反する変更 |
+
+→ どちらの issue を先に着手する場合も、もう一方の architect 設計を読んでから着手する。
+PR を切る順序は architect 段階で確定する。
+
+---
+
+## 方針
+
+エージェント定義ファイル（39個）に存在する重複記述を削減し、
+各エージェントのコンテキストサイズを小さくする。
+**「固有の記述のみ各エージェントに残す」** を原則とする。
+
+---
+
+## 対応項目
+
+### ① AGENT_RESULT のシンプル化（最優先・確定）
+
+**現状の問題**
+各エージェントのAGENT_RESULTに多数のフィールドが定義されており、
+オーケストレーターが実際に使用しないフィールドも含まれている。
+
+**対応方針**
+最小構成に絞る。オーケストレーターが必要とする情報のみ残す。
+
+```
+# 最小AGENT_RESULT
+STATUS: pass | fail | skip
+CRITICAL_ISSUES: <あれば列挙・なければ省略>
+NEXT: <次のエージェント名>
+```
+
+固有フィールドは各エージェントに残すが、
+「共通フィールド + 必須固有フィールドのみ」に整理する。
+
+**削減規模**: 大（39エージェント全体）
+**実装コスト**: 中（全エージェントの定義更新 + オーケストレーターの読み取り調整）
+
+---
+
+### ② Project-Specific Behavior の共通化（最優先）
+
+**現状の問題**
+以下のブロックが全エージェント（約39個）に同一内容で存在する。
+約390行の重複。
+
+```markdown
+## Project-Specific Behavior
+Before committing and before producing user-facing output, consult
+`.claude/rules/project-rules.md` (via `Read`) and apply:
+- `## Authoring` → Co-Authored-By policy
+- `## Localization` → Output Language
+If absent, apply defaults:
+- Co-Authored-By: enabled
+- Output Language: en
+> Follows `.claude/rules/denial-categories.md` for post-failure diagnosis
+```
+
+**対応方針**
+`aphelion-overview.md` に移動し、全エージェントから該当セクションを削除。
+aphelion-overview.mdは既に全エージェントに自動ロードされるため、
+追加のロードコストなしに共通化できる。
+
+**削減規模**: 大（約390行・全エージェントに効く）
+**実装コスト**: 低（aphelion-overview.mdへの追記 + 各エージェントから削除）
+
+---
+
+### ③ エラーハンドリングの共通化（中期）
+
+**現状の問題**
+gh CLI不在・リモートリポジトリ未存在・ブランチ重複等の
+エラー条件と対応が複数エージェントに重複して記述されている（約150行）。
+
+**対応方針**
+既存の `denial-categories.md` を拡張してBash以外のエラーも統合。
+または `rules/error-handling.md` を新設して共通エラーパターンを集約。
+
+```
+# rules/error-handling.md（新設案）
+## gh CLI エラー
+- not installed / not authenticated → GitHub操作をスキップ・AGENT_RESULTにskipped記録
+## リモートリポジトリ未存在
+- gh repo view失敗 → ユーザーに通知・GitHub操作をスキップ
+## ブランチ重複
+- 既存ブランチ検出 → ユーザーに再利用/新規作成を確認
+```
+
+**削減規模**: 中（約150行・15エージェント程度）
+**実装コスト**: 中
+
+---
+
+### ④ gh CLI 可用性チェックのスクリプト化（中期）
+
+**現状の問題**
+以下のチェックがGitHub操作を行うエージェント（約8個）に重複。
+
+```bash
+gh --version
+gh auth status
+gh repo view --json nameWithOwner
+```
+
+**対応方針**
+共通シェルスクリプトに切り出し、各エージェントから参照する。
+
+```bash
+# scripts/check-gh.sh（新設）
+gh --version && gh auth status && gh repo view --json nameWithOwner
+```
+
+**削減規模**: 中（約80行）
+**実装コスト**: 中
+
+---
+
+### ⑤ Completion Conditions 定型文の共通化（長期）
+
+**現状の問題**
+以下の定型チェックが全エージェントに存在。
+
+```
+- [ ] The required output block has been produced
+- [ ] Handoff information has been clearly stated
+```
+
+**対応方針**
+aphelion-overview.md に共通条件として移動。
+各エージェントには固有の条件のみ残す。
+
+**削減規模**: 小（約80行）
+**実装コスト**: 低
+
+---
+
+### ⑥ AskUserQuestion 定型パターンの共通化（長期）
+
+**現状の問題**
+承認ゲートのJSON構造（Approve / Revise / Abort の3択）が
+約10エージェントに同一パターンで存在（約100行）。
+
+**対応方針**
+`rules/hitl-patterns.md` として共通パターンを定義し参照する。
+
+**削減規模**: 小（約100行）
+**実装コスト**: 中（Claude Codeの参照解決の挙動確認が必要）
+
+---
+
+## 優先度と削減効果まとめ
+
+| 項目 | 削減規模 | 実装コスト | 優先度 |
+|------|------|------|------|
+| ① AGENT_RESULT シンプル化 | 大 | 中 | 最優先 |
+| ② Project-Specific Behavior 共通化 | 大（約390行） | 低 | 最優先 |
+| ③ エラーハンドリング共通化 | 中（約150行） | 中 | 中期 |
+| ④ gh CLIチェック スクリプト化 | 中（約80行） | 中 | 中期 |
+| ⑤ Completion Conditions 共通化 | 小（約80行） | 低 | 長期 |
+| ⑥ AskUserQuestion 共通化 | 小（約100行） | 中 | 長期 |
+
+①②をセットで実施することで全体重複の約60%を解消できる見込み。
+
+## 成果物（着手時に生成）
+
+**①（最優先）**
+- 全39エージェントの AGENT_RESULT フィールド見直し
+- 各オーケストレーターの AGENT_RESULT 読み取りロジック調整
+
+**②（最優先）**
+- `.claude/rules/aphelion-overview.md` への Project-Specific Behavior 追記
+- 全39エージェントから該当セクション削除
+
+**③（中期）**
+- `.claude/rules/denial-categories.md` の拡張 または
+- `.claude/rules/error-handling.md` の新設
+
+**④（中期）**
+- `scripts/check-gh.sh` の新設
+- 該当エージェント（約8個）の Mandatory Checks 更新
+
+**⑤⑥（長期）**
+- aphelion-overview.md への共通 Completion Conditions 追記
+- `.claude/rules/hitl-patterns.md` の新設（⑥）

--- a/docs/design-notes/reviewer-enhancement.md
+++ b/docs/design-notes/reviewer-enhancement.md
@@ -1,0 +1,74 @@
+> Last updated: 2026-05-15
+> GitHub Issue: [#133](https://github.com/kirin0198/aphelion-agents/issues/133)
+> Authored by: analyst (2026-05-15)
+> Promoted from: docs/design-notes/proposals/reviewer-enhancement-memo.md
+> Next: architect (mandatory — 3 新 agent + delivery-flow triage/rollback への横断的影響)
+
+# 専門レビュアー追加 — ui-reviewer / performance-reviewer / dependency-reviewer
+
+本書は user 起票の proposal を analyst が promotion したもの。
+proposal 段階で「設計確定・未着手」と評価されていたため、内容は元メモを保持し、
+ヘッダのみ標準フォーマットへ書き換えている。
+
+## エージェント数 bump の波及範囲 (architect / developer 確認用)
+
+3 エージェント追加で agent count 39 → 42。波及する更新先 (#54 doc-flow と同パターン):
+
+- `README.md` / `README.ja.md` 本文 + shields.io バッジ
+- `docs/wiki/{en,ja}/Home.md`
+- `docs/wiki/{en,ja}/Agents-Delivery.md`
+- `.claude/rules/aphelion-overview.md`
+- `site/src/content/docs/{en,ja}/index.mdx`
+- `CHANGELOG.md`
+
+## doc-reviewer / security-auditor との役割分離 (再掲・厳守)
+
+| 領域 | 担当 |
+|---|---|
+| 実装コード ↔ UI_SPEC.md 準拠 | **ui-reviewer** (新規) |
+| UI_SPEC.md ↔ SPEC.md 整合 | **doc-reviewer** (既存) |
+| ライセンス競合 / 依存陳腐化 | **dependency-reviewer** (新規) |
+| 脆弱性検出 (CVE) | **security-auditor** (既存) — dependency-reviewer は触らない |
+
+---
+
+## 方針
+
+現状の `reviewer` は変更せず、専門レビュアーをトリアージで追加選択する構成にする。
+
+## 現状の reviewer（変更なし）
+
+- 起動条件: Light+（全プラン）
+- 観点: UC適合性・アーキテクチャ準拠・コード品質・テストカバレッジ・API契約
+
+## 追加する専門レビュアー（3つ）
+
+### `ui-reviewer`
+- 起動条件: HAS_UI: true · Light+
+- 観点: UI実装 ↔ UI_SPEC.md / VISUAL_SPEC.md 準拠・アクセシビリティ・レスポンシブ
+- 注意: doc-reviewerとの役割分離
+  - 「実装コードがUI_SPEC.mdに準拠しているか」→ ui-reviewer
+  - 「UI_SPEC.md自体がSPEC.mdと整合しているか」→ doc-reviewer
+
+### `performance-reviewer`
+- 起動条件: Standard+
+- 観点: 静的解析によるパフォーマンスアンチパターン検出
+  （N+1クエリ・不要ループ・キャッシュ戦略・クエリ効率）
+- 制約: 静的解析の限界を明示すること（実測値は保証しない）
+
+### `dependency-reviewer`
+- 起動条件: Full
+- 観点: ライセンス競合・依存関係の陳腐化
+- 注意: 脆弱性検出は security-auditor に委譲（重複させない）
+
+## rollback 制御
+
+delivery-flow が `CRITICAL_COUNT > 0` を判定して一元管理する。
+複数レビュアーが失敗した場合も、オーケストレーターが統合して developer へ rollback 指示。
+
+## 成果物（着手時に生成）
+
+- `.claude/agents/ui-reviewer.md`
+- `.claude/agents/performance-reviewer.md`
+- `.claude/agents/dependency-reviewer.md`
+- `.claude/agents/delivery-flow.md`（トリアージ条件・rollback制御の更新）

--- a/docs/design-notes/setup-improvement.md
+++ b/docs/design-notes/setup-improvement.md
@@ -1,0 +1,137 @@
+> Last updated: 2026-05-15
+> GitHub Issue: [#130](https://github.com/kirin0198/aphelion-agents/issues/130)
+> Authored by: analyst (2026-05-15)
+> Promoted from: docs/design-notes/proposals/setup-improvement-memo.md
+> Next: architect (`/aphelion-check` 設計のみ。他のサブ項目は developer 直行可)
+
+# 初期セットアップ改善 (6 サブ課題のバンドル)
+
+本書は user 起票の proposal を analyst が promotion したもの。
+proposal 段階で「設計確定・未着手」と評価されていたため、内容は元メモを保持し、
+ヘッダのみ標準フォーマットへ書き換えている。
+
+## 実装フェージング
+
+| サブ課題 | 優先度 | 想定 PR | 次エージェント |
+|---|---|---|---|
+| ① `/aphelion-init` 必須化 | 高 | PR-1 | developer (CLI + walkthrough 修正) |
+| ⑥ `/aphelion-check` 新設 | 高 | PR-2 | architect → developer (新 slash command 設計) |
+| ④ 既存プロジェクト導線強化 | 高 | PR-3 | developer (wiki Getting-Started 拡張) |
+| ② npx キャッシュ自動化 | 中 | PR-4 | developer (bin/ スクリプト修正) |
+| ⑤ `--user` フラグ説明 | 中 | PR-3 と同梱可 | developer (wiki) |
+| ③ PRODUCT_TYPE 事前確認 | 低 | PR-5 | developer (rules-designer 質問追加) |
+
+---
+
+## 課題と対応方針
+
+### 課題①: `/aphelion-init` の必須化
+
+**問題**
+現状「Step 1.5（推奨）」として任意扱い。スキップされると全エージェントがデフォルト値で動作し品質にばらつきが生じる。
+
+**対応方針**
+- First Run Walkthroughで「Step 1（必須）」に格上げ
+- `init` コマンド実行後に `/aphelion-init` の実行を促すメッセージを表示
+- `rules-designer` が未実行の場合、各フロー起動時に警告を出す
+
+---
+
+### 課題②: npxキャッシュ問題の自動化
+
+**問題**
+`update` 実行時にキャッシュが古い場合、ユーザーが手動で `npm cache clean --force` を実行する必要がある。気づかずに古いバージョンを使い続けるリスクがある。
+
+**対応方針**
+- `update` コマンド内でリモートの `package.json` バージョンとローカルのバージョンを自動比較
+- 差異がある場合は自動でキャッシュクリアして再取得
+- 実行後に「source: aphelion-agents@X.Y.Z → updated to X.Y.Z」を表示して確認できるようにする
+
+---
+
+### 課題③: PRODUCT_TYPE の事前確認
+
+**問題**
+インストール直後にユーザーが PRODUCT_TYPE を意識しないまま `/discovery-flow` を起動できる。Operations フローのスキップ有無に影響する重要な設定。
+
+**対応方針**
+- `/aphelion-init`（rules-designer）の質問項目に PRODUCT_TYPE を追加
+  - `service / tool / library / cli` から選択
+- 選択結果を `project-rules.md` に記録
+- 各フローオーケストレーターが `project-rules.md` から PRODUCT_TYPE を読み取れるようにする
+
+---
+
+### 課題④: 既存プロジェクトへの導入フロー強化
+
+**問題**
+Quick Startが新規プロジェクト前提の記述中心。既存プロジェクト導入時の手順（codebase-analyzerを先に走らせるべきか等）のガイダンスが薄い。
+
+**対応方針**
+- Getting Started に「既存プロジェクト向けクイックスタート」セクションを独立して追加
+- 導入フローを明示:
+  ```
+  1. npx init
+  2. /aphelion-init
+  3. /codebase-analyzer  ← SPEC.md/ARCHITECTURE.md がない場合
+  4. /analyst または /maintenance-flow
+  ```
+- SPEC.md の有無で分岐するフローチャートをドキュメントに追加
+
+---
+
+### 課題⑤: `--user` フラグの使い分け説明
+
+**問題**
+グローバルインストール（`~/.claude/`）とプロジェクトローカルインストールの使い分け基準が不明確。`project-rules.md` がグローバルに置かれると意図しない挙動になる可能性がある。
+
+**対応方針**
+- Getting Started に使い分けガイドを追加:
+
+  | ケース | 推奨 |
+  |------|------|
+  | 特定プロジェクトで使う | `init`（プロジェクトローカル） |
+  | 複数プロジェクトで共通利用 | `init --user`（グローバル） |
+  | project-rules.md を使う | 必ずプロジェクトローカル |
+
+- `init --user` 実行時に「project-rules.md はプロジェクトごとに設定してください」という注意を表示
+
+---
+
+### 課題⑥: ヘルスチェックコマンド（`/aphelion-check`）の新設
+
+**問題**
+セットアップ後に正しく設定されているかを確認する手段がない。ファイル配置・hooks設定・gh CLI認証・Claude Code バージョンを一括確認できるコマンドが必要。
+
+**対応方針**
+- `/aphelion-check` コマンドを新設
+- チェック項目:
+  - [ ] `.claude/agents/` に39ファイルが存在するか
+  - [ ] `.claude/rules/aphelion-overview.md` が存在するか
+  - [ ] `.claude/rules/project-rules.md` が存在するか（未設定の場合は警告）
+  - [ ] hooks 設定が有効か（`.claude/settings.json` 確認）
+  - [ ] `gh auth status` が通るか
+  - [ ] `git` が使えるか
+  - [ ] `docker info` が通るか（sandbox-runner の container モード用）
+- チェック結果をサマリー表示し、問題があれば対処方法を案内
+
+---
+
+## 優先度
+
+| 課題 | 優先度 |
+|------|------|
+| ①`/aphelion-init` の必須化 | 高 |
+| ⑥`/aphelion-check` の新設 | 高 |
+| ④既存プロジェクト導線強化 | 高 |
+| ②npxキャッシュ自動化 | 中 |
+| ⑤`--user` フラグ説明 | 中 |
+| ③PRODUCT_TYPE 事前確認 | 低 |
+
+## 成果物（着手時に生成）
+
+- `.claude/commands/aphelion-check.md`（新設）
+- `bin/` スクリプトの update コマンド修正（②）
+- `.claude/agents/rules-designer.md`（PRODUCT_TYPE 質問追加・③）
+- `docs/wiki/en/Getting-Started.md`（④⑤の説明追加）
+- First Run Walkthrough の改訂（①）

--- a/docs/design-notes/token-reduction.md
+++ b/docs/design-notes/token-reduction.md
@@ -1,0 +1,196 @@
+> Last updated: 2026-05-15
+> GitHub Issue: [#132](https://github.com/kirin0198/aphelion-agents/issues/132)
+> Authored by: analyst (2026-05-15)
+> Promoted from: docs/design-notes/proposals/token-reduction-memo.md
+> Related: [agent-definition-simplification.md](./agent-definition-simplification.md) (#131) — §B と §② が aphelion-overview.md 上で衝突
+> Next: architect (mandatory — §C agent split / §E cache 戦略は設計判断)
+
+# トークン消費削減
+
+本書は user 起票の proposal を analyst が promotion したもの。
+proposal 段階で「設計確定・未着手」と評価されていたため、内容は元メモを保持し、
+ヘッダのみ標準フォーマットへ書き換えている。
+
+## #131 との座標合わせ
+
+| 本 issue (#132) | agent-definition-simplification (#131) | 衝突点 |
+|---|---|---|
+| §B aphelion-overview.md 軽量化 (**削減**) | §② Project-Specific Behavior → aphelion-overview.md (~390 行 **追加**) | 同一ファイルへの相反する変更 |
+
+→ どちらの issue を先に着手する場合も、もう一方の architect 設計を読んでから着手する。
+PR を切る順序は architect 段階で確定する。
+
+## architect が answer すべき open question
+
+1. **§E (Prompt Cache)**: Claude Code の prompt cache 制御 API が利用可能か?
+   利用可能なら sub-PR 1 として最優先 (実装コスト低)。
+2. **§C (Model split)**: `analyst-intake` (Sonnet) / `analyst-core` (Opus) 分割の妥当性。
+   ユーザ体感は変えない前提だが、agent 定義ファイル数増・delivery-flow 配線変更を伴うため要設計判断。
+
+---
+
+## 現状のトークン消費構造
+
+### 主な消費源
+
+| 消費源 | 説明 |
+|------|------|
+| 共通ルールの全エージェントロード | aphelion-overview.md・project-rules.md が全エージェント起動時に毎回ロードされる |
+| 成果物の全文読み込み | SPEC.md・ARCHITECTURE.md を各エージェントが全文読む |
+| delivery-flow の直列実行 | 12エージェントが順番に起動し各々が同じドキュメントを全文読む |
+| rollback時の再実行 | max 3回のrollbackで同じコンテキストを最大3回ロード |
+| doc-reviewerの横断チェック | 複数ドキュメントを全文比較するため入力が大きい |
+| opusモデルの使用 | analyst はopus指定。高精度不要なフェーズでもopusが走る |
+
+---
+
+## 削減アイデア一覧
+
+### A. 関連UCのみ参照（長期）
+
+**概要**
+AGENT_RESULTに「関連UCのID」を含め、次のエージェントはSPEC.md全文ではなく該当セクションのみ読む。
+
+```
+developer AGENT_RESULT:
+  RELEVANT_UCS: [UC-001, UC-003, UC-007]
+  → tester は SPEC.md 全文ではなく UC-001/003/007 のみ読む
+```
+
+**削減効果**: ○ 大規模SPEC.mdに効く
+**実装コスト**: 高（全39エージェントのAGENT_RESULT定義への追加が必要）
+**優先度**: 長期
+
+---
+
+### B. aphelion-overview.md の軽量化（最優先）
+
+**概要**
+全エージェントが自動ロードする共通ルールを「本当に全エージェントが必要な情報」のみに絞る。
+ドメイン固有のルールはドメイン別ファイルに分離し、必要なエージェントだけが読む。
+
+**削減効果**: ◎ 全エージェントのベースコストに直結
+**実装コスト**: 低（既存ファイルの整理のみ）
+**優先度**: 最優先
+
+---
+
+### C. モデルの使い分け（中期）★詳細設計
+
+**概要**
+現状 analyst は opus 指定だが、フェーズによって必要な精度が異なる。
+フェーズごとにモデルを使い分けることでコストを削減する。
+
+**フェーズ別モデル設計**
+
+| フェーズ | 現状 | 推奨モデル | 理由 |
+|------|------|------|------|
+| Phase A: インテーク収集（タイプ分類・質問） | opus | Sonnet | 構造化質問の収集は高精度不要 |
+| Phase B: TBD再質問・センチネル処理 | opus | Sonnet | ルールベースの処理 |
+| 深掘り分析（§5–§8生成） | opus | Opus | 設計判断・根本原因分析が必要 |
+| SPEC.md差分更新 | opus | Sonnet | テンプレート的な書き込み |
+| GitHub issue作成 | opus | Sonnet | フォーマット整形のみ |
+
+**実装方法**
+
+Claude Codeではエージェント内でフェーズごとにモデルを切り替える仕組みがないため、**エージェントをフェーズで分割**してモデル指定を変える。
+
+```
+analyst-intake（Sonnet）
+  - Phase A: タイプ分類・タイトル・スラグ収集
+  - Phase B: タイプ別構造化質問・TBD禁止処理
+  - docs/design-notes/<slug>.md §1–§4 生成
+  - GitHub issue 作成
+      ↓
+analyst-core（Opus）
+  - 深掘り分析（§5–§8生成）
+  - ユーザー承認取得
+  - SPEC.md / UI_SPEC.md 差分更新
+  - AGENT_RESULT 出力 → NEXT: architect
+```
+
+**ユーザー体験への影響**
+- なし。`/analyst` 起動後の動作は変わらない
+- フロー内部でanalyst-intakeがanalyst-coreを呼び出す構造になる
+
+**以前の「分割不要」判断との関係**
+- 以前の判断: 「分類→トリアージ→経路確定という責任分割は不要」（機能的分割）
+- 今回の分割: コスト最適化が目的（技術的分割）
+- ユーザーから見た動作・フローは変わらないため、以前の判断に反しない
+
+**他のエージェントへの展開候補**
+
+| エージェント | 分割候補 | 効果 |
+|------|------|------|
+| architect | 設計方針決定（Opus）/ ARCHITECTURE.md書き込み（Sonnet） | 中 |
+| developer | タスク計画（Sonnet）/ 実装（Sonnet）/ 品質チェック（Sonnet） | 小（元々Sonnet相当） |
+| doc-reviewer | 整合性チェック（Opus）/ レポート生成（Sonnet） | 中 |
+
+**削減効果**: ○ opus使用箇所に効く
+**実装コスト**: 中（analyst定義ファイルの分割・delivery-flowの呼び出し更新）
+**優先度**: 中期
+
+---
+
+### D. SPEC_SUMMARY の導入（長期）
+
+**概要**
+SPEC.mdが大きくなるにつれ全文読み込みコストが増大する問題に対し、サマリーファイルを導入する2段階参照方式。
+
+```
+SPEC.md（フルバージョン）
+SPEC_SUMMARY.md（各UCの1行サマリー・自動生成）
+  → 後続エージェントはまずSPEC_SUMMARYを読み
+  → 必要なUCのみSPEC.mdから詳細を取得
+```
+
+**削減効果**: ○ 大規模SPEC.mdに効く
+**実装コスト**: 高（spec-designer + 全後続エージェントの更新が必要）
+**優先度**: 長期
+
+---
+
+### E. Prompt Cache の活用（最優先・要調査）
+
+**概要**
+Claude Codeはprompt cachingをサポートしている。変更頻度の低いファイルをキャッシュ対象として明示することでトークンコストを削減できる。
+
+**キャッシュ候補ファイル**
+- `.claude/rules/aphelion-overview.md`（全セッション共通・変更なし）
+- `.claude/rules/project-rules.md`（プロジェクト内で変更なし）
+- `SPEC.md`（フェーズ内では変更なし）
+
+**要調査事項**
+- Claude Code上でのprompt caching制御の可否
+- キャッシュの有効期間・無効化タイミング
+
+**削減効果**: ◎ 変更不要ファイルに大きく効く
+**実装コスト**: 低（設定変更のみ・調査後に判断）
+**優先度**: 最優先（ただし調査が先）
+
+---
+
+## 優先度まとめ
+
+| アイデア | 削減効果 | 実装コスト | 優先度 |
+|------|------|------|------|
+| B: aphelion-overview.md 軽量化 | ◎ | 低 | 最優先 |
+| E: Prompt Cache 活用 | ◎ | 低 | 最優先（要調査） |
+| C: モデル使い分け（analyst分割） | ○ | 中 | 中期 |
+| A: 関連UCのみ参照 | ○ | 高 | 長期 |
+| D: SPEC_SUMMARY 導入 | ○ | 高 | 長期 |
+
+## 成果物（着手時に生成）
+
+**B（最優先）**
+- `.claude/rules/aphelion-overview.md` の精査・軽量化
+- ドメイン別ルールファイルの分離（必要に応じて）
+
+**E（最優先・調査後）**
+- prompt caching 設定の追加（Claude Code対応範囲の調査）
+
+**C（中期）**
+- `.claude/agents/analyst-intake.md`（新設・Sonnet）
+- `.claude/agents/analyst-core.md`（新設・Opus）
+- `.claude/agents/analyst.md` の廃止または薄いラッパーへの変更
+- `.claude/agents/delivery-flow.md` / `maintenance-flow.md` の呼び出し更新


### PR DESCRIPTION
## Summary

User placed 4 proposal memos in `docs/design-notes/proposals/` and asked analyst to promote each into a tracked issue + active planning doc. This PR completes the promotion step.

Per `.claude/agents/analyst.md` §"Promotion from proposals/":
- moved each `proposals/<name>-memo.md` → `docs/design-notes/<slug>.md`
- replaced the original `> ステータス: 設計確定・未着手` header with the standard analyst planning-doc header (`Last updated` / `GitHub Issue` / `Authored by` / `Next`)
- preserved the original memo body content unchanged

## Issues created

| # | Slug | Type | Next |
|---|---|---|---|
| [#130](https://github.com/kirin0198/aphelion-agents/issues/130) | `setup-improvement` | Feature/DX (6 sub-items) | architect for `/aphelion-check`; developer direct for others |
| [#131](https://github.com/kirin0198/aphelion-agents/issues/131) | `agent-definition-simplification` | Refactoring (~60% dup reduction) | architect (39 agents + orchestrator contract) |
| [#132](https://github.com/kirin0198/aphelion-agents/issues/132) | `token-reduction` | Perf / cost optimization | architect (§C agent split, §E cache strategy) |
| [#133](https://github.com/kirin0198/aphelion-agents/issues/133) | `reviewer-enhancement` | Feature (3 new reviewer agents) | architect (cross-cutting triage + rollback) |

## Coordination notes

- **#131 ↔ #132 conflict**: both touch `aphelion-overview.md` in opposing directions (#131 §② ADDS ~390 lines, #132 §B REMOVES content). Cross-reference added in both planning docs; design must be coordinated at the architect stage.
- **#133 agent count bump**: 39 → 42 propagates to README/wiki/badge/aphelion-overview/site as documented in the planning doc (same set as #54 doc-flow precedent).

## Related Issue

Linked Issues: #130, #131, #132, #133 (multiple — no single `Closes` since this PR is the promotion step itself, not the implementation)

## Linked Plans

- docs/design-notes/setup-improvement.md
- docs/design-notes/agent-definition-simplification.md
- docs/design-notes/token-reduction.md
- docs/design-notes/reviewer-enhancement.md

## Test plan

- [x] All 4 issues created and reachable via GitHub UI
- [x] `docs/design-notes/proposals/` contains only `README.md` (no leftover memos)
- [x] All 4 planning docs have standard analyst headers
- [ ] CI green