### PR TITLE
feat: add existing-project Quick Start + --user guide to Getting-Started (#130 PR-3)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,22 +1,5 @@
 # TASK.md
 
-> Source: docs/design-notes/setup-improvement.md (CURRENT_PR: PR-3, Last updated: 2026-05-17)
-
-## Phase: PR-3 — Existing Project Quick Start + --user flag guide
-Last updated: 2026-05-28T00:30:00
-Status: In progress
-
-## Task List
-
-### Phase PR-3
-- [x] TASK-001: Add "Existing Project Quick Start" section + ToC entry to en/Getting-Started.md | Target file: docs/wiki/en/Getting-Started.md
-- [x] TASK-002: Add same section to ja/Getting-Started.md (bilingual sync) | Target file: docs/wiki/ja/Getting-Started.md
-- [x] TASK-003: Add --user decision table + warning to Quick Start (both langs) | Target files: docs/wiki/en/Getting-Started.md, docs/wiki/ja/Getting-Started.md
-- [x] TASK-004: Shrink Scenario 4 to cross-reference (both langs) | Target files: docs/wiki/en/Getting-Started.md, docs/wiki/ja/Getting-Started.md
-- [ ] TASK-005: Reset TASK.md to empty placeholder (phase completion)
-
-## Recent Commits
-(none yet — committing now)
-
-## Session Interruption Notes
-(none)
+> Empty placeholder. The `developer` agent will populate this file when the
+> next implementation phase begins. See `.claude/rules/document-versioning.md`
+> §"TASK.md Lifecycle" for the reset rule.

--- a/TASK.md
+++ b/TASK.md
@@ -1,5 +1,22 @@
 # TASK.md
 
-> Empty placeholder. The `developer` agent will populate this file when the
-> next implementation phase begins. See `.claude/rules/document-versioning.md`
-> §"TASK.md Lifecycle" for the reset rule.
+> Source: docs/design-notes/setup-improvement.md (CURRENT_PR: PR-3, Last updated: 2026-05-17)
+
+## Phase: PR-3 — Existing Project Quick Start + --user flag guide
+Last updated: 2026-05-28T00:30:00
+Status: In progress
+
+## Task List
+
+### Phase PR-3
+- [x] TASK-001: Add "Existing Project Quick Start" section + ToC entry to en/Getting-Started.md | Target file: docs/wiki/en/Getting-Started.md
+- [x] TASK-002: Add same section to ja/Getting-Started.md (bilingual sync) | Target file: docs/wiki/ja/Getting-Started.md
+- [x] TASK-003: Add --user decision table + warning to Quick Start (both langs) | Target files: docs/wiki/en/Getting-Started.md, docs/wiki/ja/Getting-Started.md
+- [x] TASK-004: Shrink Scenario 4 to cross-reference (both langs) | Target files: docs/wiki/en/Getting-Started.md, docs/wiki/ja/Getting-Started.md
+- [ ] TASK-005: Reset TASK.md to empty placeholder (phase completion)
+
+## Recent Commits
+(none yet — committing now)
+
+## Session Interruption Notes
+(none)

--- a/docs/wiki/en/Getting-Started.md
+++ b/docs/wiki/en/Getting-Started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 > **Language**: [English](../en/Getting-Started.md) | [日本語](../ja/Getting-Started.md)
-> **Last updated**: 2026-05-17 (updated 2026-05-17: promote /aphelion-init to Step 2 required, #130)
+> **Last updated**: 2026-05-28 (updated 2026-05-28: add existing-project Quick Start + --user guide, #130 PR-3)
 > **Audience**: New users
 
 This page covers everything you need to start using Aphelion: Claude Code setup, first-run walkthrough, usage scenarios, command reference, and troubleshooting.
@@ -10,6 +10,7 @@ This page covers everything you need to start using Aphelion: Claude Code setup,
 
 - [Prerequisites](#prerequisites)
 - [Quick Start](#quick-start)
+- [Existing Project Quick Start](#existing-project-quick-start)
 - [First Run Walkthrough](#first-run-walkthrough)
 - [Usage Scenarios](#usage-scenarios)
 - [Command Reference](#command-reference)
@@ -60,6 +61,19 @@ npx github:kirin0198/aphelion-agents update --user
 > `version` in [package.json on `main`](https://github.com/kirin0198/aphelion-agents/blob/main/package.json)
 > to confirm freshness.
 
+#### `init` vs `init --user`: which should I use?
+
+| Case | Recommended |
+|------|-------------|
+| Use in a specific project | `init` (project-local) |
+| Share across multiple projects | `init --user` (global) |
+| Using project-rules.md | Always project-local |
+
+> **Warning:** `project-rules.md` must be placed in the project's `.claude/rules/` directory (project-local).
+> Installing Aphelion with `init --user` places agents and rules in `~/.claude/` globally, but
+> `project-rules.md` must still be generated per project via `/aphelion-init`. A globally placed
+> `project-rules.md` in `~/.claude/rules/` can cause unintended behavior across unrelated projects.
+
 ### Install via git clone (alternative)
 
 Clone the repository first:
@@ -78,6 +92,57 @@ cd /path/to/your-project && claude
 
 /aphelion-init
 /discovery-flow I want to build a TODO app
+```
+
+---
+
+## Existing Project Quick Start
+
+Already have a codebase? Follow these steps to bring Aphelion in:
+
+**Step 1: Install Aphelion**
+
+```bash
+npx github:kirin0198/aphelion-agents init
+# or: cp -r /path/to/aphelion-agents/.claude /path/to/your-project/
+```
+
+**Step 2: Set up project-specific rules**
+
+```
+/aphelion-init
+```
+
+`rules-designer` generates `.claude/rules/project-rules.md` for your project. This is required
+before running any flow.
+
+**Step 3: Generate docs (only if SPEC.md / ARCHITECTURE.md are absent)**
+
+```
+/codebase-analyzer Analyze this project and generate SPEC.md and ARCHITECTURE.md
+```
+
+Skip this step if your project already has `SPEC.md` and `ARCHITECTURE.md`.
+
+**Step 4: Start working**
+
+```
+/analyst {issue or feature description}
+# or
+/maintenance-flow {trigger description}
+```
+
+Use `/analyst` for a single-issue workflow. Use `/maintenance-flow` when you want automatic
+Patch / Minor / Major triage.
+
+**Decision flowchart:**
+
+```
+Does your project have SPEC.md and ARCHITECTURE.md?
+|
++-- YES --> /analyst  or  /maintenance-flow
+|
++-- NO  --> /codebase-analyzer  -->  /analyst  or  /maintenance-flow
 ```
 
 ---
@@ -204,18 +269,8 @@ Prefer `/maintenance-flow` over `/analyst` when:
 
 ### Scenario 4: Existing Project without Docs
 
-Reverse-engineer the specification first:
-
-```
-/codebase-analyzer Analyze this project and generate SPEC.md and ARCHITECTURE.md
-```
-
-After review and approval:
-
-```
-/analyst I want to add OAuth2 social login
-/delivery-flow
-```
+See [Existing Project Quick Start](#existing-project-quick-start) for the full 4-step guide,
+including when to run `/codebase-analyzer` and how to proceed to `/analyst` or `/maintenance-flow`.
 
 ### Scenario 5: Standalone Agents
 

--- a/docs/wiki/ja/Getting-Started.md
+++ b/docs/wiki/ja/Getting-Started.md
@@ -1,8 +1,8 @@
 # Getting Started
 
 > **Language**: [English](../en/Getting-Started.md) | [日本語](../ja/Getting-Started.md)
-> **Last updated**: 2026-05-17 (updated 2026-05-17: /aphelion-init をステップ2必須に格上げ, #130)
-> **EN canonical**: 2026-05-17 (updated 2026-05-17) of wiki/en/Getting-Started.md
+> **Last updated**: 2026-05-28 (updated 2026-05-28: 既存プロジェクト向けクイックスタート + --user ガイド追加, #130 PR-3)
+> **EN canonical**: 2026-05-28 (updated 2026-05-28) of wiki/en/Getting-Started.md
 > **Audience**: 新規ユーザー
 
 このページはAphelionを使い始めるために必要なすべてをカバーします：Claude Code のセットアップ、初回実行のウォークスルー、利用シナリオ、コマンドリファレンス、トラブルシューティング。
@@ -11,6 +11,7 @@
 
 - [前提条件](#前提条件)
 - [クイックスタート](#クイックスタート)
+- [既存プロジェクト向けクイックスタート](#既存プロジェクト向けクイックスタート)
 - [初回実行ウォークスルー](#初回実行ウォークスルー)
 - [利用シナリオ](#利用シナリオ)
 - [コマンドリファレンス](#コマンドリファレンス)
@@ -56,6 +57,18 @@ npx github:kirin0198/aphelion-agents update --user
 > **キャッシュに関する注意:** `npx` は `name@version` でパッケージをキャッシュします。同じバージョン文字列の古いキャッシュがローカルに残っている場合、`update` はその古いスナップショットを無言でコピーします。強制的に最新を取得するには: ref を `main` に固定する (`npx github:kirin0198/aphelion-agents#main update`) か、キャッシュをクリアして (`npm cache clean --force`) 再実行してください。
 > 実行時に表示される `source: aphelion-agents@<version>` を [main の package.json](https://github.com/kirin0198/aphelion-agents/blob/main/package.json) の `version` と突き合わせると確実に最新が反映されたか確認できます。
 
+#### `init` vs `init --user`: どちらを使うべきか？
+
+| ケース | 推奨 |
+|------|------|
+| 特定プロジェクトで使う | `init`（プロジェクトローカル） |
+| 複数プロジェクトで共通利用 | `init --user`（グローバル） |
+| project-rules.md を使う | 必ずプロジェクトローカル |
+
+> **注意:** `project-rules.md` はプロジェクトの `.claude/rules/` ディレクトリに配置する必要があります（プロジェクトローカル）。
+> `init --user` でグローバルにインストールした場合でも、`project-rules.md` は各プロジェクトで `/aphelion-init` を実行して生成してください。
+> `~/.claude/rules/` にグローバルで `project-rules.md` を置くと、無関係なプロジェクトにも影響が及ぶ可能性があります。
+
 ### git clone でインストール（代替手順）
 
 リポジトリをクローンしてから手動でファイルをコピーする方法：
@@ -68,6 +81,55 @@ cd /path/to/your-project && claude
 
 /aphelion-init
 /discovery-flow TODOアプリを作りたい
+```
+
+---
+
+## 既存プロジェクト向けクイックスタート
+
+既存のコードベースに Aphelion を導入する手順です：
+
+**ステップ1: Aphelion をインストール**
+
+```bash
+npx github:kirin0198/aphelion-agents init
+# または: cp -r /path/to/aphelion-agents/.claude /path/to/your-project/
+```
+
+**ステップ2: プロジェクト固有ルールのセットアップ**
+
+```
+/aphelion-init
+```
+
+`rules-designer` がプロジェクトの `.claude/rules/project-rules.md` を生成します。フローを実行する前に必ず行ってください。
+
+**ステップ3: ドキュメントの生成（SPEC.md / ARCHITECTURE.md がない場合のみ）**
+
+```
+/codebase-analyzer このプロジェクトを分析してSPEC.mdとARCHITECTURE.mdを生成してください
+```
+
+プロジェクトに既に `SPEC.md` と `ARCHITECTURE.md` がある場合はこのステップをスキップしてください。
+
+**ステップ4: 作業を開始**
+
+```
+/analyst {issueや機能の説明}
+# または
+/maintenance-flow {トリガーの説明}
+```
+
+単一 issue のワークフローには `/analyst`、Patch / Minor / Major の自動トリアージが必要な場合は `/maintenance-flow` を使用してください。
+
+**判断フローチャート:**
+
+```
+プロジェクトに SPEC.md と ARCHITECTURE.md がありますか？
+|
++-- YES --> /analyst  または  /maintenance-flow
+|
++-- NO  --> /codebase-analyzer  -->  /analyst  または  /maintenance-flow
 ```
 
 ---
@@ -191,18 +253,7 @@ Deliveryが完了した後（serviceプロジェクトの場合）：
 
 ### シナリオ4：既存プロジェクトへの変更（ドキュメントなし）
 
-まず仕様書を逆生成：
-
-```
-/codebase-analyzer このプロジェクトを分析してSPEC.mdとARCHITECTURE.mdを生成してください
-```
-
-レビューと承認後：
-
-```
-/analyst OAuth2ソーシャルログインを追加したい
-/delivery-flow
-```
+詳細な4ステップのガイド（`/codebase-analyzer` を実行するタイミング、`/analyst` または `/maintenance-flow` への進め方を含む）は [既存プロジェクト向けクイックスタート](#既存プロジェクト向けクイックスタート) を参照してください。
 
 ### シナリオ5：スタンドアロンエージェント
 


### PR DESCRIPTION
## Summary

- New `## Existing Project Quick Start` section in both EN and JA `Getting-Started.md` with 4-step flow (install → `/aphelion-init` → optional `/codebase-analyzer` → `/analyst` or `/maintenance-flow`) and ASCII decision flowchart
- `init` vs `init --user` decision table + `project-rules.md` must be project-local warning, placed inside `## Quick Start` (both langs)
- Scenario 4 ("Existing Project without Docs") shrunk to a one-line cross-reference pointing to the new section
- Bilingual sync: both files now have 11 lockstep `## ` headings; `check-readme-wiki-sync.sh` exits 0

## Related Issue
Linked Issue: #130 (PR-3 of 6)

## Linked Plan
docs/design-notes/setup-improvement.md

## Test plan
- [x] `python3` heading count: EN=11, JA=11 (lockstep)
- [x] `bash scripts/check-readme-wiki-sync.sh` exits 0
- [x] New section renders correctly (verified via Read after edit)
- [x] ASCII flowchart is well-formed (identical structure in EN and JA)
- [x] TASK.md reset to empty placeholder after phase completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)