### PR TITLE
feat: add /aphelion-check health check slash command (#130, PR-2 of 5)

### DIFF
--- a/.claude/commands/aphelion-check.md
+++ b/.claude/commands/aphelion-check.md
@@ -120,7 +120,7 @@ After running all checks, produce a Markdown table in this exact format:
 **Result: X passed, Y warned, Z failed**
 ```
 
-Replace placeholder status values with actual results. Use `✅ pass`, `⚠️ warn`, or `❌ fail` exactly as shown. Replace `—` with an actionable remediation hint if the check did not pass. Show the actual total agent count in parentheses after the agent list in row 1, e.g. "(developer, reviewer, tester, analyst, analyst-intake, analyst-core, architect) — 42 files total".
+Replace placeholder status values with actual results. Use `✅ pass`, `⚠️ warn`, or `❌ fail` exactly as shown. Replace `—` with an actionable remediation hint if the check did not pass. Show the actual total agent count in parentheses after the agent list in row 1, e.g. "(developer, reviewer, tester, analyst, analyst-intake, analyst-core, architect) — N files total" where N is the count detected at runtime.
 
 After the table, if any checks failed (❌), output a brief "Next steps" section listing the most urgent remediation actions.
 

--- a/.claude/commands/aphelion-check.md
+++ b/.claude/commands/aphelion-check.md
@@ -1,0 +1,127 @@
+Run a health check on the current Aphelion installation and report results.
+
+This command verifies that the core components of an Aphelion installation are present
+and properly configured. It checks agent files, rules files, hooks configuration, and
+external tool availability. Run this after `npx aphelion-agents init` to confirm
+the setup is complete, or any time you suspect a misconfiguration.
+
+All 7 checks are run sequentially. Each check is classified as:
+- pass (green): the component is present and functional
+- warn (yellow): the component is missing or misconfigured but Aphelion can still run in
+  a degraded mode; take corrective action when convenient
+- fail (red): a required component is absent; agents that depend on it will not work
+  correctly until fixed
+
+## Steps
+
+1. **Core agents present** (fail if missing)
+
+   Run:
+   ```
+   ls .claude/agents/*.md 2>/dev/null
+   ```
+
+   Check that the following high-importance agents exist as individual files:
+   - `developer.md`
+   - `reviewer.md`
+   - `tester.md`
+   - `analyst.md`
+   - `analyst-intake.md`
+   - `analyst-core.md`
+   - `architect.md`
+
+   Also report the total agent file count for informational purposes.
+
+   Pass criterion: all 7 named files exist.
+   Remediation if any are missing: Re-run `npx aphelion-agents init` (or `npx aphelion-agents update`) to restore missing agent files.
+
+2. **`aphelion-overview.md` exists** (fail if missing)
+
+   Run:
+   ```
+   ls .claude/rules/aphelion-overview.md 2>/dev/null
+   ```
+
+   Pass criterion: file exists.
+   Remediation: Re-run `npx aphelion-agents init` to restore the rules files.
+
+3. **`project-rules.md` exists** (warn if missing)
+
+   Run:
+   ```
+   ls .claude/rules/project-rules.md 2>/dev/null
+   ```
+
+   Pass criterion: file exists.
+   Remediation: Run `/aphelion-init` to create `project-rules.md` for this project. Without it, agents fall back to defaults (may not match your project conventions).
+
+4. **Hooks configured in settings.json** (warn if missing or incomplete)
+
+   Run:
+   ```
+   cat .claude/settings.json 2>/dev/null
+   ```
+
+   Check that the file exists and contains references to all three Aphelion hooks:
+   - `aphelion-secrets-precommit`
+   - `aphelion-sensitive-file-guard`
+   - `aphelion-deps-postinstall`
+
+   Pass criterion: all three hook names appear in `.claude/settings.json`.
+   Remediation if file is missing: Re-run `npx aphelion-agents init` (init only copies settings.json if it does not already exist). If the file exists but hooks are absent: run `npx aphelion-agents update` to restore hook entries (note: settings.json is protected after init — check manually if update does not restore them).
+
+5. **`gh auth status` passes** (fail if not authenticated)
+
+   Run:
+   ```
+   gh auth status 2>&1
+   ```
+
+   Pass criterion: command exits 0 (user is authenticated to GitHub CLI).
+   Remediation: Run `gh auth login` and follow the browser-based authentication flow.
+
+6. **`git` on PATH** (fail if absent)
+
+   Run:
+   ```
+   git --version 2>&1
+   ```
+
+   Pass criterion: command exits 0 and prints a version string.
+   Remediation: Install Git (`https://git-scm.com/downloads`) and ensure it is on your PATH.
+
+7. **`docker info` (sandbox container mode)** (warn if unavailable)
+
+   Run:
+   ```
+   docker info 2>&1
+   ```
+
+   Pass criterion: command exits 0 (Docker daemon is running).
+   Remediation: This is optional. `sandbox-runner` can operate in `platform_permission` mode without Docker. Start Docker Desktop (or Docker daemon) if you want full container isolation for high-risk commands.
+
+## Output format
+
+After running all checks, produce a Markdown table in this exact format:
+
+```
+## Aphelion Health Check
+
+| # | Check | Status | Remediation |
+|---|-------|--------|-------------|
+| 1 | Core agents present (developer, reviewer, tester, analyst, analyst-intake, analyst-core, architect) | ✅ pass | — |
+| 2 | aphelion-overview.md exists | ✅ pass | — |
+| 3 | project-rules.md exists | ⚠️ warn | Run `/aphelion-init` to create it |
+| 4 | Hooks configured in settings.json | ✅ pass | — |
+| 5 | gh auth status | ❌ fail | Run `gh auth login` |
+| 6 | git on PATH | ✅ pass | — |
+| 7 | docker info (sandbox optional) | ⚠️ warn | sandbox-runner container mode unavailable; platform_permission fallback active |
+
+**Result: X passed, Y warned, Z failed**
+```
+
+Replace placeholder status values with actual results. Use `✅ pass`, `⚠️ warn`, or `❌ fail` exactly as shown. Replace `—` with an actionable remediation hint if the check did not pass. Show the actual total agent count in parentheses after the agent list in row 1, e.g. "(developer, reviewer, tester, analyst, analyst-intake, analyst-core, architect) — 42 files total".
+
+After the table, if any checks failed (❌), output a brief "Next steps" section listing the most urgent remediation actions.
+
+$ARGUMENTS

--- a/.claude/commands/aphelion-help.md
+++ b/.claude/commands/aphelion-help.md
@@ -19,6 +19,7 @@ responsibility and are not listed here — run `/help` for those.
 | Command | Purpose |
 |---------|---------|
 | `/aphelion-init` | First-run project rules setup (launches `rules-designer`) |
+| `/aphelion-check` | Health check: verify agents, rules, hooks, gh auth, git, Docker |
 
 ## Standalone agents
 

--- a/TASK.md
+++ b/TASK.md
@@ -3,14 +3,14 @@
 > Source: docs/design-notes/setup-improvement.md (2026-05-17, PR-2 of 5)
 
 ## Phase: PR-2 — /aphelion-check slash command
-Last updated: 2026-05-17T01:00:00Z
+Last updated: 2026-05-17T02:00:00Z
 Status: In progress
 
 ## Task List
 
 ### Phase PR-2
 - [x] TASK-001: Create `.claude/commands/aphelion-check.md` with health check instructions | Target file: .claude/commands/aphelion-check.md
-- [ ] TASK-002: Update `aphelion-help.md` to list `/aphelion-check` | Target file: .claude/commands/aphelion-help.md
+- [x] TASK-002: Update `aphelion-help.md` to list `/aphelion-check` | Target file: .claude/commands/aphelion-help.md
 - [ ] TASK-003: Update planning doc CURRENT_PR: PR-1 → PR-2 | Target file: docs/design-notes/setup-improvement.md
 - [ ] TASK-004: Reset TASK.md to empty placeholder | Target file: TASK.md
 

--- a/TASK.md
+++ b/TASK.md
@@ -1,5 +1,21 @@
 # TASK.md
 
-> Empty placeholder. The `developer` agent will populate this file when the
-> next implementation phase begins. See `.claude/rules/document-versioning.md`
-> §"TASK.md Lifecycle" for the reset rule.
+> Source: docs/design-notes/setup-improvement.md (2026-05-17, PR-2 of 5)
+
+## Phase: PR-2 — /aphelion-check slash command
+Last updated: 2026-05-17T01:00:00Z
+Status: In progress
+
+## Task List
+
+### Phase PR-2
+- [x] TASK-001: Create `.claude/commands/aphelion-check.md` with health check instructions | Target file: .claude/commands/aphelion-check.md
+- [ ] TASK-002: Update `aphelion-help.md` to list `/aphelion-check` | Target file: .claude/commands/aphelion-help.md
+- [ ] TASK-003: Update planning doc CURRENT_PR: PR-1 → PR-2 | Target file: docs/design-notes/setup-improvement.md
+- [ ] TASK-004: Reset TASK.md to empty placeholder | Target file: TASK.md
+
+## Recent Commits
+(Record git log --oneline -3 each time a task is completed)
+
+## Session Interruption Notes
+(Record the situation here when a session is interrupted)

--- a/TASK.md
+++ b/TASK.md
@@ -3,7 +3,7 @@
 > Source: docs/design-notes/setup-improvement.md (2026-05-17, PR-2 of 5)
 
 ## Phase: PR-2 — /aphelion-check slash command
-Last updated: 2026-05-17T02:00:00Z
+Last updated: 2026-05-17T03:00:00Z
 Status: In progress
 
 ## Task List
@@ -11,7 +11,7 @@ Status: In progress
 ### Phase PR-2
 - [x] TASK-001: Create `.claude/commands/aphelion-check.md` with health check instructions | Target file: .claude/commands/aphelion-check.md
 - [x] TASK-002: Update `aphelion-help.md` to list `/aphelion-check` | Target file: .claude/commands/aphelion-help.md
-- [ ] TASK-003: Update planning doc CURRENT_PR: PR-1 → PR-2 | Target file: docs/design-notes/setup-improvement.md
+- [x] TASK-003: Update planning doc CURRENT_PR: PR-1 → PR-2 | Target file: docs/design-notes/setup-improvement.md
 - [ ] TASK-004: Reset TASK.md to empty placeholder | Target file: TASK.md
 
 ## Recent Commits

--- a/TASK.md
+++ b/TASK.md
@@ -1,21 +1,5 @@
 # TASK.md
 
-> Source: docs/design-notes/setup-improvement.md (2026-05-17, PR-2 of 5)
-
-## Phase: PR-2 — /aphelion-check slash command
-Last updated: 2026-05-17T03:00:00Z
-Status: In progress
-
-## Task List
-
-### Phase PR-2
-- [x] TASK-001: Create `.claude/commands/aphelion-check.md` with health check instructions | Target file: .claude/commands/aphelion-check.md
-- [x] TASK-002: Update `aphelion-help.md` to list `/aphelion-check` | Target file: .claude/commands/aphelion-help.md
-- [x] TASK-003: Update planning doc CURRENT_PR: PR-1 → PR-2 | Target file: docs/design-notes/setup-improvement.md
-- [ ] TASK-004: Reset TASK.md to empty placeholder | Target file: TASK.md
-
-## Recent Commits
-(Record git log --oneline -3 each time a task is completed)
-
-## Session Interruption Notes
-(Record the situation here when a session is interrupted)
+> Empty placeholder. The `developer` agent will populate this file when the
+> next implementation phase begins. See `.claude/rules/document-versioning.md`
+> §"TASK.md Lifecycle" for the reset rule.

--- a/docs/design-notes/setup-improvement.md
+++ b/docs/design-notes/setup-improvement.md
@@ -10,7 +10,7 @@ PLANNING_DOC: docs/design-notes/setup-improvement.md
 MAINTENANCE_TIER: Minor
 PLAN: Standard
 HANDOFF_TO: developer
-CURRENT_PR: PR-1
+CURRENT_PR: PR-2
 PHASING: |
   PR-1: ① /aphelion-init必須化 (feat/aphelion-init-mandatory)
   PR-2: ⑥ /aphelion-check新設 (feat/aphelion-check) — developer-direct, no architect

--- a/docs/wiki/en/Getting-Started.md
+++ b/docs/wiki/en/Getting-Started.md
@@ -235,6 +235,7 @@ You can invoke any agent directly without a flow:
 |---------|---------|-------------|
 | `/aphelion-init` | First-run project rules setup (launches `rules-designer`) | Right after `npx aphelion-agents init` |
 | `/aphelion-help` | List all Aphelion slash commands | Anytime, in any project |
+| `/aphelion-check` | Health check: verify agents, rules, hooks, gh auth, git, Docker | Anytime, in any project |
 | `/discovery-flow {description}` | Start requirements exploration | New projects |
 | `/delivery-flow` | Start design & implementation | After Discovery, or with existing SPEC.md |
 | `/operations-flow` | Start deployment & operations | After Delivery, service type only |

--- a/docs/wiki/ja/Getting-Started.md
+++ b/docs/wiki/ja/Getting-Started.md
@@ -222,6 +222,7 @@ Deliveryが完了した後（serviceプロジェクトの場合）：
 |---------|------|------|
 | `/aphelion-init` | 初回プロジェクトルール設定（`rules-designer` を起動） | `npx aphelion-agents init` 直後 |
 | `/aphelion-help` | Aphelion のスラッシュコマンド一覧を表示 | 任意のプロジェクトで随時 |
+| `/aphelion-check` | ヘルスチェック: agents / rules / hooks / gh auth / git / Docker を検証 | 任意のプロジェクトで随時 |
 | `/discovery-flow {説明}` | 要件探索を開始 | 新規プロジェクト |
 | `/delivery-flow` | 設計・実装を開始 | Discovery後、または既存SPEC.mdがある場合 |
 | `/operations-flow` | デプロイ・運用を開始 | Delivery後、serviceタイプのみ |


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/aphelion-check.md` — a new slash command that runs 7 health checks against the current Aphelion installation and reports a Markdown table with per-check pass/warn/fail status and remediation hints
- Checks cover: core agents present (7 named files), `aphelion-overview.md`, `project-rules.md` (warn-only), hooks config in `settings.json`, `gh auth status`, `git` on PATH, `docker info` (warn-only sandbox check)
- Agent presence check is brittle-resistant: tests 7 specific named files instead of hardcoding a total count of 42
- Updates `/aphelion-help` (Shortcuts section) to list the new command

## Related Issue

Linked Issue: #130 (PR-2 of 5)

## Linked Plan

docs/design-notes/setup-improvement.md

## Test plan

- [ ] After merge, run `/aphelion-check` in a Claude Code session on this repo
- [ ] Verify all 7 checks fire and produce output
- [ ] Verify the summary line format: "X passed, Y warned, Z failed"
- [ ] Verify `/aphelion-help` lists `/aphelion-check` in the Shortcuts section
- [ ] Test warn path: temporarily rename `.claude/rules/project-rules.md` and verify row 3 shows ⚠️ warn
- [ ] Test fail path: run `gh auth logout` and verify row 5 shows ❌ fail